### PR TITLE
Make approval prompt deny by default

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButton.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButton.swift
@@ -6,25 +6,21 @@ import Foundation
     struct ApprovalPanelDecisionButton: View {
         private typealias Metric = ApprovalPanelStyle.Metric
 
-        let icon: String
-        let title: String
-        let subtitle: String
-        let role: ApprovalPanelDecisionButtonRole
-        let keyboardShortcut: KeyboardShortcut?
+        let spec: ApprovalPanelDecisionButtonSpec
         let action: () -> Void
 
         var body: some View {
             let button = Button(action: action) {
                 HStack(spacing: Metric.cautionSpacing) {
-                    Image(systemName: icon)
+                    Image(systemName: spec.icon)
                         .font(.system(size: Metric.buttonIconSize, weight: .semibold))
                         .accessibilityHidden(true)
                     VStack(alignment: .leading, spacing: Metric.detailLabelSpacing) {
-                        Text(title)
+                        Text(spec.title)
                             .font(.system(size: Metric.buttonTitleFontSize, weight: .bold))
                             .lineLimit(titleLineLimit)
                             .minimumScaleFactor(Metric.minimumScaleFactor)
-                        Text(subtitle)
+                        Text(spec.subtitle)
                             .font(.system(size: Metric.buttonSubtitleFontSize, weight: .medium))
                             .lineLimit(Metric.singleLineLimit)
                             .minimumScaleFactor(Metric.minimumScaleFactor)
@@ -37,15 +33,15 @@ import Foundation
             }
             .buttonStyle(.plain)
 
-            if let keyboardShortcut: KeyboardShortcut {
-                button.keyboardShortcut(keyboardShortcut)
+            if let keyboardShortcut: ApprovalPanelKeyboardShortcut = spec.keyboardShortcut {
+                button.keyboardShortcut(keyboardShortcut.keyboardShortcut)
             } else {
                 button
             }
         }
 
         private var foregroundColor: Color {
-            switch role {
+            switch spec.role {
             case .primary:
                 .white
 
@@ -55,7 +51,7 @@ import Foundation
         }
 
         private var titleLineLimit: Int {
-            switch role {
+            switch spec.role {
             case .primary:
                 Metric.buttonTitleLineLimit
 
@@ -80,7 +76,7 @@ import Foundation
         }
 
         private var backgroundFill: Color {
-            switch role {
+            switch spec.role {
             case .primary:
                 Color.green
 
@@ -90,7 +86,7 @@ import Foundation
         }
 
         private var borderColor: Color {
-            switch role {
+            switch spec.role {
             case .primary:
                 Color.green.opacity(Metric.primaryBorderOpacity)
 

--- a/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButtonRole.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButtonRole.swift
@@ -3,7 +3,7 @@ import Foundation
 #if canImport(SwiftUI)
     import SwiftUI
 
-    enum ApprovalPanelDecisionButtonRole {
+    enum ApprovalPanelDecisionButtonRole: Equatable {
         case primary
         case secondary
     }

--- a/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButtonSpec.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButtonSpec.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+#if canImport(SwiftUI)
+    import SwiftUI
+
+    struct ApprovalPanelDecisionButtonSpec: Equatable {
+        let decision: ApprovalDecisionKind
+        let icon: String
+        let title: String
+        let subtitle: String
+        let role: ApprovalPanelDecisionButtonRole
+        let keyboardShortcut: ApprovalPanelKeyboardShortcut?
+
+        static func makeAll(viewModel: ApprovalRequestViewModel) -> [Self] {
+            [
+                Self(
+                    decision: .deny,
+                    icon: "shield.slash",
+                    title: "Deny",
+                    subtitle: "Default: Return",
+                    role: .secondary,
+                    keyboardShortcut: .defaultAction
+                ),
+                Self(
+                    decision: .approveOnce,
+                    icon: "clock",
+                    title: "Allow once",
+                    subtitle: "This time only",
+                    role: .secondary,
+                    keyboardShortcut: nil
+                ),
+                Self(
+                    decision: .approveReusable,
+                    icon: "checkmark.shield",
+                    title: "Allow same command briefly",
+                    subtitle: "\(viewModel.compactTimeRemaining) or \(viewModel.reusableUses) uses",
+                    role: .primary,
+                    keyboardShortcut: nil
+                )
+            ]
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/ApprovalPanelKeyboardShortcut.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelKeyboardShortcut.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+#if canImport(SwiftUI)
+    import SwiftUI
+
+    enum ApprovalPanelKeyboardShortcut: Equatable {
+        case defaultAction
+
+        var keyboardShortcut: KeyboardShortcut {
+            switch self {
+            case .defaultAction:
+                .defaultAction
+            }
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
@@ -219,50 +219,18 @@ import Foundation
 
         private var decisionButtons: some View {
             HStack(spacing: Metric.buttonSpacing) {
-                denyButton
+                ForEach(decisionButtonSpecs, id: \.decision) { spec in
+                    ApprovalPanelDecisionButton(spec: spec) {
+                        decide(spec.decision)
+                    }
                     .frame(width: Metric.decisionButtonWidth)
-                allowOnceButton
-                    .frame(width: Metric.decisionButtonWidth)
-                allowReusableButton
-                    .frame(width: Metric.decisionButtonWidth)
+                }
             }
             .frame(height: Metric.buttonHeight)
         }
 
-        private var denyButton: some View {
-            ApprovalPanelDecisionButton(
-                icon: "shield.slash",
-                title: "Deny",
-                subtitle: "Default action",
-                role: .secondary,
-                keyboardShortcut: .cancelAction
-            ) {
-                decide(.deny)
-            }
-        }
-
-        private var allowOnceButton: some View {
-            ApprovalPanelDecisionButton(
-                icon: "clock",
-                title: "Allow once",
-                subtitle: "This time only",
-                role: .secondary,
-                keyboardShortcut: .defaultAction
-            ) {
-                decide(.approveOnce)
-            }
-        }
-
-        private var allowReusableButton: some View {
-            ApprovalPanelDecisionButton(
-                icon: "checkmark.shield",
-                title: "Allow same command briefly",
-                subtitle: "\(viewModel.compactTimeRemaining) or \(viewModel.reusableUses) uses",
-                role: .primary,
-                keyboardShortcut: nil
-            ) {
-                decide(.approveReusable)
-            }
+        private var decisionButtonSpecs: [ApprovalPanelDecisionButtonSpec] {
+            ApprovalPanelDecisionButtonSpec.makeAll(viewModel: viewModel)
         }
 
         private var footer: some View {

--- a/approver/Tests/AgentSecretApproverTests/ApprovalPanelDecisionButtonSpecTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalPanelDecisionButtonSpecTests.swift
@@ -1,0 +1,70 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+#if canImport(SwiftUI)
+    final class ApprovalPanelDecisionButtonSpecTests: XCTestCase {
+        private static let sampleExpiration: TimeInterval = 1_800_000_000
+        private static let viewModelNow: TimeInterval = 1_799_999_880
+
+        private static func sampleButtonSpecs() -> [ApprovalPanelDecisionButtonSpec] {
+            let request = ApprovalRequest(
+                requestID: "req_buttons",
+                nonce: "nonce_buttons",
+                reason: "Run deploy",
+                command: ["/usr/bin/env", "deploy"],
+                cwd: "/tmp/project",
+                expiresAt: Date(timeIntervalSince1970: sampleExpiration),
+                secrets: [
+                    RequestedSecret(alias: "DEPLOY_TOKEN", ref: "op://Shared/Deploy/token")
+                ],
+                resolvedExecutable: "/usr/bin/env"
+            )
+            let viewModel = ApprovalRequestViewModel(
+                request: request,
+                now: Date(timeIntervalSince1970: viewModelNow)
+            )
+            return ApprovalPanelDecisionButtonSpec.makeAll(viewModel: viewModel)
+        }
+
+        func testDenyIsTheOnlyDefaultApprovalPanelAction() {
+            let specs = Self.sampleButtonSpecs()
+
+            XCTAssertEqual(specs.map(\.decision), [.deny, .approveOnce, .approveReusable])
+            XCTAssertEqual(
+                specs.filter { spec in spec.keyboardShortcut == .defaultAction }.map(\.decision),
+                [.deny]
+            )
+        }
+
+        func testApprovalActionsRequirePointerSelection() throws {
+            let specs = Self.sampleButtonSpecs()
+            let approveOnce: ApprovalPanelDecisionButtonSpec = try XCTUnwrap(
+                specs.first { spec in spec.decision == .approveOnce }
+            )
+            let approveReusable: ApprovalPanelDecisionButtonSpec = try XCTUnwrap(
+                specs.first { spec in spec.decision == .approveReusable }
+            )
+
+            XCTAssertNil(approveOnce.keyboardShortcut)
+            XCTAssertNil(approveReusable.keyboardShortcut)
+            XCTAssertFalse(approveOnce.subtitle.localizedCaseInsensitiveContains("default"))
+            XCTAssertFalse(approveReusable.subtitle.localizedCaseInsensitiveContains("default"))
+        }
+
+        func testDenyCopyDescribesReturnKeyDefault() throws {
+            let deny: ApprovalPanelDecisionButtonSpec = try XCTUnwrap(
+                Self.sampleButtonSpecs().first { spec in spec.decision == .deny }
+            )
+
+            XCTAssertEqual(deny.title, "Deny")
+            XCTAssertTrue(deny.subtitle.localizedCaseInsensitiveContains("default"))
+            XCTAssertTrue(deny.subtitle.localizedCaseInsensitiveContains("return"))
+            XCTAssertEqual(deny.keyboardShortcut, .defaultAction)
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary
- move approval panel button metadata into a testable spec
- make Deny the only Return/default action
- remove keyboard shortcuts from approval actions so approval requires pointer selection

## Verification
- \?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)
Test Suite 'All tests' started at 2026-05-02 14:15:05.603.
Test Suite 'AgentSecretApproverPackageTests.xctest' started at 2026-05-02 14:15:05.604.
Test Suite 'ApprovalAccountScopeTests' started at 2026-05-02 14:15:05.604.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' started.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' passed (0.001 seconds).
Test Suite 'ApprovalAccountScopeTests' passed at 2026-05-02 14:15:05.604.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalControllerTests' started at 2026-05-02 14:15:05.605.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelMarksLongCommandsInspectable]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelMarksLongCommandsInspectable]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' passed (0.000 seconds).
Test Suite 'ApprovalControllerTests' passed at 2026-05-02 14:15:05.609.
	 Executed 8 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
Test Suite 'ApprovalPanelDecisionButtonSpecTests' started at 2026-05-02 14:15:05.609.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' passed (0.000 seconds).
Test Suite 'ApprovalPanelDecisionButtonSpecTests' passed at 2026-05-02 14:15:05.610.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalPanelSecretGroupRowTests' started at 2026-05-02 14:15:05.610.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' passed (0.065 seconds).
Test Suite 'ApprovalPanelSecretGroupRowTests' passed at 2026-05-02 14:15:05.675.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.065 (0.065) seconds
Test Suite 'AgentSecretApproverPackageTests.xctest' passed at 2026-05-02 14:15:05.675.
	 Executed 13 tests, with 0 failures (0 unexpected) in 0.070 (0.071) seconds
Test Suite 'All tests' passed at 2026-05-02 14:15:05.675.
	 Executed 13 tests, with 0 failures (0 unexpected) in 0.070 (0.071) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
- \Linting Go module: /Users/kovyrin/.codex/worktrees/0156/2026-04-28-kovyrin-agent-secret
0 issues.
?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)
?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)
Running Go coverage gate: package >= 80%, total >= 80%
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)	coverage: 82.9% of statements
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)	coverage: 86.8% of statements
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)	coverage: 80.2% of statements
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)	coverage: 85.0% of statements
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)	coverage: 83.1% of statements
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)	coverage: 81.8% of statements
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)	coverage: 81.8% of statements
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)	coverage: 83.1% of statements
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)	coverage: 83.3% of statements
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)	coverage: 86.7% of statements
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)	coverage: 84.0% of statements
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)	coverage: 80.6% of statements
coverage: ok, total 82.6%
No vulnerabilities found.
Test Suite 'All tests' started at 2026-05-02 14:15:13.821.
Test Suite 'AgentSecretApproverPackageTests.xctest' started at 2026-05-02 14:15:13.822.
Test Suite 'ApprovalAccountScopeTests' started at 2026-05-02 14:15:13.822.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' started.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' passed (0.001 seconds).
Test Suite 'ApprovalAccountScopeTests' passed at 2026-05-02 14:15:13.823.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalControllerTests' started at 2026-05-02 14:15:13.823.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelMarksLongCommandsInspectable]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelMarksLongCommandsInspectable]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' passed (0.000 seconds).
Test Suite 'ApprovalControllerTests' passed at 2026-05-02 14:15:13.826.
	 Executed 8 tests, with 0 failures (0 unexpected) in 0.003 (0.004) seconds
Test Suite 'ApprovalPanelDecisionButtonSpecTests' started at 2026-05-02 14:15:13.826.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' passed (0.000 seconds).
Test Suite 'ApprovalPanelDecisionButtonSpecTests' passed at 2026-05-02 14:15:13.827.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'ApprovalPanelSecretGroupRowTests' started at 2026-05-02 14:15:13.827.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' passed (0.069 seconds).
Test Suite 'ApprovalPanelSecretGroupRowTests' passed at 2026-05-02 14:15:13.896.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.069 (0.069) seconds
Test Suite 'AgentSecretApproverPackageTests.xctest' passed at 2026-05-02 14:15:13.896.
	 Executed 13 tests, with 0 failures (0 unexpected) in 0.073 (0.074) seconds
Test Suite 'All tests' passed at 2026-05-02 14:15:13.896.
	 Executed 13 tests, with 0 failures (0 unexpected) in 0.073 (0.075) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
- \[0/1] Planning build
Building for production...
[0/2] Write swift-version--58304C5D6DBC2206.txt
Build of product 'agent-secret-approver' complete! (0.14s)
/Users/kovyrin/.codex/worktrees/0156/2026-04-28-kovyrin-agent-secret/approver/dist/AgentSecretApprover.app
- \?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)

Closes #11.