### PR TITLE
Validate custom socket parent directories

### DIFF
--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -55,11 +55,8 @@ func (m Manager) Start(ctx context.Context) error {
 	if m.DaemonPath == "" {
 		return errors.New("daemon path is required")
 	}
-	if err := os.MkdirAll(filepath.Dir(m.SocketPath), 0o700); err != nil {
-		return fmt.Errorf("create daemon socket directory: %w", err)
-	}
-	if err := os.Chmod(filepath.Dir(m.SocketPath), 0o700); err != nil {
-		return fmt.Errorf("secure daemon socket directory: %w", err)
+	if err := prepareSocketDirectory(m.SocketPath); err != nil {
+		return err
 	}
 	_ = cleanupStaleSocket(m.SocketPath)
 

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -156,6 +157,28 @@ func TestManagerDaemonArgsReplaceSocketPlaceholder(t *testing.T) {
 	want := []string{"--listen", "/tmp/agent-secret.sock", "--verbose"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("custom daemon args = %v, want %v", got, want)
+	}
+}
+
+func TestManagerRejectsPermissiveCustomSocketParentWithoutChmod(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod custom dir: %v", err)
+	}
+	manager := Manager{
+		SocketPath:     filepath.Join(dir, "agent-secretd.sock"),
+		DaemonPath:     filepath.Join(t.TempDir(), "missing-agent-secretd"),
+		StartupTimeout: time.Millisecond,
+	}
+
+	err := manager.Start(context.Background())
+	if !errors.Is(err, ErrInsecureSocketDirectory) {
+		t.Fatalf("expected insecure socket directory error, got %v", err)
+	}
+	if got := statMode(t, dir); got != 0o755 {
+		t.Fatalf("manager changed custom socket dir mode to %s", got)
 	}
 }
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -7,10 +7,14 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 )
 
-var ErrDaemonUnavailable = errors.New("daemon unavailable")
+var (
+	ErrDaemonUnavailable       = errors.New("daemon unavailable")
+	ErrInsecureSocketDirectory = errors.New("insecure daemon socket directory")
+)
 
 func DefaultSocketPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -21,11 +25,8 @@ func DefaultSocketPath() (string, error) {
 }
 
 func ListenUnix(path string) (*net.UnixListener, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return nil, fmt.Errorf("create socket directory: %w", err)
-	}
-	if err := os.Chmod(filepath.Dir(path), 0o700); err != nil {
-		return nil, fmt.Errorf("secure socket directory: %w", err)
+	if err := prepareSocketDirectory(path); err != nil {
+		return nil, err
 	}
 	if err := cleanupStaleSocket(path); err != nil {
 		return nil, err
@@ -41,6 +42,49 @@ func ListenUnix(path string) (*net.UnixListener, error) {
 		return nil, fmt.Errorf("secure daemon socket: %w", err)
 	}
 	return listener, nil
+}
+
+func prepareSocketDirectory(path string) error {
+	defaultPath, err := DefaultSocketPath()
+	if err == nil && filepath.Clean(path) == filepath.Clean(defaultPath) {
+		return prepareDefaultSocketDirectory(filepath.Dir(path))
+	}
+	return prepareCustomSocketDirectory(filepath.Dir(path))
+}
+
+func prepareDefaultSocketDirectory(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create socket directory: %w", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("secure socket directory: %w", err)
+	}
+	return nil
+}
+
+func prepareCustomSocketDirectory(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create socket directory: %w", err)
+	}
+	return rejectInsecureSocketDirectory(dir)
+}
+
+func rejectInsecureSocketDirectory(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("stat socket directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %s is not a directory", ErrInsecureSocketDirectory, dir)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("%w: %s has mode %s", ErrInsecureSocketDirectory, dir, info.Mode().Perm())
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if ok && int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("%w: %s is owned by uid %d", ErrInsecureSocketDirectory, dir, stat.Uid)
+	}
+	return nil
 }
 
 func Dial(ctx context.Context, path string) (*net.UnixConn, error) {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -24,6 +24,70 @@ func TestDefaultSocketPathIgnoresEnvironmentOverrides(t *testing.T) {
 	}
 }
 
+func TestListenUnixCreatesDefaultSocketDirectoryPrivate(t *testing.T) {
+	home := shortTempDir(t, "agent-secret-home-")
+	t.Setenv("HOME", home)
+	path, err := DefaultSocketPath()
+	if err != nil {
+		t.Fatalf("DefaultSocketPath returned error: %v", err)
+	}
+
+	listener, err := ListenUnix(path)
+	if err != nil {
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	dirMode := statMode(t, filepath.Dir(path))
+	if dirMode != 0o700 {
+		t.Fatalf("default socket dir mode = %s, want 0700", dirMode)
+	}
+	socketMode := statMode(t, path)
+	if socketMode != 0o600 {
+		t.Fatalf("socket mode = %s, want 0600", socketMode)
+	}
+}
+
+func TestListenUnixAcceptsPrivateCustomSocketParent(t *testing.T) {
+	t.Parallel()
+
+	dir := shortTempDir(t, "agent-secret-socket-")
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("chmod custom dir: %v", err)
+	}
+	path := filepath.Join(dir, "agent-secretd.sock")
+
+	listener, err := ListenUnix(path)
+	if err != nil {
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	if got := statMode(t, dir); got != 0o700 {
+		t.Fatalf("custom socket dir mode changed to %s", got)
+	}
+}
+
+func TestListenUnixRejectsPermissiveCustomSocketParentWithoutChmod(t *testing.T) {
+	t.Parallel()
+
+	dir := shortTempDir(t, "agent-secret-socket-")
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod custom dir: %v", err)
+	}
+	path := filepath.Join(dir, "agent-secretd.sock")
+
+	listener, err := ListenUnix(path)
+	if listener != nil {
+		_ = listener.Close()
+	}
+	if !errors.Is(err, ErrInsecureSocketDirectory) {
+		t.Fatalf("expected insecure socket directory error, got %v", err)
+	}
+	if got := statMode(t, dir); got != 0o755 {
+		t.Fatalf("custom socket dir mode changed to %s", got)
+	}
+}
+
 func TestListenUnixRejectsNonSocketPath(t *testing.T) {
 	t.Parallel()
 
@@ -79,4 +143,23 @@ func TestCleanupStaleSocketRefusesLiveDaemon(t *testing.T) {
 		t.Fatal("expected live daemon socket rejection")
 	}
 	<-done
+}
+
+func statMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Mode().Perm()
+}
+
+func shortTempDir(t *testing.T, pattern string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", pattern)
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }


### PR DESCRIPTION
## Summary
- split managed default socket directory setup from custom socket parent validation
- keep default socket directory creation/chmod behavior at 0700
- reject custom socket parents that are not owner-private without chmodding them
- cover listener and manager startup paths for permissive custom parents

## Verification
- mise exec -- go test ./internal/daemon -run 'Test(ListenUnix|Manager|DefaultSocket|CleanupStaleSocket)'\n- mise run test\n- mise run build\n- mise run lint\n- mise run test:race\n\nCloses #9