### PR TITLE
Bind exec requests to trusted CLI peers

### DIFF
--- a/cmd/agent-secretd/main.go
+++ b/cmd/agent-secretd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -33,6 +34,8 @@ func run() int {
 
 	flags := flag.NewFlagSet("agent-secretd", flag.ExitOnError)
 	flags.StringVar(&socketPath, "socket", socketPath, "daemon socket path")
+	var trustedClients stringListFlag
+	flags.Var(&trustedClients, "trusted-client", "trusted agent-secret executable path; repeatable")
 	approverPath := flags.String("approver", os.Getenv("AGENT_SECRET_APPROVER_PATH"), "approver executable or .app path")
 	accountName := flags.String("account", os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT"), "1Password account sign-in address, name, or UUID; empty uses OP_ACCOUNT or my.1password.com")
 	if err := flags.Parse(os.Args[1:]); err != nil {
@@ -66,7 +69,15 @@ func run() int {
 		stderrf("agent-secretd: initialize broker: %v\n", err)
 		return 1
 	}
-	server, err := daemon.NewServer(daemon.ServerOptions{Broker: broker, Approvals: approver})
+	trustedClientPaths := []string(trustedClients)
+	if len(trustedClientPaths) == 0 {
+		trustedClientPaths = daemon.DefaultTrustedClientPaths()
+	}
+	server, err := daemon.NewServer(daemon.ServerOptions{
+		Broker:        broker,
+		Approvals:     approver,
+		ExecValidator: daemon.NewTrustedExecutableValidator(trustedClientPaths),
+	})
 	if err != nil {
 		stderrf("agent-secretd: initialize server: %v\n", err)
 		return 1
@@ -80,6 +91,21 @@ func run() int {
 
 func stderrf(format string, args ...any) {
 	_, _ = fmt.Fprintf(os.Stderr, format, args...)
+}
+
+type stringListFlag []string
+
+func (f *stringListFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *stringListFlag) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("trusted client path is required")
+	}
+	*f = append(*f, value)
+	return nil
 }
 
 type desktopResolver struct {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -335,7 +335,11 @@ func startAppTestServer(t *testing.T, opts daemon.BrokerOptions) (appTestClient,
 	if err != nil {
 		t.Fatalf("NewBroker returned error: %v", err)
 	}
-	server, err := daemon.NewServer(daemon.ServerOptions{Broker: broker, Validator: appAllowPeer{}})
+	server, err := daemon.NewServer(daemon.ServerOptions{
+		Broker:        broker,
+		Validator:     appAllowPeer{},
+		ExecValidator: daemon.NewTrustedExecutableValidator(daemon.CurrentExecutableTrustedClientPaths()),
+	})
 	if err != nil {
 		t.Fatalf("NewServer returned error: %v", err)
 	}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Manager struct {
-	SocketPath     string
-	DaemonPath     string
-	DaemonArgs     []string
-	StartupTimeout time.Duration
+	SocketPath         string
+	DaemonPath         string
+	DaemonArgs         []string
+	TrustedClientPaths []string
+	StartupTimeout     time.Duration
 }
 
 func NewManager(socketPath string) (Manager, error) {
@@ -27,9 +28,10 @@ func NewManager(socketPath string) (Manager, error) {
 	}
 	if daemonPath := strings.TrimSpace(os.Getenv("AGENT_SECRET_DAEMON_PATH")); daemonPath != "" {
 		return Manager{
-			SocketPath:     socketPath,
-			DaemonPath:     daemonPath,
-			StartupTimeout: 3 * time.Second,
+			SocketPath:         socketPath,
+			DaemonPath:         daemonPath,
+			TrustedClientPaths: CurrentExecutableTrustedClientPaths(),
+			StartupTimeout:     3 * time.Second,
 		}, nil
 	}
 	daemonPath, err := defaultDaemonPath()
@@ -37,9 +39,10 @@ func NewManager(socketPath string) (Manager, error) {
 		return Manager{}, err
 	}
 	return Manager{
-		SocketPath:     socketPath,
-		DaemonPath:     daemonPath,
-		StartupTimeout: 3 * time.Second,
+		SocketPath:         socketPath,
+		DaemonPath:         daemonPath,
+		TrustedClientPaths: CurrentExecutableTrustedClientPaths(),
+		StartupTimeout:     3 * time.Second,
 	}, nil
 }
 
@@ -138,7 +141,14 @@ func (m Manager) stopped(ctx context.Context) bool {
 
 func (m Manager) daemonArgs() []string {
 	if len(m.DaemonArgs) == 0 {
-		return []string{"--socket", m.SocketPath}
+		args := []string{"--socket", m.SocketPath}
+		for _, path := range m.TrustedClientPaths {
+			if strings.TrimSpace(path) == "" {
+				continue
+			}
+			args = append(args, "--trusted-client", path)
+		}
+		return args
 	}
 	args := make([]string, 0, len(m.DaemonArgs))
 	for _, arg := range m.DaemonArgs {

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -118,6 +118,9 @@ func TestNewManagerUsesDefaultSocketAndDaemonPathOverride(t *testing.T) {
 	if manager.DaemonPath != "/tmp/agent-secretd-test" {
 		t.Fatalf("DaemonPath = %q, want env override", manager.DaemonPath)
 	}
+	if !slices.Equal(manager.TrustedClientPaths, CurrentExecutableTrustedClientPaths()) {
+		t.Fatalf("TrustedClientPaths = %v, want current executable", manager.TrustedClientPaths)
+	}
 	if manager.StartupTimeout != 3*time.Second {
 		t.Fatalf("StartupTimeout = %s, want 3s", manager.StartupTimeout)
 	}
@@ -129,6 +132,19 @@ func TestManagerDaemonArgsReplaceSocketPlaceholder(t *testing.T) {
 	manager := Manager{SocketPath: "/tmp/agent-secret.sock"}
 	if got := manager.daemonArgs(); !slices.Equal(got, []string{"--socket", "/tmp/agent-secret.sock"}) {
 		t.Fatalf("default daemon args = %v", got)
+	}
+
+	manager.TrustedClientPaths = []string{"/usr/local/bin/agent-secret", "/opt/agent-secret"}
+	wantTrusted := []string{
+		"--socket",
+		"/tmp/agent-secret.sock",
+		"--trusted-client",
+		"/usr/local/bin/agent-secret",
+		"--trusted-client",
+		"/opt/agent-secret",
+	}
+	if got := manager.daemonArgs(); !slices.Equal(got, wantTrusted) {
+		t.Fatalf("trusted daemon args = %v, want %v", got, wantTrusted)
 	}
 
 	manager.DaemonArgs = []string{"--listen", "{socket}", "--verbose"}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -35,17 +35,19 @@ func (SameUIDValidator) Validate(conn *net.UnixConn) error {
 }
 
 type Server struct {
-	broker    *Broker
-	approvals ApprovalEndpoint
-	validator PeerValidator
-	stopOnce  sync.Once
-	stop      chan struct{}
+	broker        *Broker
+	approvals     ApprovalEndpoint
+	validator     PeerValidator
+	execValidator ExecPeerValidator
+	stopOnce      sync.Once
+	stop          chan struct{}
 }
 
 type ServerOptions struct {
-	Broker    *Broker
-	Approvals ApprovalEndpoint
-	Validator PeerValidator
+	Broker        *Broker
+	Approvals     ApprovalEndpoint
+	Validator     PeerValidator
+	ExecValidator ExecPeerValidator
 }
 
 func NewServer(opts ServerOptions) (*Server, error) {
@@ -56,11 +58,16 @@ func NewServer(opts ServerOptions) (*Server, error) {
 	if validator == nil {
 		validator = SameUIDValidator{}
 	}
+	execValidator := opts.ExecValidator
+	if execValidator == nil {
+		execValidator = NewTrustedExecutableValidator(DefaultTrustedClientPaths())
+	}
 	return &Server{
-		broker:    opts.Broker,
-		approvals: opts.Approvals,
-		validator: validator,
-		stop:      make(chan struct{}),
+		broker:        opts.Broker,
+		approvals:     opts.Approvals,
+		validator:     validator,
+		execValidator: execValidator,
+		stop:          make(chan struct{}),
 	}, nil
 }
 
@@ -174,51 +181,98 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 			}
 			_ = writeOK(encoder, env.RequestID, env.Nonce, nil)
 		case TypeRequestExec:
-			req, err := DecodePayload[request.ExecRequest](env)
-			if err != nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_request", err)
-				continue
-			}
-			grant, err := s.broker.HandleExec(ctx, env.RequestID, env.Nonce, req)
-			if err != nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
-				continue
-			}
-			activeRequestID = env.RequestID
-			err = writeOK(encoder, env.RequestID, env.Nonce, ExecResponsePayload{
-				Env:           grant.Env,
-				SecretAliases: grant.SecretAliases,
-			})
-			if err == nil {
-				_ = s.broker.MarkPayloadDelivered(env.RequestID)
+			if requestID := s.handleRequestExec(ctx, conn, encoder, env); requestID != "" {
+				activeRequestID = requestID
 			}
 		case TypeCommandStarted:
-			payload, err := DecodePayload[CommandStartedPayload](env)
-			if err != nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_command_started", err)
-				continue
-			}
-			if err := s.broker.ReportStarted(ctx, env.RequestID, env.Nonce, payload.ChildPID); err != nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
-				continue
-			}
-			_ = writeOK(encoder, env.RequestID, env.Nonce, nil)
+			s.handleCommandStarted(ctx, conn, encoder, env)
 		case TypeCommandCompleted:
-			payload, err := DecodePayload[CommandCompletedPayload](env)
-			if err != nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_command_completed", err)
-				continue
+			if s.handleCommandCompleted(ctx, conn, encoder, env) {
+				activeRequestID = ""
 			}
-			if err := s.broker.ReportCompleted(ctx, env.RequestID, env.Nonce, payload.ExitCode, payload.Signal); err != nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
-				continue
-			}
-			activeRequestID = ""
-			_ = writeOK(encoder, env.RequestID, env.Nonce, nil)
 		default:
 			_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_type", fmt.Errorf("%w: %s", ErrProtocolType, env.Type))
 		}
 	}
+}
+
+func (s *Server) handleRequestExec(
+	ctx context.Context,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env Envelope,
+) string {
+	req, err := DecodePayload[request.ExecRequest](env)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_request", err)
+		return ""
+	}
+	if err := req.ValidateForDaemon(); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_request", err)
+		return ""
+	}
+	if err := s.validateExecPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return ""
+	}
+	grant, err := s.broker.HandleExec(ctx, env.RequestID, env.Nonce, req)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return ""
+	}
+	err = writeOK(encoder, env.RequestID, env.Nonce, ExecResponsePayload{
+		Env:           grant.Env,
+		SecretAliases: grant.SecretAliases,
+	})
+	if err == nil {
+		_ = s.broker.MarkPayloadDelivered(env.RequestID)
+	}
+	return env.RequestID
+}
+
+func (s *Server) handleCommandStarted(
+	ctx context.Context,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env Envelope,
+) {
+	payload, err := DecodePayload[CommandStartedPayload](env)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_command_started", err)
+		return
+	}
+	if err := s.validateExecPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return
+	}
+	if err := s.broker.ReportStarted(ctx, env.RequestID, env.Nonce, payload.ChildPID); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return
+	}
+	_ = writeOK(encoder, env.RequestID, env.Nonce, nil)
+}
+
+func (s *Server) handleCommandCompleted(
+	ctx context.Context,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env Envelope,
+) bool {
+	payload, err := DecodePayload[CommandCompletedPayload](env)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_command_completed", err)
+		return false
+	}
+	if err := s.validateExecPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return false
+	}
+	if err := s.broker.ReportCompleted(ctx, env.RequestID, env.Nonce, payload.ExitCode, payload.Signal); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return false
+	}
+	_ = writeOK(encoder, env.RequestID, env.Nonce, nil)
+	return true
 }
 
 func (s *Server) peerInfo(conn *net.UnixConn) (peercred.Info, error) {
@@ -229,6 +283,14 @@ func (s *Server) peerInfo(conn *net.UnixConn) (peercred.Info, error) {
 		return provider.Info(conn)
 	}
 	return peercred.Inspect(conn)
+}
+
+func (s *Server) validateExecPeer(conn *net.UnixConn) error {
+	peer, err := s.peerInfo(conn)
+	if err != nil {
+		return err
+	}
+	return s.execValidator.ValidateExecPeer(peer)
 }
 
 func writeOK(encoder *json.Encoder, requestID string, nonce string, payload any) error {
@@ -268,6 +330,8 @@ func codeForError(err error) string {
 		return "request_expired"
 	case errors.Is(err, ErrStaleApproval):
 		return "stale_approval"
+	case errors.Is(err, ErrUntrustedClient):
+		return "untrusted_client"
 	default:
 		return "request_failed"
 	}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -328,6 +328,69 @@ func TestServerReportsBadMessagePayloadsAndTypes(t *testing.T) {
 	}
 }
 
+func TestServerRejectsMalformedExecRequestBeforeApproval(t *testing.T) {
+	t.Parallel()
+
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true}}
+	resolver := &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}}
+	client, cleanup := startTestServer(t, BrokerOptions{
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    &memoryAudit{},
+	})
+	defer cleanup()
+
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
+	req.Reason = "  fabricated metadata  "
+	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); !IsProtocolError(err, "bad_request") {
+		t.Fatalf("expected bad_request protocol error, got %v", err)
+	}
+	if approver.calls != 0 {
+		t.Fatalf("approver calls = %d, want 0", approver.calls)
+	}
+	if calls := resolver.Calls(); len(calls) != 0 {
+		t.Fatalf("resolver calls = %v, want none", calls)
+	}
+}
+
+func TestServerRejectsUntrustedExecPeerBeforeSecretPayload(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	peer := peerInfoForTest(t, os.Getpid(), exe)
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true}}
+	resolver := &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}}
+	path, stop := startRawServerWithBrokerAndExecValidator(
+		t,
+		newTestBroker(t, BrokerOptions{
+			Approver: approver,
+			Resolver: resolver,
+			Audit:    &memoryAudit{},
+		}),
+		nil,
+		staticPeerValidator{info: peer},
+		NewTrustedExecutableValidator([]string{writeExecutableAt(t, t.TempDir(), "agent-secret")}),
+	)
+	defer stop()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	client := NewClient(conn)
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
+	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); !IsProtocolError(err, "untrusted_client") {
+		t.Fatalf("expected untrusted_client protocol error, got %v", err)
+	}
+	if approver.calls != 0 {
+		t.Fatalf("approver calls = %d, want 0", approver.calls)
+	}
+	if calls := resolver.Calls(); len(calls) != 0 {
+		t.Fatalf("resolver calls = %v, want none", calls)
+	}
+}
+
 func TestServerReportsBadApprovalDecisionPayload(t *testing.T) {
 	t.Parallel()
 
@@ -421,6 +484,7 @@ func TestCodeForErrorMapsProtocolFailures(t *testing.T) {
 		{err: ErrNoPendingApproval, want: "no_pending_approval"},
 		{err: ErrRequestExpired, want: "request_expired"},
 		{err: ErrStaleApproval, want: "stale_approval"},
+		{err: ErrUntrustedClient, want: "untrusted_client"},
 		{err: errors.New("other"), want: "request_failed"},
 	}
 	for _, tt := range tests {
@@ -504,6 +568,23 @@ func startRawServerWithBroker(
 	validator PeerValidator,
 ) (string, func()) {
 	t.Helper()
+	return startRawServerWithBrokerAndExecValidator(
+		t,
+		broker,
+		approvals,
+		validator,
+		NewTrustedExecutableValidator(CurrentExecutableTrustedClientPaths()),
+	)
+}
+
+func startRawServerWithBrokerAndExecValidator(
+	t *testing.T,
+	broker *Broker,
+	approvals ApprovalEndpoint,
+	validator PeerValidator,
+	execValidator ExecPeerValidator,
+) (string, func()) {
+	t.Helper()
 	dir, err := os.MkdirTemp("/tmp", "agent-secret-test-")
 	if err != nil {
 		t.Fatalf("MkdirTemp returned error: %v", err)
@@ -513,7 +594,12 @@ func startRawServerWithBroker(
 	if err != nil {
 		t.Fatalf("ListenUnix returned error: %v", err)
 	}
-	server, err := NewServer(ServerOptions{Broker: broker, Approvals: approvals, Validator: validator})
+	server, err := NewServer(ServerOptions{
+		Broker:        broker,
+		Approvals:     approvals,
+		Validator:     validator,
+		ExecValidator: execValidator,
+	})
 	if err != nil {
 		t.Fatalf("NewServer returned error: %v", err)
 	}
@@ -541,4 +627,13 @@ func startRawServerWithBroker(
 func testSocketPath(t *testing.T) string {
 	t.Helper()
 	return filepath.Join(t.TempDir(), "missing.sock")
+}
+
+func writeExecutableAt(t *testing.T, dir string, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	return path
 }

--- a/internal/daemon/trusted_client.go
+++ b/internal/daemon/trusted_client.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/kovyrin/agent-secret/internal/peercred"
+)
+
+var ErrUntrustedClient = errors.New("untrusted daemon client")
+
+type ExecPeerValidator interface {
+	ValidateExecPeer(info peercred.Info) error
+}
+
+type TrustedExecutableValidator struct {
+	paths []string
+}
+
+func NewTrustedExecutableValidator(paths []string) TrustedExecutableValidator {
+	seen := make(map[string]struct{}, len(paths))
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		path = comparablePath(path)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		normalized = append(normalized, path)
+	}
+	slices.Sort(normalized)
+	return TrustedExecutableValidator{paths: normalized}
+}
+
+func DefaultTrustedClientPaths() []string {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	dir := filepath.Dir(exe)
+	paths := []string{filepath.Join(dir, "agent-secret")}
+	if filepath.Base(exe) == "agent-secret" {
+		paths = append(paths, exe)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, ".local", "bin", "agent-secret"))
+	}
+	return paths
+}
+
+func CurrentExecutableTrustedClientPaths() []string {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	return []string{exe}
+}
+
+func (v TrustedExecutableValidator) ValidateExecPeer(info peercred.Info) error {
+	if info.ExecutablePath == "" {
+		return fmt.Errorf("%w: peer executable path is unavailable", ErrUntrustedClient)
+	}
+	if len(v.paths) == 0 {
+		return fmt.Errorf("%w: no trusted client executables configured", ErrUntrustedClient)
+	}
+	got := comparablePath(info.ExecutablePath)
+	if _, ok := slices.BinarySearch(v.paths, got); ok {
+		return nil
+	}
+	return fmt.Errorf("%w: executable %q is not trusted", ErrUntrustedClient, got)
+}
+
+func comparablePath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return abs
+}

--- a/internal/daemon/trusted_client_test.go
+++ b/internal/daemon/trusted_client_test.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovyrin/agent-secret/internal/peercred"
+)
+
+func TestTrustedExecutableValidatorMatchesComparableExecutablePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := writeExecutableAt(t, dir, "agent-secret-real")
+	link := filepath.Join(dir, "agent-secret")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	validator := NewTrustedExecutableValidator([]string{link})
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: target})
+	if err != nil {
+		t.Fatalf("ValidateExecPeer returned error: %v", err)
+	}
+}
+
+func TestTrustedExecutableValidatorRejectsUnlistedExecutable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	trusted := writeExecutableAt(t, dir, "agent-secret")
+	other := writeExecutableAt(t, dir, "raw-client")
+
+	validator := NewTrustedExecutableValidator([]string{trusted})
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: other})
+	if !errors.Is(err, ErrUntrustedClient) {
+		t.Fatalf("expected ErrUntrustedClient, got %v", err)
+	}
+}

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -25,6 +25,7 @@ var (
 	ErrInvalidMaxReads     = errors.New("invalid max reads")
 	ErrInvalidReason       = errors.New("invalid reason")
 	ErrInvalidReference    = errors.New("invalid 1Password secret reference")
+	ErrInvalidRequest      = errors.New("invalid exec request")
 	ErrInvalidTTL          = errors.New("invalid ttl")
 )
 
@@ -90,6 +91,44 @@ type ExecRequest struct {
 
 func (r ExecRequest) Expired(at time.Time) bool {
 	return !at.Before(r.ExpiresAt)
+}
+
+func (r ExecRequest) ValidateForDaemon() error {
+	reason, err := validateReason(r.Reason)
+	if err != nil {
+		return err
+	}
+	if reason != r.Reason {
+		return fmt.Errorf("%w: reason must be pre-normalized", ErrInvalidReason)
+	}
+	if err := validateDelivery(r.DeliveryMode, r.MaxReads); err != nil {
+		return err
+	}
+	if r.TTL < MinExecTTL || r.TTL > MaxExecTTL {
+		return fmt.Errorf("%w: must be between %s and %s", ErrInvalidTTL, MinExecTTL, MaxExecTTL)
+	}
+	if r.ReceivedAt.IsZero() || r.ExpiresAt.IsZero() {
+		return fmt.Errorf("%w: request times are required", ErrInvalidRequest)
+	}
+	if !r.ExpiresAt.Equal(r.ReceivedAt.Add(r.TTL)) {
+		return fmt.Errorf("%w: expires_at must equal received_at plus ttl", ErrInvalidTTL)
+	}
+	if err := validateDaemonPath("cwd", r.CWD, false); err != nil {
+		return err
+	}
+	if err := validateDaemonPath("resolved executable", r.ResolvedExecutable, true); err != nil {
+		return err
+	}
+	if len(r.Command) == 0 || r.Command[0] == "" {
+		return fmt.Errorf("%w: argv is required", ErrInvalidCommand)
+	}
+	if _, err := validateDaemonSecrets(r.Secrets); err != nil {
+		return err
+	}
+	if err := validateOverriddenAliases(r.Secrets, r.OverriddenAliases, r.OverrideEnv); err != nil {
+		return err
+	}
+	return nil
 }
 
 func NewExec(opts ExecOptions) (ExecRequest, error) {
@@ -298,6 +337,22 @@ func validateExecutable(path string) (string, error) {
 	return evalPath(abs), nil
 }
 
+func validateDaemonPath(name string, path string, executable bool) error {
+	if path == "" {
+		return fmt.Errorf("%w: %s is required", ErrInvalidRequest, name)
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("%w: %s must be absolute", ErrInvalidRequest, name)
+	}
+	if filepath.Clean(path) != path {
+		return fmt.Errorf("%w: %s must be normalized", ErrInvalidRequest, name)
+	}
+	if executable && strings.HasSuffix(path, string(os.PathSeparator)) {
+		return fmt.Errorf("%w: %s must name a file", ErrInvalidCommand, name)
+	}
+	return nil
+}
+
 func parseSecrets(specs []SecretSpec) ([]Secret, error) {
 	if len(specs) == 0 {
 		return nil, fmt.Errorf("%w: at least one secret is required", ErrInvalidReference)
@@ -322,6 +377,63 @@ func parseSecrets(specs []SecretSpec) ([]Secret, error) {
 	}
 
 	return secrets, nil
+}
+
+func validateDaemonSecrets(secrets []Secret) ([]Secret, error) {
+	specs := make([]SecretSpec, 0, len(secrets))
+	for _, secret := range secrets {
+		parsed, err := ParseSecretRef(secret.Ref.Raw)
+		if err != nil {
+			return nil, err
+		}
+		if parsed != secret.Ref {
+			return nil, fmt.Errorf("%w: parsed reference metadata does not match raw ref", ErrInvalidReference)
+		}
+		specs = append(specs, SecretSpec{Alias: secret.Alias, Ref: secret.Ref.Raw, Account: secret.Account})
+	}
+	parsed, err := parseSecrets(specs)
+	if err != nil {
+		return nil, err
+	}
+	if len(parsed) != len(secrets) {
+		return nil, fmt.Errorf("%w: secret count mismatch", ErrInvalidReference)
+	}
+	for i := range parsed {
+		if parsed[i] != secrets[i] {
+			return nil, fmt.Errorf("%w: secret metadata must be pre-normalized", ErrInvalidReference)
+		}
+	}
+	return parsed, nil
+}
+
+func validateOverriddenAliases(secrets []Secret, aliases []string, override bool) error {
+	if len(aliases) == 0 {
+		return nil
+	}
+	if !override {
+		return fmt.Errorf("%w: overridden aliases require override", ErrInvalidAlias)
+	}
+	if !slices.IsSorted(aliases) {
+		return fmt.Errorf("%w: overridden aliases must be sorted", ErrInvalidAlias)
+	}
+	known := make(map[string]struct{}, len(secrets))
+	for _, secret := range secrets {
+		known[secret.Alias] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(aliases))
+	for _, alias := range aliases {
+		if !aliasPattern.MatchString(alias) {
+			return fmt.Errorf("%w: %q", ErrInvalidAlias, alias)
+		}
+		if _, exists := seen[alias]; exists {
+			return fmt.Errorf("%w: duplicate overridden alias %q", ErrInvalidAlias, alias)
+		}
+		seen[alias] = struct{}{}
+		if _, exists := known[alias]; !exists {
+			return fmt.Errorf("%w: overridden alias %q is not requested", ErrInvalidAlias, alias)
+		}
+	}
+	return nil
 }
 
 func detectOverrides(env []string, secrets []Secret, override bool) ([]string, error) {

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -166,6 +167,71 @@ func TestNewExecRecordsOverrideAliases(t *testing.T) {
 	}
 }
 
+func TestExecRequestValidateForDaemonAcceptsClientNormalizedRequest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeExecutable(t, dir)
+
+	req, err := NewExec(mutate(baseOptions(dir, "reason"), func(o *ExecOptions) {
+		o.Env = append(o.Env, "TOKEN=already")
+		o.OverrideEnv = true
+	}))
+	if err != nil {
+		t.Fatalf("NewExec returned error: %v", err)
+	}
+	if err := req.ValidateForDaemon(); err != nil {
+		t.Fatalf("ValidateForDaemon returned error: %v", err)
+	}
+}
+
+func TestExecRequestValidateForDaemonRejectsFabricatedMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeExecutable(t, dir)
+	req, err := NewExec(baseOptions(dir, "reason"))
+	if err != nil {
+		t.Fatalf("NewExec returned error: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*ExecRequest)
+		want   error
+	}{
+		{name: "unnormalized reason", mutate: func(r *ExecRequest) { r.Reason = " reason " }, want: ErrInvalidReason},
+		{name: "ttl outside bounds", mutate: func(r *ExecRequest) { r.TTL = time.Second }, want: ErrInvalidTTL},
+		{name: "expiration mismatch", mutate: func(r *ExecRequest) { r.ExpiresAt = r.ExpiresAt.Add(time.Second) }, want: ErrInvalidTTL},
+		{name: "relative cwd", mutate: func(r *ExecRequest) { r.CWD = "project" }, want: ErrInvalidRequest},
+		{name: "relative resolved executable", mutate: func(r *ExecRequest) { r.ResolvedExecutable = "tool" }, want: ErrInvalidRequest},
+		{name: "missing command", mutate: func(r *ExecRequest) { r.Command = nil }, want: ErrInvalidCommand},
+		{name: "tampered ref metadata", mutate: func(r *ExecRequest) { r.Secrets[0].Ref.Field = "other" }, want: ErrInvalidReference},
+		{name: "duplicate alias", mutate: func(r *ExecRequest) {
+			r.Secrets = append(r.Secrets, r.Secrets[0])
+		}, want: ErrInvalidAlias},
+		{name: "unknown overridden alias", mutate: func(r *ExecRequest) {
+			r.OverrideEnv = true
+			r.OverriddenAliases = []string{"OTHER"}
+		}, want: ErrInvalidAlias},
+		{name: "override aliases without override", mutate: func(r *ExecRequest) {
+			r.OverriddenAliases = []string{"TOKEN"}
+		}, want: ErrInvalidAlias},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := cloneRequest(req)
+			tt.mutate(&got)
+			if err := got.ValidateForDaemon(); !errors.Is(err, tt.want) {
+				t.Fatalf("expected %v, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
 func TestExecRequestExpiryUsesDaemonReceiptTTL(t *testing.T) {
 	t.Parallel()
 
@@ -215,6 +281,14 @@ func baseOptions(dir string, reason string) ExecOptions {
 func mutate(opts ExecOptions, fn func(*ExecOptions)) ExecOptions {
 	fn(&opts)
 	return opts
+}
+
+func cloneRequest(req ExecRequest) ExecRequest {
+	req.Command = slices.Clone(req.Command)
+	req.Env = slices.Clone(req.Env)
+	req.Secrets = slices.Clone(req.Secrets)
+	req.OverriddenAliases = slices.Clone(req.OverriddenAliases)
+	return req
 }
 
 func writeExecutable(t *testing.T, dir string) string {


### PR DESCRIPTION
## Summary
- require request.exec and command lifecycle messages to come from a configured trusted agent-secret executable path
- pass the launching CLI path to agent-secretd during daemon startup
- validate exec request metadata on the daemon before approval or secret resolution
- add direct socket bypass and malformed metadata tests

Closes #2

## Verification
- mise run lint:go
- mise run test
- mise run lint
- mise run build
- mise run test:race