### PR TITLE
Show 1Password account scope in approval requests

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalPanelSecretCard.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelSecretCard.swift
@@ -26,6 +26,12 @@ import Foundation
                         .font(.system(size: Metric.detailTitleFontSize, design: .monospaced))
                         .lineLimit(Metric.twoLineLimit)
                         .truncationMode(.middle)
+                    if let accountLabel: String = secret.accountLabel {
+                        Text(accountLabel)
+                            .font(.system(size: Metric.detailSubtitleFontSize))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(Metric.singleLineLimit)
+                    }
                 }
             }
         }

--- a/approver/Sources/AgentSecretApprover/ApprovalPanelSecretGroupRow.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelSecretGroupRow.swift
@@ -107,6 +107,11 @@ import Foundation
                         .foregroundStyle(.secondary)
                         .lineLimit(nil)
                         .fixedSize(horizontal: false, vertical: true)
+                    if let accountLabel: String = secret.accountLabel {
+                        Text(accountLabel)
+                            .font(.system(size: Metric.groupExpandedRefFontSize))
+                            .foregroundStyle(.secondary)
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }

--- a/approver/Sources/AgentSecretApprover/ApprovalPanelSecretListRow.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelSecretListRow.swift
@@ -15,12 +15,20 @@ import Foundation
                     .font(.system(size: Metric.secretListAliasFontSize, weight: .semibold, design: .monospaced))
                     .lineLimit(Metric.singleLineLimit)
                     .frame(width: Metric.secretListAliasWidth, alignment: .leading)
-                Text(secret.ref)
-                    .font(.system(size: Metric.secretListRefFontSize, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(Metric.singleLineLimit)
-                    .truncationMode(.middle)
-                    .layoutPriority(Metric.refLayoutPriority)
+                VStack(alignment: .leading, spacing: Metric.rowTextSpacing) {
+                    Text(secret.ref)
+                        .font(.system(size: Metric.secretListRefFontSize, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(Metric.singleLineLimit)
+                        .truncationMode(.middle)
+                    if let accountLabel: String = secret.accountLabel {
+                        Text(accountLabel)
+                            .font(.system(size: Metric.secretListRefFontSize))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(Metric.singleLineLimit)
+                    }
+                }
+                .layoutPriority(Metric.refLayoutPriority)
             }
         }
 

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
@@ -129,10 +129,10 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
 
     private static func secretPresentation(for secrets: [RequestedSecret]) -> SecretPresentation {
         let rows: [RequestedSecretRowViewModel] = secrets.map { secret -> RequestedSecretRowViewModel in
-            RequestedSecretRowViewModel(alias: secret.alias, ref: secret.ref)
+            RequestedSecretRowViewModel(alias: secret.alias, ref: secret.ref, account: secret.account)
         }
         let rowText: [String] = rows.map { secret -> String in
-            "\(secret.alias) -> \(secret.ref)"
+            Self.secretRowText(secret)
         }
         let vaultGroups: [SecretVaultGroupViewModel] = Self.vaultGroups(for: rows)
         return SecretPresentation(
@@ -146,18 +146,25 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
 
     private static func vaultGroups(for rows: [RequestedSecretRowViewModel]) -> [SecretVaultGroupViewModel] {
         var groups: [SecretVaultGroupViewModel] = []
-        var groupIndexesByVault: [String: Int] = [:]
+        var groupIndexesByScope: [String: Int] = [:]
         for row in rows {
-            if let index: Int = groupIndexesByVault[row.vaultName] {
+            if let index: Int = groupIndexesByScope[row.vaultScopeName] {
                 var group: SecretVaultGroupViewModel = groups[index]
                 group = SecretVaultGroupViewModel(vaultName: group.vaultName, secrets: group.secrets + [row])
                 groups[index] = group
             } else {
-                groupIndexesByVault[row.vaultName] = groups.count
-                groups.append(SecretVaultGroupViewModel(vaultName: row.vaultName, secrets: [row]))
+                groupIndexesByScope[row.vaultScopeName] = groups.count
+                groups.append(SecretVaultGroupViewModel(vaultName: row.vaultScopeName, secrets: [row]))
             }
         }
         return groups
+    }
+
+    private static func secretRowText(_ secret: RequestedSecretRowViewModel) -> String {
+        if let accountLabel: String = secret.accountLabel {
+            return "\(secret.alias) [\(accountLabel)] -> \(secret.ref)"
+        }
+        return "\(secret.alias) -> \(secret.ref)"
     }
 
     private static func promptQuestion(secretCount: Int) -> String {

--- a/approver/Sources/AgentSecretApprover/RequestedSecret.swift
+++ b/approver/Sources/AgentSecretApprover/RequestedSecret.swift
@@ -6,10 +6,13 @@ public struct RequestedSecret: Codable, Equatable, Sendable {
     public var alias: String
     /// 1Password reference approved by the operator.
     public var ref: String
+    /// 1Password account scope for this reference, when the daemon can resolve it.
+    public var account: String?
 
     /// Creates a requested secret row for the approval prompt.
-    public init(alias: String, ref: String) {
+    public init(alias: String, ref: String, account: String? = nil) {
         self.alias = alias
         self.ref = ref
+        self.account = account
     }
 }

--- a/approver/Sources/AgentSecretApprover/RequestedSecretRowViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/RequestedSecretRowViewModel.swift
@@ -8,8 +8,14 @@ public struct RequestedSecretRowViewModel: Equatable, Sendable {
     public let alias: String
     /// Backing 1Password reference.
     public let ref: String
+    /// 1Password account scope for this reference, when available.
+    public let account: String?
+    /// Visible account scope label.
+    public let accountLabel: String?
     /// Vault name parsed from an op reference when available.
     public let vaultName: String
+    /// Account-qualified vault scope used for grouping.
+    public let vaultScopeName: String
     /// Item name parsed from an op reference when available.
     public let itemName: String?
     /// Field name parsed from an op reference when available.
@@ -18,11 +24,25 @@ public struct RequestedSecretRowViewModel: Equatable, Sendable {
     public let symbolName: String
 
     /// Creates a display-only secret row.
-    public init(alias: String, ref: String) {
+    public init(alias: String, ref: String, account: String? = nil) {
         let parts: [String] = Self.referenceParts(ref)
+        let normalizedAccount: String?
+        if let account {
+            let trimmedAccount = account.trimmingCharacters(in: .whitespacesAndNewlines)
+            normalizedAccount = trimmedAccount.isEmpty ? nil : trimmedAccount
+        } else {
+            normalizedAccount = nil
+        }
         self.alias = alias
         self.ref = ref
+        self.account = normalizedAccount
+        accountLabel = normalizedAccount.map { account in "Account: \(account)" }
         vaultName = parts.first ?? "Unknown vault"
+        if let normalizedAccount {
+            vaultScopeName = "\(normalizedAccount) / \(vaultName)"
+        } else {
+            vaultScopeName = vaultName
+        }
         itemName = parts.dropFirst().first
         fieldName = parts.dropFirst().dropFirst().first
         symbolName = Self.symbolName(alias: alias, ref: ref)

--- a/approver/Sources/AgentSecretApprover/SecretVaultGroupViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/SecretVaultGroupViewModel.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Requested secrets grouped by their backing vault.
+/// Requested secrets grouped by their backing vault or account-qualified vault.
 public struct SecretVaultGroupViewModel: Equatable, Sendable {
-    /// Vault name shown in the grouped secret summary.
+    /// Vault or account-qualified vault name shown in the grouped secret summary.
     public let vaultName: String
     /// Secrets requested from this vault.
     public let secrets: [RequestedSecretRowViewModel]

--- a/approver/Sources/AgentSecretApproverApp/main.swift
+++ b/approver/Sources/AgentSecretApproverApp/main.swift
@@ -103,7 +103,8 @@ private func requestFromArguments(_ arguments: [String]) throws -> ApprovalReque
         secrets: [
             RequestedSecret(
                 alias: "EXAMPLE_TOKEN",
-                ref: "op://Example Vault/Example Item/token"
+                ref: "op://Example Vault/Example Item/token",
+                account: "Work"
             )
         ]
     )

--- a/approver/Sources/AgentSecretApproverSmoke/main.swift
+++ b/approver/Sources/AgentSecretApproverSmoke/main.swift
@@ -14,7 +14,8 @@ private let kRequest: ApprovalRequest = .init(
     secrets: [
         RequestedSecret(
             alias: "EXAMPLE_TOKEN",
-            ref: "op://Example Vault/Example Item/token"
+            ref: "op://Example Vault/Example Item/token",
+            account: "Work"
         )
     ]
 )

--- a/approver/Tests/AgentSecretApproverTests/ApprovalAccountScopeTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalAccountScopeTests.swift
@@ -1,0 +1,42 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class ApprovalAccountScopeTests: XCTestCase {
+    private static let sampleExpiration: TimeInterval = 1_800_000_000
+    private static let viewModelNow: TimeInterval = 1_799_999_880
+
+    func testViewModelDistinguishesSameReferenceAcrossAccounts() {
+        let request = ApprovalRequest(
+            requestID: "req_accounts",
+            nonce: "nonce_accounts",
+            reason: "Run deploy",
+            command: ["/usr/bin/env", "deploy"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: Self.sampleExpiration),
+            secrets: [
+                RequestedSecret(alias: "PERSONAL_TOKEN", ref: "op://Shared/Deploy/token", account: "Personal"),
+                RequestedSecret(alias: "WORK_TOKEN", ref: "op://Shared/Deploy/token", account: "Work")
+            ],
+            resolvedExecutable: "/usr/bin/env"
+        )
+        let viewModel = ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: Self.viewModelNow)
+        )
+
+        XCTAssertEqual(viewModel.requestedSecrets.map(\.account), ["Personal", "Work"])
+        XCTAssertEqual(viewModel.requestedSecrets.map(\.accountLabel), ["Account: Personal", "Account: Work"])
+        XCTAssertEqual(viewModel.vaultGroups.map(\.vaultName), ["Personal / Shared", "Work / Shared"])
+        XCTAssertTrue(
+            viewModel.renderedText.contains(
+                "PERSONAL_TOKEN [Account: Personal] -> op://Shared/Deploy/token"
+            )
+        )
+        XCTAssertTrue(viewModel.renderedText.contains("WORK_TOKEN [Account: Work] -> op://Shared/Deploy/token"))
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
@@ -55,7 +55,8 @@ final class ApprovalControllerTests: XCTestCase {
             secrets: [
                 RequestedSecret(
                     alias: "EXAMPLE_TOKEN",
-                    ref: "op://Example Vault/Example Item/token"
+                    ref: "op://Example Vault/Example Item/token",
+                    account: "Work"
                 )
             ],
             resolvedExecutable: "/opt/homebrew/bin/terraform"
@@ -141,6 +142,7 @@ final class ApprovalControllerTests: XCTestCase {
         XCTAssertEqual(request.overriddenAliases, ["EXAMPLE_TOKEN"])
         XCTAssertEqual(request.reusableUses, Self.expectedReusableUses)
         XCTAssertEqual(request.secrets.first?.ref, "op://Example Vault/Example Item/token")
+        XCTAssertEqual(request.secrets.first?.account, "Work")
 
         let decision: ApprovalDecision = try decoder.decode(
             ApprovalDecision.self,
@@ -238,7 +240,11 @@ final class ApprovalControllerTests: XCTestCase {
 
         XCTAssertTrue(viewModel.renderedText.contains("Run Terraform plan"))
         XCTAssertTrue(viewModel.renderedText.contains("/tmp/project"))
-        XCTAssertTrue(viewModel.renderedText.contains("EXAMPLE_TOKEN -> op://Example Vault/Example Item/token"))
+        XCTAssertTrue(
+            viewModel.renderedText.contains(
+                "EXAMPLE_TOKEN [Account: Work] -> op://Example Vault/Example Item/token"
+            )
+        )
         XCTAssertTrue(viewModel.renderedText.contains("Resolved binary: /opt/homebrew/bin/terraform"))
         XCTAssertTrue(viewModel.renderedText.contains("Time remaining: 2 minutes"))
         XCTAssertTrue(viewModel.renderedText.contains("Will replace existing variables: EXAMPLE_TOKEN"))

--- a/approver/Tests/AgentSecretApproverTests/Fixtures/approval_request.json
+++ b/approver/Tests/AgentSecretApproverTests/Fixtures/approval_request.json
@@ -17,6 +17,7 @@
   "secrets": [
     {
       "alias": "EXAMPLE_TOKEN",
+      "account": "Work",
       "ref": "op://Example Vault/Example Item/token"
     }
   ]

--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -38,8 +38,9 @@ type ApprovalRequestPayload struct {
 }
 
 type ApprovalRequestedSecret struct {
-	Alias string `json:"alias"`
-	Ref   string `json:"ref"`
+	Alias   string `json:"alias"`
+	Ref     string `json:"ref"`
+	Account string `json:"account,omitempty"`
 }
 
 type ApprovalDecisionPayload struct {
@@ -270,7 +271,11 @@ func (l ProcessApproverLauncher) identityPolicy() ApproverIdentityPolicy {
 func approvalPayload(requestID string, nonce string, req request.ExecRequest) ApprovalRequestPayload {
 	secrets := make([]ApprovalRequestedSecret, 0, len(req.Secrets))
 	for _, secret := range req.Secrets {
-		secrets = append(secrets, ApprovalRequestedSecret{Alias: secret.Alias, Ref: secret.Ref.Raw})
+		secrets = append(secrets, ApprovalRequestedSecret{
+			Alias:   secret.Alias,
+			Ref:     secret.Ref.Raw,
+			Account: secret.Account,
+		})
 	}
 	return ApprovalRequestPayload{
 		RequestID:          requestID,

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -58,6 +58,9 @@ func TestApprovalFixturesDecodeInGo(t *testing.T) {
 	if approvalRequest.Secrets[0].Ref != "op://Example Vault/Example Item/token" {
 		t.Fatalf("unexpected secret ref: %+v", approvalRequest.Secrets)
 	}
+	if approvalRequest.Secrets[0].Account != "Work" {
+		t.Fatalf("unexpected secret account: %+v", approvalRequest.Secrets)
+	}
 
 	decisionData := readFixture(t, "approval_decision.json")
 	var decision ApprovalDecisionPayload
@@ -95,6 +98,9 @@ func TestSocketApproverLaunchesAndAcceptsExpectedPeerDecision(t *testing.T) {
 	}
 	if payload.RequestID != "req_1" || payload.Nonce != "nonce_1" {
 		t.Fatalf("unexpected payload identifiers: %+v", payload)
+	}
+	if payload.Secrets[0].Account != "Work" {
+		t.Fatalf("payload secret account = %q, want Work", payload.Secrets[0].Account)
 	}
 	uses := 3
 	err = approver.SubmitDecision(context.Background(), peerInfoForTest(t, os.Getpid(), exe), ApprovalDecisionPayload{
@@ -429,7 +435,7 @@ func approvalTestRequest(t *testing.T, expiresAt time.Time) request.ExecRequest 
 		Command:            []string{"terraform", "plan"},
 		ResolvedExecutable: "/opt/homebrew/bin/terraform",
 		CWD:                "/tmp/project",
-		Secrets:            []request.Secret{{Alias: "TOKEN", Ref: ref}},
+		Secrets:            []request.Secret{{Alias: "TOKEN", Ref: ref, Account: "Work"}},
 		ReceivedAt:         expiresAt.Add(-request.DefaultExecTTL),
 		ExpiresAt:          expiresAt,
 		TTL:                request.DefaultExecTTL,

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -233,7 +233,7 @@ func TestServerApprovalProtocolOverSingleSocket(t *testing.T) {
 	approver := newSocketApproverForTest(t, launcher, time.Now)
 	broker := newTestBroker(t, BrokerOptions{
 		Approver: approver,
-		Resolver: &mockResolver{values: map[string]string{ref: "value"}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
 		Audit:    &memoryAudit{},
 	})
 	client, cleanup := startTestServerWithBroker(t, broker, approver, staticPeerValidator{info: peer})


### PR DESCRIPTION
## Summary
- add per-secret account scope to approval request payloads and shared protocol fixture
- decode and preserve account scope in the Swift approver model
- display account labels in compact, grouped, and single-secret approval UI paths, with account-qualified grouping for same-ref/different-account requests

## Verification
- mise format
- mise exec -- go test ./internal/daemon
- mise exec -- bash -lc 'cd approver && swift test'\n- mise run test\n- mise run lint\n- mise run build\n- mise run test:race\n\nCloses #5