### PR TITLE
Harden daemon and approver discovery

### DIFF
--- a/approver/scripts/build-app.sh
+++ b/approver/scripts/build-app.sh
@@ -41,4 +41,8 @@ cat >"$bundle/Contents/Info.plist" <<'PLIST'
 </plist>
 PLIST
 
+if command -v codesign >/dev/null 2>&1; then
+  codesign --force --sign - "$bundle" >/dev/null
+fi
+
 echo "$bundle"

--- a/cmd/agent-secretd/main.go
+++ b/cmd/agent-secretd/main.go
@@ -36,7 +36,7 @@ func run() int {
 	flags.StringVar(&socketPath, "socket", socketPath, "daemon socket path")
 	var trustedClients stringListFlag
 	flags.Var(&trustedClients, "trusted-client", "trusted agent-secret executable path; repeatable")
-	approverPath := flags.String("approver", os.Getenv("AGENT_SECRET_APPROVER_PATH"), "approver executable or .app path")
+	approverPath := flags.String("approver", defaultApproverFlagValue(), "approver executable or .app path")
 	accountName := flags.String("account", os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT"), "1Password account sign-in address, name, or UUID; empty uses OP_ACCOUNT or my.1password.com")
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		stderrf("agent-secretd: parse flags: %v\n", err)
@@ -91,6 +91,10 @@ func run() int {
 
 func stderrf(format string, args ...any) {
 	_, _ = fmt.Fprintf(os.Stderr, format, args...)
+}
+
+func defaultApproverFlagValue() string {
+	return ""
 }
 
 type stringListFlag []string

--- a/cmd/agent-secretd/main_test.go
+++ b/cmd/agent-secretd/main_test.go
@@ -2,6 +2,14 @@ package main
 
 import "testing"
 
+func TestDefaultApproverFlagValueIgnoresEnvironmentOverride(t *testing.T) {
+	t.Setenv("AGENT_SECRET_APPROVER_PATH", "/tmp/fake-approver")
+
+	if got := defaultApproverFlagValue(); got != "" {
+		t.Fatalf("default approver flag value = %q, want empty", got)
+	}
+}
+
 func TestNewResolverUsesDesktopResolverWithoutAccountOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	ErrApproverLaunchFailed = errors.New("approver launch failed")
+	ErrApproverIdentity     = errors.New("approver identity mismatch")
 	ErrApproverPeerMismatch = errors.New("approver peer identity mismatch")
 	ErrNoPendingApproval    = errors.New("no pending approval request")
 	ErrStaleApproval        = errors.New("stale approval response")
@@ -55,6 +56,17 @@ type ApprovalEndpoint interface {
 
 type ApproverLauncher interface {
 	Launch(ctx context.Context, socketPath string, payload ApprovalRequestPayload) (ExpectedApprover, error)
+}
+
+type ApproverIdentityPolicy interface {
+	ValidateApproverExecutable(path string) (ApproverIdentity, error)
+}
+
+type ApproverIdentity struct {
+	ExecutablePath string
+	BundlePath     string
+	BundleID       string
+	TeamID         string
 }
 
 type ExpectedApprover struct {
@@ -201,7 +213,8 @@ func (a *SocketApprover) SubmitDecision(
 }
 
 type ProcessApproverLauncher struct {
-	AppPath string
+	AppPath        string
+	IdentityPolicy ApproverIdentityPolicy
 }
 
 func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string, _ ApprovalRequestPayload) (ExpectedApprover, error) {
@@ -209,6 +222,11 @@ func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string, 
 	if err != nil {
 		return ExpectedApprover{}, err
 	}
+	identity, err := l.identityPolicy().ValidateApproverExecutable(executable)
+	if err != nil {
+		return ExpectedApprover{}, err
+	}
+	executable = identity.ExecutablePath
 
 	cmd := exec.CommandContext(ctx, executable, "--socket", socketPath)
 	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
@@ -240,6 +258,13 @@ func (l ProcessApproverLauncher) executablePath() (string, error) {
 		return filepath.Join(l.AppPath, "Contents", "MacOS", "agent-secret-approver"), nil
 	}
 	return l.AppPath, nil
+}
+
+func (l ProcessApproverLauncher) identityPolicy() ApproverIdentityPolicy {
+	if l.IdentityPolicy != nil {
+		return l.IdentityPolicy
+	}
+	return DefaultApproverIdentityPolicy()
 }
 
 func approvalPayload(requestID string, nonce string, req request.ExecRequest) ApprovalRequestPayload {

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -22,6 +22,12 @@ type recordingLauncher struct {
 	err      error
 }
 
+type allowApproverIdentityPolicy struct{}
+
+func (allowApproverIdentityPolicy) ValidateApproverExecutable(path string) (ApproverIdentity, error) {
+	return ApproverIdentity{ExecutablePath: path}, nil
+}
+
 func (l *recordingLauncher) Launch(_ context.Context, _ string, payload ApprovalRequestPayload) (ExpectedApprover, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -292,7 +298,10 @@ func TestProcessApproverLauncherLaunchesBinary(t *testing.T) {
 		t.Fatalf("write helper: %v", err)
 	}
 
-	expected, err := (ProcessApproverLauncher{AppPath: helper}).Launch(
+	expected, err := (ProcessApproverLauncher{
+		AppPath:        helper,
+		IdentityPolicy: allowApproverIdentityPolicy{},
+	}).Launch(
 		context.Background(),
 		"/tmp/agent-secret-test.sock",
 		ApprovalRequestPayload{},
@@ -308,16 +317,67 @@ func TestProcessApproverLauncherLaunchesBinary(t *testing.T) {
 	}
 }
 
+func TestProcessApproverLauncherRejectsBareBinaryByDefault(t *testing.T) {
+	t.Parallel()
+
+	helper := filepath.Join(t.TempDir(), "agent-secret-approver")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+
+	_, err := (ProcessApproverLauncher{AppPath: helper}).Launch(
+		context.Background(),
+		"/tmp/agent-secret-test.sock",
+		ApprovalRequestPayload{},
+	)
+	if !errors.Is(err, ErrApproverIdentity) {
+		t.Fatalf("expected approver identity error, got %v", err)
+	}
+}
+
 func TestProcessApproverLauncherWrapsStartFailure(t *testing.T) {
 	t.Parallel()
 
-	_, err := (ProcessApproverLauncher{AppPath: filepath.Join(t.TempDir(), "missing")}).Launch(
+	_, err := (ProcessApproverLauncher{
+		AppPath:        filepath.Join(t.TempDir(), "missing"),
+		IdentityPolicy: allowApproverIdentityPolicy{},
+	}).Launch(
 		context.Background(),
 		"/tmp/agent-secret-test.sock",
 		ApprovalRequestPayload{},
 	)
 	if !errors.Is(err, ErrApproverLaunchFailed) {
 		t.Fatalf("expected launch failure, got %v", err)
+	}
+}
+
+func TestBundleApproverIdentityPolicyValidatesBundleMetadata(t *testing.T) {
+	t.Parallel()
+
+	executable := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, DefaultApproverExecutable)
+	identity, err := (BundleApproverIdentityPolicy{VerifySignature: false}).ValidateApproverExecutable(executable)
+	if err != nil {
+		t.Fatalf("ValidateApproverExecutable returned error: %v", err)
+	}
+	wantExecutable, err := comparableApproverPath(executable)
+	if err != nil {
+		t.Fatalf("comparableApproverPath returned error: %v", err)
+	}
+	if identity.ExecutablePath != wantExecutable {
+		t.Fatalf("identity executable = %q, want %q", identity.ExecutablePath, wantExecutable)
+	}
+	if identity.BundleID != DefaultApproverBundleID {
+		t.Fatalf("identity bundle id = %q", identity.BundleID)
+	}
+}
+
+func TestBundleApproverIdentityPolicyRejectsWrongBundleID(t *testing.T) {
+	t.Parallel()
+
+	executable := writeApproverBundle(t, t.TempDir(), "com.example.fake", DefaultApproverExecutable)
+	_, err := (BundleApproverIdentityPolicy{VerifySignature: false}).ValidateApproverExecutable(executable)
+	if !errors.Is(err, ErrApproverIdentity) {
+		t.Fatalf("expected approver identity error, got %v", err)
 	}
 }
 
@@ -328,6 +388,34 @@ func newSocketApproverForTest(t *testing.T, launcher ApproverLauncher, now func(
 		t.Fatalf("NewSocketApprover returned error: %v", err)
 	}
 	return approver
+}
+
+func writeApproverBundle(t *testing.T, dir string, bundleID string, executableName string) string {
+	t.Helper()
+	bundlePath := filepath.Join(dir, "AgentSecretApprover.app")
+	macOSPath := filepath.Join(bundlePath, "Contents", "MacOS")
+	if err := os.MkdirAll(macOSPath, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	executablePath := filepath.Join(macOSPath, executableName)
+	if err := os.WriteFile(executablePath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	info := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>` + bundleID + `</string>
+  <key>CFBundleExecutable</key>
+  <string>` + executableName + `</string>
+</dict>
+</plist>
+`
+	if err := os.WriteFile(filepath.Join(bundlePath, "Contents", "Info.plist"), []byte(info), 0o644); err != nil {
+		t.Fatalf("write Info.plist: %v", err)
+	}
+	return executablePath
 }
 
 func approvalTestRequest(t *testing.T, expiresAt time.Time) request.ExecRequest {

--- a/internal/daemon/approver_identity.go
+++ b/internal/daemon/approver_identity.go
@@ -1,0 +1,170 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultApproverBundleID   = "com.kovyrin.agent-secret.approver"
+	DefaultApproverExecutable = "agent-secret-approver"
+)
+
+type BundleApproverIdentityPolicy struct {
+	ExpectedBundleID   string
+	ExpectedExecutable string
+	ExpectedTeamID     string
+	VerifySignature    bool
+}
+
+func DefaultApproverIdentityPolicy() BundleApproverIdentityPolicy {
+	return BundleApproverIdentityPolicy{
+		ExpectedBundleID:   DefaultApproverBundleID,
+		ExpectedExecutable: DefaultApproverExecutable,
+		VerifySignature:    runtime.GOOS == "darwin",
+	}
+}
+
+func (p BundleApproverIdentityPolicy) ValidateApproverExecutable(path string) (ApproverIdentity, error) {
+	path, err := comparableApproverPath(path)
+	if err != nil {
+		return ApproverIdentity{}, err
+	}
+	bundlePath, err := appBundleForExecutable(path)
+	if err != nil {
+		return ApproverIdentity{}, err
+	}
+
+	infoPath := filepath.Join(bundlePath, "Contents", "Info.plist")
+	bundleID, err := plistString(infoPath, "CFBundleIdentifier")
+	if err != nil {
+		return ApproverIdentity{}, err
+	}
+	expectedBundleID := p.ExpectedBundleID
+	if expectedBundleID == "" {
+		expectedBundleID = DefaultApproverBundleID
+	}
+	if bundleID != expectedBundleID {
+		return ApproverIdentity{}, fmt.Errorf("%w: bundle id %q != %q", ErrApproverIdentity, bundleID, expectedBundleID)
+	}
+
+	executableName, err := plistString(infoPath, "CFBundleExecutable")
+	if err != nil {
+		return ApproverIdentity{}, err
+	}
+	expectedExecutable := p.ExpectedExecutable
+	if expectedExecutable == "" {
+		expectedExecutable = DefaultApproverExecutable
+	}
+	if executableName != expectedExecutable {
+		return ApproverIdentity{}, fmt.Errorf("%w: executable %q != %q", ErrApproverIdentity, executableName, expectedExecutable)
+	}
+	bundleExecutable := filepath.Join(bundlePath, "Contents", "MacOS", executableName)
+	bundleExecutable, err = comparableApproverPath(bundleExecutable)
+	if err != nil {
+		return ApproverIdentity{}, err
+	}
+	if path != bundleExecutable {
+		return ApproverIdentity{}, fmt.Errorf("%w: executable %q is outside expected bundle executable %q", ErrApproverIdentity, path, bundleExecutable)
+	}
+
+	teamID := ""
+	if p.VerifySignature {
+		teamID, err = verifyCodeSignature(bundlePath)
+		if err != nil {
+			return ApproverIdentity{}, err
+		}
+	}
+	if p.ExpectedTeamID != "" && teamID != p.ExpectedTeamID {
+		return ApproverIdentity{}, fmt.Errorf("%w: team id %q != %q", ErrApproverIdentity, teamID, p.ExpectedTeamID)
+	}
+
+	return ApproverIdentity{
+		ExecutablePath: path,
+		BundlePath:     bundlePath,
+		BundleID:       bundleID,
+		TeamID:         teamID,
+	}, nil
+}
+
+func appBundleForExecutable(path string) (string, error) {
+	dir := filepath.Dir(path)
+	for {
+		if filepath.Ext(dir) == ".app" {
+			bundlePath, err := comparableApproverPath(dir)
+			if err != nil {
+				return "", err
+			}
+			return bundlePath, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("%w: executable %q is not inside a .app bundle", ErrApproverIdentity, path)
+		}
+		dir = parent
+	}
+}
+
+func plistString(path string, key string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("%w: read %s: %w", ErrApproverIdentity, path, err)
+	}
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	var currentKey string
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			break
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		switch start.Name.Local {
+		case "key":
+			var value string
+			if err := decoder.DecodeElement(&value, &start); err != nil {
+				return "", fmt.Errorf("%w: parse %s key: %w", ErrApproverIdentity, path, err)
+			}
+			currentKey = value
+		case "string":
+			var value string
+			if err := decoder.DecodeElement(&value, &start); err != nil {
+				return "", fmt.Errorf("%w: parse %s string: %w", ErrApproverIdentity, path, err)
+			}
+			if currentKey == key {
+				return value, nil
+			}
+			currentKey = ""
+		}
+	}
+	return "", fmt.Errorf("%w: %s missing %s", ErrApproverIdentity, path, key)
+}
+
+func verifyCodeSignature(bundlePath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(ctx, "/usr/bin/codesign", "--verify", "--strict", "--deep", bundlePath).Run(); err != nil {
+		return "", fmt.Errorf("%w: verify code signature for %s: %w", ErrApproverIdentity, bundlePath, err)
+	}
+	output, err := exec.CommandContext(ctx, "/usr/bin/codesign", "-dv", "--verbose=4", bundlePath).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%w: inspect code signature for %s: %w", ErrApproverIdentity, bundlePath, err)
+	}
+	for line := range strings.SplitSeq(string(output), "\n") {
+		teamID, ok := strings.CutPrefix(strings.TrimSpace(line), "TeamIdentifier=")
+		if ok {
+			return teamID, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -26,14 +26,6 @@ func NewManager(socketPath string) (Manager, error) {
 			return Manager{}, err
 		}
 	}
-	if daemonPath := strings.TrimSpace(os.Getenv("AGENT_SECRET_DAEMON_PATH")); daemonPath != "" {
-		return Manager{
-			SocketPath:         socketPath,
-			DaemonPath:         daemonPath,
-			TrustedClientPaths: CurrentExecutableTrustedClientPaths(),
-			StartupTimeout:     3 * time.Second,
-		}, nil
-	}
 	daemonPath, err := defaultDaemonPath()
 	if err != nil {
 		return Manager{}, err

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -75,7 +75,11 @@ func runDaemonManagerHelper(t *testing.T) {
 		_, _ = fmt.Fprintf(os.Stderr, "new broker: %v\n", err)
 		os.Exit(70)
 	}
-	server, err := NewServer(ServerOptions{Broker: broker, Validator: allowPeerValidator{}})
+	server, err := NewServer(ServerOptions{
+		Broker:        broker,
+		Validator:     allowPeerValidator{},
+		ExecValidator: NewTrustedExecutableValidator(CurrentExecutableTrustedClientPaths()),
+	})
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "new server: %v\n", err)
 		os.Exit(70)
@@ -102,7 +106,7 @@ func waitForStatusFailure(t *testing.T, manager Manager) {
 	t.Fatal("daemon still responded after stop")
 }
 
-func TestNewManagerUsesDefaultSocketAndDaemonPathOverride(t *testing.T) {
+func TestNewManagerIgnoresDaemonPathEnvironmentOverride(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("AGENT_SECRET_DAEMON_PATH", "/tmp/agent-secretd-test")
@@ -115,8 +119,8 @@ func TestNewManagerUsesDefaultSocketAndDaemonPathOverride(t *testing.T) {
 	if manager.SocketPath != wantSocket {
 		t.Fatalf("SocketPath = %q, want %q", manager.SocketPath, wantSocket)
 	}
-	if manager.DaemonPath != "/tmp/agent-secretd-test" {
-		t.Fatalf("DaemonPath = %q, want env override", manager.DaemonPath)
+	if manager.DaemonPath == "/tmp/agent-secretd-test" {
+		t.Fatalf("DaemonPath honored requester-controlled env override: %q", manager.DaemonPath)
 	}
 	if !slices.Equal(manager.TrustedClientPaths, CurrentExecutableTrustedClientPaths()) {
 		t.Fatalf("TrustedClientPaths = %v, want current executable", manager.TrustedClientPaths)
@@ -156,14 +160,20 @@ func TestManagerDaemonArgsReplaceSocketPlaceholder(t *testing.T) {
 }
 
 func TestDaemonAppPathAndStartCommand(t *testing.T) {
-	t.Setenv("AGENT_SECRET_DAEMON_APP_PATH", "/tmp/AgentSecretDaemon.app")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	daemonAppPath := filepath.Join(home, "Applications", "AgentSecretDaemon.app")
+	if err := os.MkdirAll(daemonAppPath, 0o755); err != nil {
+		t.Fatalf("mkdir daemon app: %v", err)
+	}
+	t.Setenv("AGENT_SECRET_DAEMON_APP_PATH", "/tmp/PoisonDaemon.app")
 	t.Setenv("OP_ACCOUNT", "DefaultFixture")
 	t.Setenv("AGENT_SECRET_1PASSWORD_ACCOUNT", "Fixture")
-	t.Setenv("AGENT_SECRET_APPROVER_PATH", "/Applications/AgentSecretApprover.app")
+	t.Setenv("AGENT_SECRET_APPROVER_PATH", "/tmp/PoisonApprover.app")
 
 	appPath, ok := defaultDaemonAppPath()
 	if runtime.GOOS == "darwin" {
-		if !ok || appPath != "/tmp/AgentSecretDaemon.app" {
+		if !ok || appPath != daemonAppPath {
 			t.Fatalf("default daemon app path = %q, %v", appPath, ok)
 		}
 		cmd := daemonStartCommand(context.Background(), appPath, []string{"--socket", "/tmp/d.sock"})
@@ -178,7 +188,6 @@ func TestDaemonAppPathAndStartCommand(t *testing.T) {
 			"OP_ACCOUNT=DefaultFixture",
 			"--env",
 			"AGENT_SECRET_1PASSWORD_ACCOUNT=Fixture",
-			"AGENT_SECRET_APPROVER_PATH=/Applications/AgentSecretApprover.app",
 			"--args",
 			"--socket",
 			"/tmp/d.sock",
@@ -186,6 +195,9 @@ func TestDaemonAppPathAndStartCommand(t *testing.T) {
 			if !slices.Contains(cmd.Args, want) {
 				t.Fatalf("darwin app command args %v missing %q", cmd.Args, want)
 			}
+		}
+		if slices.Contains(cmd.Args, "AGENT_SECRET_APPROVER_PATH=/tmp/PoisonApprover.app") {
+			t.Fatalf("darwin app command args forwarded poisoned approver path: %v", cmd.Args)
 		}
 		return
 	}

--- a/internal/daemon/process_unix.go
+++ b/internal/daemon/process_unix.go
@@ -33,9 +33,6 @@ func defaultDaemonAppPath() (string, bool) {
 	if runtime.GOOS != "darwin" {
 		return "", false
 	}
-	if appPath := os.Getenv("AGENT_SECRET_DAEMON_APP_PATH"); appPath != "" {
-		return appPath, true
-	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", false
@@ -52,7 +49,6 @@ func daemonAppEnvironment() []string {
 	names := []string{
 		"OP_ACCOUNT",
 		"AGENT_SECRET_1PASSWORD_ACCOUNT",
-		"AGENT_SECRET_APPROVER_PATH",
 	}
 	env := make([]string, 0, len(names))
 	for _, name := range names {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -141,6 +141,10 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 		case TypeDaemonStatus:
 			_ = writeOK(encoder, env.RequestID, env.Nonce, StatusPayload{PID: os.Getpid()})
 		case TypeDaemonStop:
+			if err := s.validateTrustedClientPeer(conn); err != nil {
+				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+				continue
+			}
 			_ = writeOK(encoder, env.RequestID, env.Nonce, StatusPayload{PID: os.Getpid()})
 			s.Stop(ctx)
 			return
@@ -211,7 +215,7 @@ func (s *Server) handleRequestExec(
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_request", err)
 		return ""
 	}
-	if err := s.validateExecPeer(conn); err != nil {
+	if err := s.validateTrustedClientPeer(conn); err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
 		return ""
 	}
@@ -241,7 +245,7 @@ func (s *Server) handleCommandStarted(
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_command_started", err)
 		return
 	}
-	if err := s.validateExecPeer(conn); err != nil {
+	if err := s.validateTrustedClientPeer(conn); err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
 		return
 	}
@@ -263,7 +267,7 @@ func (s *Server) handleCommandCompleted(
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_command_completed", err)
 		return false
 	}
-	if err := s.validateExecPeer(conn); err != nil {
+	if err := s.validateTrustedClientPeer(conn); err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
 		return false
 	}
@@ -285,7 +289,7 @@ func (s *Server) peerInfo(conn *net.UnixConn) (peercred.Info, error) {
 	return peercred.Inspect(conn)
 }
 
-func (s *Server) validateExecPeer(conn *net.UnixConn) error {
+func (s *Server) validateTrustedClientPeer(conn *net.UnixConn) error {
 	peer, err := s.peerInfo(conn)
 	if err != nil {
 		return err
@@ -324,6 +328,8 @@ func codeForError(err error) string {
 		return "invalid_nonce"
 	case errors.Is(err, ErrApproverPeerMismatch):
 		return "approver_peer_mismatch"
+	case errors.Is(err, ErrApproverIdentity):
+		return "approver_identity_mismatch"
 	case errors.Is(err, ErrNoPendingApproval):
 		return "no_pending_approval"
 	case errors.Is(err, ErrRequestExpired):

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -187,6 +187,42 @@ func TestServerDaemonStopTerminatesListener(t *testing.T) {
 	}
 }
 
+func TestServerRejectsUntrustedDaemonStopPeer(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	peer := peerInfoForTest(t, os.Getpid(), exe)
+	path, stop := startRawServerWithBrokerAndExecValidator(
+		t,
+		newTestBroker(t, BrokerOptions{
+			Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
+			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
+			Audit:    &memoryAudit{},
+		}),
+		nil,
+		staticPeerValidator{info: peer},
+		NewTrustedExecutableValidator([]string{writeExecutableAt(t, t.TempDir(), "agent-secret")}),
+	)
+	defer stop()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	client := NewClient(conn)
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.Status(context.Background()); err != nil {
+		t.Fatalf("Status returned error: %v", err)
+	}
+	if _, err := client.Stop(context.Background()); !IsProtocolError(err, "untrusted_client") {
+		t.Fatalf("expected untrusted_client stop error, got %v", err)
+	}
+	if _, err := client.Status(context.Background()); err != nil {
+		t.Fatalf("daemon stopped after rejected stop: %v", err)
+	}
+}
+
 func TestServerApprovalProtocolOverSingleSocket(t *testing.T) {
 	t.Parallel()
 
@@ -481,6 +517,7 @@ func TestCodeForErrorMapsProtocolFailures(t *testing.T) {
 		{err: ErrAuditRequired, want: "audit_failed"},
 		{err: ErrInvalidNonce, want: "invalid_nonce"},
 		{err: ErrApproverPeerMismatch, want: "approver_peer_mismatch"},
+		{err: ErrApproverIdentity, want: "approver_identity_mismatch"},
 		{err: ErrNoPendingApproval, want: "no_pending_approval"},
 		{err: ErrRequestExpired, want: "request_expired"},
 		{err: ErrStaleApproval, want: "stale_approval"},


### PR DESCRIPTION
## Summary
- stop honoring requester-controlled daemon and approver path environment overrides in default launch paths
- require daemon.stop from the same trusted CLI peer boundary as request.exec
- validate approver app bundle identity before launch using bundle metadata and code-signature verification
- ad-hoc sign locally built approver bundles so dev installs satisfy the identity policy

Closes #3

## Verification
- mise exec -- go test ./cmd/agent-secretd ./internal/daemon
- mise run lint:go
- mise run test
- mise run lint
- mise run build
- mise run test:race
- /usr/bin/codesign --verify --strict --deep approver/dist/AgentSecretApprover.app