### PR TITLE
Audit post-start CLI disconnects

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1175,8 +1175,8 @@ Exit criteria:
 
 - V1 `exec` logs approval request, approval grant, approval denial, approval
   timeout, reusable approval reuse/refresh, secret fetch attempt, secret fetch
-  failure, command start/start-complete/completion, post-payload disconnect, and
-  daemon stop events.
+  failure, command start/start-complete/completion, post-payload disconnect,
+  post-start lifecycle disconnect, and daemon stop events.
 - Future handle/session delivery APIs must add expiry and destroy audit events
   before those APIs are considered complete.
 - Logs contain refs and aliases but no values.
@@ -1200,6 +1200,9 @@ Exit criteria:
   `command_started`, the daemon records `exec_client_disconnected_after_payload`,
   clears one-shot daemon-held values, and does not try to kill or infer a child
   process. Reusable cached values are not cleared by this event alone.
+- If `agent-secret exec` disconnects after `command_started` but before
+  `command_completed`, the daemon records
+  `exec_client_disconnected_after_start` with request metadata and child PID.
 - If a child process exits, cleanup runs.
 - If a reusable approval expires while a child is still running, the command is
   allowed to finish and broker-held cached values are cleared.

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -36,6 +36,7 @@ const (
 	EventCommandStarted                     EventType = "command_started"
 	EventCommandCompleted                   EventType = "command_completed"
 	EventExecClientDisconnectedAfterPayload EventType = "exec_client_disconnected_after_payload"
+	EventExecClientDisconnectedAfterStart   EventType = "exec_client_disconnected_after_start"
 	EventDaemonStop                         EventType = "daemon_stop"
 )
 

--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -73,6 +73,7 @@ type activeExec struct {
 	approvalID       string
 	payloadDelivered bool
 	started          bool
+	childPID         *int
 }
 
 type BrokerOptions struct {
@@ -189,7 +190,8 @@ func (b *Broker) ReportStarted(ctx context.Context, requestID string, nonce stri
 	}
 
 	event := audit.FromExecRequest(audit.EventCommandStarted, requestID, active.req)
-	event.ChildPID = new(childPID)
+	pid := childPID
+	event.ChildPID = &pid
 	if err := b.recordRequiredAudit(ctx, event); err != nil {
 		return err
 	}
@@ -197,6 +199,7 @@ func (b *Broker) ReportStarted(ctx context.Context, requestID string, nonce stri
 	b.mu.Lock()
 	if current := b.active[requestID]; current != nil {
 		current.started = true
+		current.childPID = &pid
 	}
 	b.mu.Unlock()
 	return nil
@@ -228,11 +231,16 @@ func (b *Broker) ClientDisconnected(ctx context.Context, requestID string) {
 		delete(b.active, requestID)
 	}
 	b.mu.Unlock()
-	if !ok || !active.payloadDelivered || active.started {
+	if !ok || !active.payloadDelivered {
 		return
 	}
 
-	event := audit.FromExecRequest(audit.EventExecClientDisconnectedAfterPayload, requestID, active.req)
+	eventType := audit.EventExecClientDisconnectedAfterPayload
+	if active.started {
+		eventType = audit.EventExecClientDisconnectedAfterStart
+	}
+	event := audit.FromExecRequest(eventType, requestID, active.req)
+	event.ChildPID = active.childPID
 	_ = b.audit.Record(ctx, event)
 }
 

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -612,6 +612,47 @@ func TestBrokerClientDisconnectAfterPayloadAuditsWithoutKillingProcess(t *testin
 	}
 }
 
+func TestBrokerClientDisconnectAfterStartAuditsIncompleteLifecycle(t *testing.T) {
+	t.Parallel()
+
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": canarySecretValue}},
+		Audit:    aud,
+	})
+	if _, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", testExecRequest(t, []request.SecretSpec{
+		{Alias: "TOKEN", Ref: "op://Example/Item/token"},
+	})); err != nil {
+		t.Fatalf("HandleExec returned error: %v", err)
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); err != nil {
+		t.Fatalf("MarkPayloadDelivered returned error: %v", err)
+	}
+	if err := broker.ReportStarted(context.Background(), "req_1", "nonce_1", 1234); err != nil {
+		t.Fatalf("ReportStarted returned error: %v", err)
+	}
+	broker.ClientDisconnected(context.Background(), "req_1")
+
+	events := aud.Events()
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventCommandStarting,
+		audit.EventCommandStarted,
+		audit.EventExecClientDisconnectedAfterStart,
+	}
+	if got := auditEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+	disconnect := events[len(events)-1]
+	if disconnect.ChildPID == nil || *disconnect.ChildPID != 1234 {
+		t.Fatalf("disconnect child pid = %v, want 1234", disconnect.ChildPID)
+	}
+	assertAuditEventsValueFree(t, events)
+}
+
 func TestBrokerAuditFailureStopsBeforePayload(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -169,6 +169,44 @@ func TestServerClientDisconnectAfterPayloadAudits(t *testing.T) {
 	t.Fatalf("disconnect audit was not recorded: %+v", aud.Events())
 }
 
+func TestServerClientDisconnectAfterStartAuditsIncompleteLifecycle(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	aud := &memoryAudit{}
+	client, cleanup := startTestServer(t, BrokerOptions{
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{ref: canarySecretValue}},
+		Audit:    aud,
+	})
+	defer cleanup()
+
+	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", testExecRequest(t, []request.SecretSpec{
+		{Alias: "TOKEN", Ref: ref},
+	})); err != nil {
+		t.Fatalf("RequestExec returned error: %v", err)
+	}
+	if err := client.ReportStarted(context.Background(), "req_1", "nonce_1", 4321); err != nil {
+		t.Fatalf("ReportStarted returned error: %v", err)
+	}
+	_ = client.Close()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		for _, event := range aud.Events() {
+			if event.Type == audit.EventExecClientDisconnectedAfterStart {
+				if event.ChildPID == nil || *event.ChildPID != 4321 {
+					t.Fatalf("disconnect child pid = %v, want 4321", event.ChildPID)
+				}
+				assertAuditEventsValueFree(t, aud.Events())
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("post-start disconnect audit was not recorded: %+v", aud.Events())
+}
+
 func TestServerDaemonStopTerminatesListener(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a metadata-only `exec_client_disconnected_after_start` audit event
- preserve started child PID in daemon active request state for incomplete lifecycle audits
- cover broker and server disconnect-after-start paths, while keeping the existing after-payload-before-start coverage
- update PRD failure/audit criteria for the new event

## Verification
- npx --yes markdownlint-cli docs/prd.md
- mise exec -- go test ./internal/daemon ./internal/audit
- mise run test
- mise run build
- mise run lint
- mise run test:race

Closes #7