### PR TITLE
Narrow gosec suppressions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,15 +52,10 @@ linters:
   settings:
     gosec:
       excludes:
-        # This tool intentionally launches approved commands and app bundles.
-        - G204
         # Private directories need executable bits; test scripts need executable bits.
         - G301
         - G302
         - G306
-        # Paths are validated by caller-specific policy and tests, not blanket taint rules.
-        - G304
-        - G703
         # Queue promotion is detached from request cancellation by design.
         - G118
     revive:

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -181,6 +181,7 @@ func openPath(path string, now func() time.Time) (*Writer, error) {
 		return nil, err
 	}
 
+	//nolint:gosec // G304: audit path is daemon-owned; openPath rejects insecure existing files before and after creation.
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open audit log: %w", err)

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -64,6 +64,7 @@ func TestOpenDefaultCreatesPrivateJSONLAuditLog(t *testing.T) {
 		t.Fatalf("audit file mode = %s, want 0600", got)
 	}
 
+	//nolint:gosec // G304: test reads the audit file path created under the test HOME.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read audit log: %v", err)

--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -229,6 +229,7 @@ func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string, 
 	}
 	executable = identity.ExecutablePath
 
+	//nolint:gosec // G204: executable was canonicalized and validated by the approver identity policy above.
 	cmd := exec.CommandContext(ctx, executable, "--socket", socketPath)
 	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
 	if err != nil {

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -479,6 +479,7 @@ func readFixture(t *testing.T, name string) []byte {
 		"Fixtures",
 		name,
 	)
+	//nolint:gosec // G304: test fixture path is derived from runtime.Caller within this repository.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read fixture %s: %v", name, err)

--- a/internal/daemon/approver_identity.go
+++ b/internal/daemon/approver_identity.go
@@ -114,6 +114,7 @@ func appBundleForExecutable(path string) (string, error) {
 }
 
 func plistString(path string, key string) (string, error) {
+	//nolint:gosec // G304: path is the Info.plist inside the canonicalized .app bundle under validation.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("%w: read %s: %w", ErrApproverIdentity, path, err)
@@ -153,9 +154,11 @@ func plistString(path string, key string) (string, error) {
 func verifyCodeSignature(bundlePath string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	//nolint:gosec // G204: codesign path is fixed and bundlePath is canonicalized before signature verification.
 	if err := exec.CommandContext(ctx, "/usr/bin/codesign", "--verify", "--strict", "--deep", bundlePath).Run(); err != nil {
 		return "", fmt.Errorf("%w: verify code signature for %s: %w", ErrApproverIdentity, bundlePath, err)
 	}
+	//nolint:gosec // G204: codesign path is fixed and bundlePath is canonicalized before signature inspection.
 	output, err := exec.CommandContext(ctx, "/usr/bin/codesign", "-dv", "--verbose=4", bundlePath).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%w: inspect code signature for %s: %w", ErrApproverIdentity, bundlePath, err)

--- a/internal/daemon/process_other.go
+++ b/internal/daemon/process_other.go
@@ -10,6 +10,7 @@ import (
 func configureDaemonProcess(_ *exec.Cmd) {}
 
 func daemonStartCommand(ctx context.Context, path string, args []string) *exec.Cmd {
+	//nolint:gosec // G204: daemon path is not environment-controlled; production NewManager selects bundled/current executable paths.
 	return exec.CommandContext(ctx, path, args...)
 }
 

--- a/internal/daemon/process_unix.go
+++ b/internal/daemon/process_unix.go
@@ -23,9 +23,11 @@ func daemonStartCommand(ctx context.Context, path string, args []string) *exec.C
 		}
 		openArgs = append(openArgs, "--args")
 		openArgs = append(openArgs, args...)
+		//nolint:gosec // G204: open path is fixed; app path comes from NewManager defaults or explicit test Manager setup.
 		return exec.CommandContext(ctx, "/usr/bin/open", openArgs...)
 	}
 
+	//nolint:gosec // G204: daemon path is not environment-controlled; production NewManager selects bundled/current executable paths.
 	return exec.CommandContext(ctx, path, args...)
 }
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -77,6 +77,7 @@ func (s *Server) ListenAndServe(ctx context.Context, path string) error {
 		return err
 	}
 	defer func() { _ = listener.Close() }()
+	//nolint:gosec // G703: path is the socket just created by ListenUnix after private-directory validation.
 	defer func() { _ = os.Remove(path) }()
 	return s.Serve(ctx, listener)
 }

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -37,6 +37,7 @@ func ListenUnix(path string) (*net.UnixListener, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listen on daemon socket: %w", err)
 	}
+	//nolint:gosec // G703: path is the Unix socket just created after directory validation.
 	if err := os.Chmod(path, 0o600); err != nil {
 		_ = listener.Close()
 		return nil, fmt.Errorf("secure daemon socket: %w", err)
@@ -53,9 +54,11 @@ func prepareSocketDirectory(path string) error {
 }
 
 func prepareDefaultSocketDirectory(dir string) error {
+	//nolint:gosec // G703: dir is the managed default socket directory under Application Support.
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create socket directory: %w", err)
 	}
+	//nolint:gosec // G703: only the managed default socket directory is chmodded.
 	if err := os.Chmod(dir, 0o700); err != nil {
 		return fmt.Errorf("secure socket directory: %w", err)
 	}
@@ -63,6 +66,7 @@ func prepareDefaultSocketDirectory(dir string) error {
 }
 
 func prepareCustomSocketDirectory(dir string) error {
+	//nolint:gosec // G703: custom mkdir creates missing private parents but existing parents are validated, not chmodded.
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create socket directory: %w", err)
 	}
@@ -70,6 +74,7 @@ func prepareCustomSocketDirectory(dir string) error {
 }
 
 func rejectInsecureSocketDirectory(dir string) error {
+	//nolint:gosec // G703: stat is required to validate the custom socket parent before use.
 	info, err := os.Stat(dir)
 	if err != nil {
 		return fmt.Errorf("stat socket directory: %w", err)
@@ -123,6 +128,7 @@ func WaitUntilReady(ctx context.Context, path string, interval time.Duration) er
 }
 
 func cleanupStaleSocket(path string) error {
+	//nolint:gosec // G703: lstat checks whether the configured socket path is a stale Unix socket before removal.
 	info, err := os.Lstat(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -141,6 +147,7 @@ func cleanupStaleSocket(path string) error {
 		_ = conn.Close()
 		return fmt.Errorf("daemon already listening on %s", path)
 	}
+	//nolint:gosec // G703: removal is limited to stale Unix socket paths after lstat and failed live-daemon dial.
 	if err := os.Remove(path); err != nil {
 		return fmt.Errorf("remove stale daemon socket: %w", err)
 	}

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -19,6 +19,7 @@ type Entry struct {
 }
 
 func Load(path string) ([]Entry, error) {
+	//nolint:gosec // G304: env-file path is an explicit local user input for this parser.
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open env file %q: %w", path, err)

--- a/internal/execwrap/execwrap.go
+++ b/internal/execwrap/execwrap.go
@@ -81,6 +81,7 @@ func Run(ctx context.Context, spec Spec, interrupts <-chan os.Signal) (Result, e
 	if ctx != nil {
 		commandContext = context.WithoutCancel(ctx)
 	}
+	//nolint:gosec // G204: command path and argv come from a daemon-approved ExecSpec after request validation and audit.
 	cmd := exec.CommandContext(commandContext, spec.Path, spec.Args...)
 	cmd.Dir = spec.Dir
 	cmd.Env = env

--- a/internal/profileconfig/profileconfig.go
+++ b/internal/profileconfig/profileconfig.go
@@ -113,6 +113,7 @@ func Load(opts LoadOptions) (Profile, error) {
 		return Profile{}, err
 	}
 
+	//nolint:gosec // G304: config path is selected from explicit project config discovery and parsed as configuration only.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return Profile{}, fmt.Errorf("read profile config %s: %w", path, err)


### PR DESCRIPTION
## Summary
- remove broad gosec excludes for dynamic command execution and dynamic file/path use
- keep only local `gosec` suppressions at audited call sites
- document the concrete invariant for each remaining dynamic command/path operation

## Verification
- mise exec -- golangci-lint run --timeout 5m
- mise run test
- mise run build
- mise run lint
- mise run test:race

Closes #10