### PR TITLE
Audit approval denials and secret fetch failures

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1173,8 +1173,12 @@ Exit criteria:
 
 ### Audit Criteria
 
-- Approval, denial, fetch, resolve, expiry, destroy, and command completion
-  events are logged.
+- V1 `exec` logs approval request, approval grant, approval denial, approval
+  timeout, reusable approval reuse/refresh, secret fetch attempt, secret fetch
+  failure, command start/start-complete/completion, post-payload disconnect, and
+  daemon stop events.
+- Future handle/session delivery APIs must add expiry and destroy audit events
+  before those APIs are considered complete.
 - Logs contain refs and aliases but no values.
 - Logs are readable only by the current user by default.
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -24,8 +24,14 @@ var (
 type EventType string
 
 const (
+	EventApprovalRequested                  EventType = "approval_requested"
+	EventApprovalGranted                    EventType = "approval_granted"
+	EventApprovalDenied                     EventType = "approval_denied"
+	EventApprovalTimedOut                   EventType = "approval_timed_out"
 	EventApprovalReused                     EventType = "approval_reused"
 	EventApprovalRefreshed                  EventType = "approval_refreshed"
+	EventSecretFetchStarted                 EventType = "secret_fetch_started"
+	EventSecretFetchFailed                  EventType = "secret_fetch_failed"
 	EventCommandStarting                    EventType = "command_starting"
 	EventCommandStarted                     EventType = "command_started"
 	EventCommandCompleted                   EventType = "command_completed"

--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -147,8 +147,8 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 	}
 
 	event := audit.FromExecRequest(audit.EventCommandStarting, requestID, req)
-	if err := b.audit.Record(ctx, event); err != nil {
-		return ExecGrant{}, fmt.Errorf("%w: %w", ErrAuditRequired, err)
+	if err := b.recordRequiredAudit(ctx, event); err != nil {
+		return ExecGrant{}, err
 	}
 
 	b.mu.Lock()
@@ -190,8 +190,8 @@ func (b *Broker) ReportStarted(ctx context.Context, requestID string, nonce stri
 
 	event := audit.FromExecRequest(audit.EventCommandStarted, requestID, active.req)
 	event.ChildPID = new(childPID)
-	if err := b.audit.Record(ctx, event); err != nil {
-		return fmt.Errorf("%w: %w", ErrAuditRequired, err)
+	if err := b.recordRequiredAudit(ctx, event); err != nil {
+		return err
 	}
 
 	b.mu.Lock()
@@ -211,8 +211,8 @@ func (b *Broker) ReportCompleted(ctx context.Context, requestID string, nonce st
 	event := audit.FromExecRequest(audit.EventCommandCompleted, requestID, active.req)
 	event.ExitCode = new(exitCode)
 	event.Signal = signal
-	if err := b.audit.Record(ctx, event); err != nil {
-		return fmt.Errorf("%w: %w", ErrAuditRequired, err)
+	if err := b.recordRequiredAudit(ctx, event); err != nil {
+		return err
 	}
 
 	b.mu.Lock()
@@ -294,15 +294,27 @@ func (b *Broker) freshGrant(
 	nonce string,
 	req request.ExecRequest,
 ) (ExecGrant, error) {
+	if err := b.recordRequiredAudit(ctx, audit.FromExecRequest(audit.EventApprovalRequested, requestID, req)); err != nil {
+		return ExecGrant{}, err
+	}
 	decision, err := b.approver.ApproveExec(ctx, requestID, nonce, req)
 	if err != nil {
+		if auditErr := b.recordApprovalError(ctx, requestID, req, err); auditErr != nil {
+			return ExecGrant{}, auditErr
+		}
 		return ExecGrant{}, err
 	}
 	if !decision.Approved {
+		if err := b.recordApprovalDenied(ctx, requestID, req); err != nil {
+			return ExecGrant{}, err
+		}
 		return ExecGrant{}, ErrApprovalDenied
 	}
+	if err := b.recordRequiredAudit(ctx, audit.FromExecRequest(audit.EventApprovalGranted, requestID, req)); err != nil {
+		return ExecGrant{}, err
+	}
 
-	refValues, err := b.resolveUniqueRefs(ctx, req.Secrets)
+	refValues, err := b.resolveUniqueRefs(ctx, requestID, req)
 	if err != nil {
 		return ExecGrant{}, err
 	}
@@ -329,12 +341,17 @@ func (b *Broker) freshGrant(
 	}, nil
 }
 
-func (b *Broker) resolveUniqueRefs(ctx context.Context, secrets []request.Secret) (map[secretIdentity]string, error) {
+func (b *Broker) resolveUniqueRefs(ctx context.Context, requestID string, req request.ExecRequest) (map[secretIdentity]string, error) {
+	secrets := req.Secrets
 	identities := uniqueSecretIdentities(secrets)
 	type result struct {
 		identity secretIdentity
 		value    string
 		err      error
+	}
+
+	if err := b.recordRequiredAudit(ctx, audit.FromExecRequest(audit.EventSecretFetchStarted, requestID, req)); err != nil {
+		return nil, err
 	}
 
 	sem := make(chan struct{}, b.fetchLimit)
@@ -352,6 +369,9 @@ func (b *Broker) resolveUniqueRefs(ctx context.Context, secrets []request.Secret
 	for range identities {
 		got := <-results
 		if got.err != nil {
+			if err := b.recordSecretFetchFailed(ctx, requestID, secrets, got.identity, got.err); err != nil {
+				return nil, err
+			}
 			return nil, fmt.Errorf("resolve approved ref: %w", got.err)
 		}
 		resolved[got.identity] = got.value
@@ -365,7 +385,7 @@ func (b *Broker) refreshedReusableValues(
 	approvalID string,
 	req request.ExecRequest,
 ) (map[string]string, error) {
-	refValues, err := b.resolveUniqueRefs(ctx, req.Secrets)
+	refValues, err := b.resolveUniqueRefs(ctx, "", req)
 	if err != nil {
 		return nil, err
 	}
@@ -377,10 +397,85 @@ func (b *Broker) refreshedReusableValues(
 	}
 	event := audit.FromExecRequest(audit.EventApprovalRefreshed, "", req)
 	event.ApprovalID = approvalID
-	if err := b.audit.Record(ctx, event); err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrAuditRequired, err)
+	if err := b.recordRequiredAudit(ctx, event); err != nil {
+		return nil, err
 	}
 	return values, nil
+}
+
+func (b *Broker) recordRequiredAudit(ctx context.Context, event audit.Event) error {
+	if err := b.audit.Record(ctx, event); err != nil {
+		return fmt.Errorf("%w: %w", ErrAuditRequired, err)
+	}
+	return nil
+}
+
+func (b *Broker) recordApprovalError(
+	ctx context.Context,
+	requestID string,
+	req request.ExecRequest,
+	err error,
+) error {
+	switch {
+	case errors.Is(err, ErrApprovalDenied):
+		return b.recordApprovalDenied(ctx, requestID, req)
+	case errors.Is(err, ErrRequestExpired):
+		event := audit.FromExecRequest(audit.EventApprovalTimedOut, requestID, req)
+		event.ErrorCode = "request_expired"
+		return b.recordRequiredAudit(ctx, event)
+	default:
+		return nil
+	}
+}
+
+func (b *Broker) recordApprovalDenied(ctx context.Context, requestID string, req request.ExecRequest) error {
+	event := audit.FromExecRequest(audit.EventApprovalDenied, requestID, req)
+	event.ErrorCode = "approval_denied"
+	return b.recordRequiredAudit(ctx, event)
+}
+
+func (b *Broker) recordSecretFetchFailed(
+	ctx context.Context,
+	requestID string,
+	secrets []request.Secret,
+	identity secretIdentity,
+	err error,
+) error {
+	event := audit.Event{
+		Type:       audit.EventSecretFetchFailed,
+		RequestID:  requestID,
+		SecretRefs: auditRefsForIdentity(secrets, identity),
+		ErrorCode:  secretFetchErrorCode(err),
+	}
+	return b.recordRequiredAudit(ctx, event)
+}
+
+func secretFetchErrorCode(err error) string {
+	if errors.Is(err, context.Canceled) {
+		return "context_canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "context_deadline_exceeded"
+	}
+	return "resolve_failed"
+}
+
+func auditRefsForIdentity(secrets []request.Secret, identity secretIdentity) []audit.SecretRef {
+	refs := []audit.SecretRef{}
+	for _, secret := range secrets {
+		if secret.Ref.Raw != identity.ref || secret.Account != identity.account {
+			continue
+		}
+		refs = append(refs, audit.SecretRef{
+			Alias:   secret.Alias,
+			Ref:     secret.Ref.Raw,
+			Account: secret.Account,
+		})
+	}
+	if len(refs) == 0 {
+		return []audit.SecretRef{{Ref: identity.ref, Account: identity.account}}
+	}
+	return refs
 }
 
 func (b *Broker) cacheResolvedValues(approvalID string, refValues map[secretIdentity]string) error {

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -1,7 +1,9 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -14,6 +16,8 @@ import (
 	"github.com/kovyrin/agent-secret/internal/policy"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
+
+const canarySecretValue = "synthetic-secret-value"
 
 type mockApprover struct {
 	decision ApprovalDecision
@@ -144,7 +148,7 @@ func TestBrokerApprovesBeforeResolvingAndAuditsBeforePayload(t *testing.T) {
 	broker := newTestBroker(t, BrokerOptions{
 		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}, order: &order},
 		Resolver: &mockResolver{values: map[string]string{
-			"op://Example/Item/token": "synthetic-secret-value",
+			"op://Example/Item/token": canarySecretValue,
 		}, order: &order},
 		Audit: aud,
 	})
@@ -153,25 +157,61 @@ func TestBrokerApprovesBeforeResolvingAndAuditsBeforePayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HandleExec returned error: %v", err)
 	}
-	if got := grant.Env["TOKEN"]; got != "synthetic-secret-value" {
+	if got := grant.Env["TOKEN"]; got != canarySecretValue {
 		t.Fatalf("env TOKEN = %q", got)
 	}
 	if !reflect.DeepEqual(order, []string{"approve", "resolve:op://Example/Item/token"}) {
 		t.Fatalf("unexpected operation order: %v", order)
 	}
 	events := aud.Events()
-	if len(events) != 1 || events[0].Type != audit.EventCommandStarting {
-		t.Fatalf("expected command_starting audit before payload, got %+v", events)
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventCommandStarting,
 	}
+	if got := auditEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+	assertAuditEventsValueFree(t, events)
 }
 
-func TestBrokerDenialDoesNotResolveOrAuditCommandStarting(t *testing.T) {
+func TestBrokerDenialAuditsOutcomeWithoutResolveOrCommandStart(t *testing.T) {
 	t.Parallel()
 
-	resolver := &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}}
+	assertApprovalFailureAudited(t, approvalFailureAuditCase{
+		name:      "denial",
+		err:       ErrApprovalDenied,
+		eventType: audit.EventApprovalDenied,
+		errorCode: "approval_denied",
+	})
+}
+
+func TestBrokerApprovalTimeoutAuditsOutcomeWithoutResolveOrCommandStart(t *testing.T) {
+	t.Parallel()
+
+	assertApprovalFailureAudited(t, approvalFailureAuditCase{
+		name:      "timeout",
+		err:       ErrRequestExpired,
+		eventType: audit.EventApprovalTimedOut,
+		errorCode: "request_expired",
+	})
+}
+
+type approvalFailureAuditCase struct {
+	name      string
+	err       error
+	eventType audit.EventType
+	errorCode string
+}
+
+func assertApprovalFailureAudited(t *testing.T, tc approvalFailureAuditCase) {
+	t.Helper()
+
+	resolver := &mockResolver{values: map[string]string{"op://Example/Item/token": canarySecretValue}}
 	aud := &memoryAudit{}
 	broker := newTestBroker(t, BrokerOptions{
-		Approver: &mockApprover{decision: ApprovalDecision{Approved: false}},
+		Approver: &mockApprover{err: tc.err},
 		Resolver: resolver,
 		Audit:    aud,
 	})
@@ -179,15 +219,21 @@ func TestBrokerDenialDoesNotResolveOrAuditCommandStarting(t *testing.T) {
 	_, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", testExecRequest(t, []request.SecretSpec{
 		{Alias: "TOKEN", Ref: "op://Example/Item/token"},
 	}))
-	if !errors.Is(err, ErrApprovalDenied) {
-		t.Fatalf("expected denial, got %v", err)
+	if !errors.Is(err, tc.err) {
+		t.Fatalf("expected approval %s, got %v", tc.name, err)
 	}
 	if len(resolver.Calls()) != 0 {
-		t.Fatalf("resolver was called after denial: %v", resolver.Calls())
+		t.Fatalf("resolver was called after approval %s: %v", tc.name, resolver.Calls())
 	}
-	if events := aud.Events(); len(events) != 0 {
-		t.Fatalf("audit wrote command events after denial: %+v", events)
+	events := aud.Events()
+	want := []audit.EventType{audit.EventApprovalRequested, tc.eventType}
+	if got := auditEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
 	}
+	if events[1].ErrorCode != tc.errorCode {
+		t.Fatalf("approval %s error code = %q", tc.name, events[1].ErrorCode)
+	}
+	assertAuditEventsValueFree(t, events)
 }
 
 func TestBrokerDeduplicatesRefsAndPreservesEmptyValues(t *testing.T) {
@@ -256,8 +302,8 @@ func TestBrokerPartialFetchFailureReturnsNoPayload(t *testing.T) {
 	broker := newTestBroker(t, BrokerOptions{
 		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
 		Resolver: &mockResolver{
-			values: map[string]string{"op://Example/Item/token": "value"},
-			errs:   map[string]error{failingRef: errors.New("unreadable")},
+			values: map[string]string{"op://Example/Item/token": canarySecretValue},
+			errs:   map[string]error{failingRef: fmt.Errorf("unreadable %s", canarySecretValue)},
 		},
 		Audit: aud,
 	})
@@ -269,9 +315,24 @@ func TestBrokerPartialFetchFailureReturnsNoPayload(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected partial fetch failure")
 	}
-	if events := aud.Events(); len(events) != 0 {
-		t.Fatalf("command_starting audit should not be written after fetch failure: %+v", events)
+	events := aud.Events()
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventSecretFetchFailed,
 	}
+	if got := auditEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+	failure := events[len(events)-1]
+	if failure.ErrorCode != "resolve_failed" {
+		t.Fatalf("fetch failure error code = %q", failure.ErrorCode)
+	}
+	if len(failure.SecretRefs) != 1 || failure.SecretRefs[0].Alias != "FAIL" || failure.SecretRefs[0].Ref != failingRef {
+		t.Fatalf("fetch failure refs = %+v", failure.SecretRefs)
+	}
+	assertAuditEventsValueFree(t, events)
 	if err := broker.MarkPayloadDelivered("req_1"); !errors.Is(err, ErrUnknownRequest) {
 		t.Fatalf("request should not become active after failed fetch, got %v", err)
 	}
@@ -513,7 +574,14 @@ func TestBrokerReportLifecycleValidatesNonceAndAudits(t *testing.T) {
 	for _, event := range aud.Events() {
 		got = append(got, event.Type)
 	}
-	want := []audit.EventType{audit.EventCommandStarting, audit.EventCommandStarted, audit.EventCommandCompleted}
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventCommandStarting,
+		audit.EventCommandStarted,
+		audit.EventCommandCompleted,
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("audit events = %v, want %v", got, want)
 	}
@@ -539,7 +607,7 @@ func TestBrokerClientDisconnectAfterPayloadAuditsWithoutKillingProcess(t *testin
 	broker.ClientDisconnected(context.Background(), "req_1")
 
 	events := aud.Events()
-	if len(events) != 2 || events[1].Type != audit.EventExecClientDisconnectedAfterPayload {
+	if len(events) != 5 || events[4].Type != audit.EventExecClientDisconnectedAfterPayload {
 		t.Fatalf("expected disconnect audit, got %+v", events)
 	}
 }
@@ -617,4 +685,23 @@ func containsAuditEvent(events []audit.Event, eventType audit.EventType) bool {
 		}
 	}
 	return false
+}
+
+func auditEventTypes(events []audit.Event) []audit.EventType {
+	types := make([]audit.EventType, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.Type)
+	}
+	return types
+}
+
+func assertAuditEventsValueFree(t *testing.T, events []audit.Event) {
+	t.Helper()
+	encoded, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal audit events: %v", err)
+	}
+	if bytes.Contains(encoded, []byte(canarySecretValue)) {
+		t.Fatalf("audit events contain secret value %q: %s", canarySecretValue, encoded)
+	}
 }

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -61,18 +62,17 @@ func TestServerExecProtocolLifecycle(t *testing.T) {
 		t.Fatalf("ReportCompleted returned error: %v", err)
 	}
 
-	got := []audit.EventType{}
-	for _, event := range aud.Events() {
-		got = append(got, event.Type)
+	got := auditEventTypes(aud.Events())
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventCommandStarting,
+		audit.EventCommandStarted,
+		audit.EventCommandCompleted,
 	}
-	want := []audit.EventType{audit.EventCommandStarting, audit.EventCommandStarted, audit.EventCommandCompleted}
-	if len(got) != len(want) {
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("audit events = %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("audit events = %v, want %v", got, want)
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add approval request/grant/denial/timeout audit events
- add secret fetch attempt/failure audit events with ref/account metadata and sanitized error codes
- update broker/server audit tests to prove denial, timeout, and fetch failure events are emitted without canary secret values
- reconcile the PRD audit criteria with the implemented v1 exec event set

## Verification
- npx --yes markdownlint-cli docs/prd.md
- mise exec -- go test ./internal/daemon ./internal/audit
- mise run test
- mise run build
- mise run lint
- mise run test:race

Closes #6