### PR TITLE
Expire stale native approval prompts

### DIFF
--- a/approver/Sources/AgentSecretApprover/AppKitApprovalPresenter.swift
+++ b/approver/Sources/AgentSecretApprover/AppKitApprovalPresenter.swift
@@ -46,7 +46,6 @@ public final class AppKitApprovalPresenter: ApprovalPresenter {
         private static func decideOnMain(for request: ApprovalRequest) -> ApprovalDecisionKind {
             let app = NSApplication.shared
             Self.activate(app)
-            let viewModel = ApprovalRequestViewModel(request: request)
             var decision: ApprovalDecisionKind = .deny
             let window = NSPanel(
                 contentRect: NSRect(
@@ -64,7 +63,7 @@ public final class AppKitApprovalPresenter: ApprovalPresenter {
             window.hasShadow = false
             window.isMovableByWindowBackground = true
             window.contentView = NSHostingView(
-                rootView: ApprovalRequestPanelView(viewModel: viewModel) { selectedDecision in
+                rootView: ApprovalRequestPanelView(request: request) { selectedDecision in
                     decision = selectedDecision
                     app.stopModal()
                 }

--- a/approver/Sources/AgentSecretApprover/ApprovalDecisionKind.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalDecisionKind.swift
@@ -10,4 +10,8 @@ public enum ApprovalDecisionKind: String, Codable, Equatable, Sendable {
     case deny
     /// Treat the request as unanswered.
     case timeout
+
+    var requiresUnexpiredRequest: Bool {
+        self == .approveOnce || self == .approveReusable
+    }
 }

--- a/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButton.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButton.swift
@@ -32,6 +32,8 @@ import Foundation
                 .background(background)
             }
             .buttonStyle(.plain)
+            .disabled(!spec.isEnabled)
+            .opacity(spec.isEnabled ? Metric.enabledButtonOpacity : Metric.disabledButtonOpacity)
 
             if let keyboardShortcut: ApprovalPanelKeyboardShortcut = spec.keyboardShortcut {
                 button.keyboardShortcut(keyboardShortcut.keyboardShortcut)

--- a/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButtonSpec.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelDecisionButtonSpec.swift
@@ -10,6 +10,7 @@ import Foundation
         let subtitle: String
         let role: ApprovalPanelDecisionButtonRole
         let keyboardShortcut: ApprovalPanelKeyboardShortcut?
+        let isEnabled: Bool
 
         static func makeAll(viewModel: ApprovalRequestViewModel) -> [Self] {
             [
@@ -19,23 +20,28 @@ import Foundation
                     title: "Deny",
                     subtitle: "Default: Return",
                     role: .secondary,
-                    keyboardShortcut: .defaultAction
+                    keyboardShortcut: .defaultAction,
+                    isEnabled: true
                 ),
                 Self(
                     decision: .approveOnce,
                     icon: "clock",
                     title: "Allow once",
-                    subtitle: "This time only",
+                    subtitle: viewModel.isExpired ? "Request expired" : "This time only",
                     role: .secondary,
-                    keyboardShortcut: nil
+                    keyboardShortcut: nil,
+                    isEnabled: !viewModel.isExpired
                 ),
                 Self(
                     decision: .approveReusable,
                     icon: "checkmark.shield",
                     title: "Allow same command briefly",
-                    subtitle: "\(viewModel.compactTimeRemaining) or \(viewModel.reusableUses) uses",
+                    subtitle: viewModel.isExpired ?
+                        "Request expired" :
+                        "\(viewModel.compactTimeRemaining) or \(viewModel.reusableUses) uses",
                     role: .primary,
-                    keyboardShortcut: nil
+                    keyboardShortcut: nil,
+                    isEnabled: !viewModel.isExpired
                 )
             ]
         }

--- a/approver/Sources/AgentSecretApprover/ApprovalPanelStyle.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelStyle.swift
@@ -39,6 +39,7 @@ import Foundation
             static let contextRowSpacing: CGFloat = 10
             static let contextTitleFontSize: CGFloat = 13
             static let contextValueFontSize: CGFloat = 12
+            static let countdownTickInterval: TimeInterval = 1
             static let decisionButtonCount: CGFloat = 3
             static let decisionButtonGapCount: CGFloat = 2
             static let decisionButtonWidth: CGFloat = (
@@ -50,6 +51,8 @@ import Foundation
             static let detailSubtitleFontSize: CGFloat = 12
             static let detailTitleFontSize: CGFloat = 14
             static let detailTopPadding: CGFloat = 5
+            static let disabledButtonOpacity: Double = 0.45
+            static let enabledButtonOpacity: Double = 1
             static let footerIconSize: CGFloat = 18
             static let footerSpacing: CGFloat = 12
             static let greenBorderOpacity: Double = 0.22

--- a/approver/Sources/AgentSecretApprover/ApprovalPromptExpiration.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPromptExpiration.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct ApprovalPromptExpiration: Equatable {
+    let expiresAt: Date
+
+    func isExpired(at now: Date) -> Bool {
+        now >= expiresAt
+    }
+
+    func timeoutDecision(at now: Date) -> ApprovalDecisionKind? {
+        isExpired(at: now) ? .timeout : nil
+    }
+
+    func guardDecision(_ decision: ApprovalDecisionKind, at now: Date) -> ApprovalDecisionKind {
+        if decision.requiresUnexpiredRequest, isExpired(at: now) {
+            return .timeout
+        }
+        return decision
+    }
+}

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView+Secrets.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView+Secrets.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+#if canImport(AppKit) && canImport(SwiftUI)
+    import AppKit
+    import SwiftUI
+
+    extension ApprovalRequestPanelView {
+        private typealias Metric = ApprovalPanelStyle.Metric
+
+        var secretSection: some View {
+            Group {
+                if viewModel.secretCount == Metric.singleSecretCount {
+                    singleSecretSection
+                } else if viewModel.secretCount <= Metric.compactSecretLimit {
+                    ApprovalPanelSecretList(heading: secretCardHeading, secrets: viewModel.requestedSecrets)
+                } else {
+                    ApprovalPanelSecretGroupList(heading: secretCardHeading, groups: viewModel.vaultGroups)
+                }
+            }
+        }
+
+        var singleSecretSection: some View {
+            VStack(alignment: .leading, spacing: Metric.secretCardSpacing) {
+                Text(secretCardHeading)
+                    .font(.system(size: Metric.sectionLabelFontSize, weight: .semibold))
+                    .foregroundStyle(Color.green)
+                ForEach(viewModel.requestedSecrets, id: \.alias) { secret in
+                    ApprovalPanelSecretCard(secret: secret)
+                }
+            }
+            .padding(Metric.secretPanelPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(secretPanelBackground)
+            .overlay(secretPanelBorder)
+        }
+
+        var secretCardHeading: String {
+            if viewModel.secretCount == Metric.singleSecretCount {
+                return "Requested secret"
+            }
+            return "Requested secrets"
+        }
+
+        var secretPanelBackground: some View {
+            RoundedRectangle(cornerRadius: Metric.panelCornerRadius, style: .continuous)
+                .fill(Color.green.opacity(Metric.greenPanelOpacity))
+        }
+
+        var secretPanelBorder: some View {
+            RoundedRectangle(cornerRadius: Metric.panelCornerRadius, style: .continuous)
+                .stroke(Color.green.opacity(Metric.greenBorderOpacity), lineWidth: Metric.borderWidth)
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
@@ -8,10 +8,12 @@ import Foundation
         private typealias Metric = ApprovalPanelStyle.Metric
         private typealias Palette = ApprovalPanelStyle.Palette
 
-        let viewModel: ApprovalRequestViewModel
+        let request: ApprovalRequest
         let decide: (ApprovalDecisionKind) -> Void
 
         @State private var detailsExpanded = false
+        @State private var didDecide = false
+        @State private var now: Date
         @State private var textInspection: ApprovalPanelTextInspection?
 
         var body: some View {
@@ -41,6 +43,19 @@ import Foundation
             .sheet(item: $textInspection) { inspection in
                 ApprovalPanelTextInspector(inspection: inspection)
             }
+            .onAppear {
+                handleClockTick(Date())
+            }
+            .onReceive(
+                Timer.publish(every: Metric.countdownTickInterval, on: .main, in: .common)
+                    .autoconnect()
+            ) { date in
+                handleClockTick(date)
+            }
+        }
+
+        var viewModel: ApprovalRequestViewModel {
+            ApprovalRequestViewModel(request: request, now: now)
         }
 
         private var cardBackground: some View {
@@ -79,50 +94,6 @@ import Foundation
             }
             .font(.system(size: Metric.inlineFontSize))
             .fixedSize(horizontal: false, vertical: true)
-        }
-
-        private var secretSection: some View {
-            Group {
-                if viewModel.secretCount == Metric.singleSecretCount {
-                    singleSecretSection
-                } else if viewModel.secretCount <= Metric.compactSecretLimit {
-                    ApprovalPanelSecretList(heading: secretCardHeading, secrets: viewModel.requestedSecrets)
-                } else {
-                    ApprovalPanelSecretGroupList(heading: secretCardHeading, groups: viewModel.vaultGroups)
-                }
-            }
-        }
-
-        private var singleSecretSection: some View {
-            VStack(alignment: .leading, spacing: Metric.secretCardSpacing) {
-                Text(secretCardHeading)
-                    .font(.system(size: Metric.sectionLabelFontSize, weight: .semibold))
-                    .foregroundStyle(Color.green)
-                ForEach(viewModel.requestedSecrets, id: \.alias) { secret in
-                    ApprovalPanelSecretCard(secret: secret)
-                }
-            }
-            .padding(Metric.secretPanelPadding)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(secretPanelBackground)
-            .overlay(secretPanelBorder)
-        }
-
-        private var secretCardHeading: String {
-            if viewModel.secretCount == Metric.singleSecretCount {
-                return "Requested secret"
-            }
-            return "Requested secrets"
-        }
-
-        private var secretPanelBackground: some View {
-            RoundedRectangle(cornerRadius: Metric.panelCornerRadius, style: .continuous)
-                .fill(Color.green.opacity(Metric.greenPanelOpacity))
-        }
-
-        private var secretPanelBorder: some View {
-            RoundedRectangle(cornerRadius: Metric.panelCornerRadius, style: .continuous)
-                .stroke(Color.green.opacity(Metric.greenBorderOpacity), lineWidth: Metric.borderWidth)
         }
 
         private var requestContext: some View {
@@ -221,7 +192,7 @@ import Foundation
             HStack(spacing: Metric.buttonSpacing) {
                 ForEach(decisionButtonSpecs, id: \.decision) { spec in
                     ApprovalPanelDecisionButton(spec: spec) {
-                        decide(spec.decision)
+                        complete(with: expiration.guardDecision(spec.decision, at: Date()))
                     }
                     .frame(width: Metric.decisionButtonWidth)
                 }
@@ -231,6 +202,10 @@ import Foundation
 
         private var decisionButtonSpecs: [ApprovalPanelDecisionButtonSpec] {
             ApprovalPanelDecisionButtonSpec.makeAll(viewModel: viewModel)
+        }
+
+        private var expiration: ApprovalPromptExpiration {
+            ApprovalPromptExpiration(expiresAt: request.expiresAt)
         }
 
         private var footer: some View {
@@ -246,6 +221,31 @@ import Foundation
                     .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        init(
+            request: ApprovalRequest,
+            now: Date = Date(),
+            decide: @escaping (ApprovalDecisionKind) -> Void
+        ) {
+            self.request = request
+            self.decide = decide
+            _now = State(initialValue: now)
+        }
+
+        private func handleClockTick(_ date: Date) {
+            now = date
+            if let timeoutDecision: ApprovalDecisionKind = expiration.timeoutDecision(at: date) {
+                complete(with: timeoutDecision)
+            }
+        }
+
+        private func complete(with decision: ApprovalDecisionKind) {
+            guard !didDecide else {
+                return
+            }
+            didDecide = true
+            decide(decision)
         }
     }
 #endif

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Expiration.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Expiration.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+extension ApprovalRequestViewModel {
+    static func promptQuestion(secretCount: Int, isExpired: Bool) -> String {
+        if isExpired {
+            return "This secret access request has expired."
+        }
+        if secretCount == 1 {
+            return "Allow this command to use the following secret?"
+        }
+        return "Allow this command to use the following \(secretCount) secrets?"
+    }
+
+    static func accessSummary(isExpired: Bool) -> String {
+        if isExpired {
+            return "can no longer receive access."
+        }
+        return "wants temporary access."
+    }
+
+    static func footerMessage(secretCount: Int, expired: Bool) -> String {
+        if expired {
+            return "This request expired before approval. Run the command again if access is still needed."
+        }
+        let noun: String = secretCount == 1 ? "secret is" : "secrets are"
+        let pronoun: String = secretCount == 1 ? "It is" : "They are"
+        return """
+        The \(noun) injected into the approved process only.
+        \(pronoun) never shown to the agent or stored on disk.
+        """
+    }
+
+    static func scopeSummary(uses: Int, remaining: String, expired: Bool) -> String {
+        if expired {
+            return "Same command only • max \(uses) uses • request expired"
+        }
+        return "Same command only • max \(uses) uses • expires in \(remaining)"
+    }
+
+    static func allowReusableTitle(uses: Int, remaining: String, expired: Bool) -> String {
+        if expired {
+            return "Allow same command briefly\nRequest expired"
+        }
+        return "Allow same command briefly\n\(remaining) or \(uses) uses"
+    }
+
+    static func isExpired(_ interval: TimeInterval) -> Bool {
+        interval <= 0
+    }
+
+    static func expiredTimeRemaining() -> String {
+        "expired"
+    }
+}

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
@@ -56,6 +56,8 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
     public let promptQuestion: String
     /// Summary text next to the command pill.
     public let accessSummary: String
+    /// True when the request can no longer be approved.
+    public let isExpired: Bool
     /// True when the number of requested secrets deserves extra attention.
     public let highScopeWarning: Bool
     /// Human-readable approval TTL.
@@ -93,24 +95,28 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         secretCount = secretPresentation.count
         vaultGroups = secretPresentation.vaultGroups
         vaultCount = secretPresentation.vaultCount
-        promptQuestion = Self.promptQuestion(secretCount: secretPresentation.count)
-        accessSummary = Self.accessSummary()
-        highScopeWarning = secretPresentation.count >= Self.highScopeSecretThreshold
         let remaining: TimeInterval = request.expiresAt.timeIntervalSince(now)
-        timeRemaining = Self.formatRemaining(remaining)
+        isExpired = Self.isExpired(remaining)
+        promptQuestion = Self.promptQuestion(secretCount: secretPresentation.count, isExpired: isExpired)
+        accessSummary = Self.accessSummary(isExpired: isExpired)
+        highScopeWarning = secretPresentation.count >= Self.highScopeSecretThreshold
+        timeRemaining = isExpired ? Self.expiredTimeRemaining() : Self.formatRemaining(remaining)
         compactTimeRemaining = timeRemaining
-        reusableUses = request.reusableUses
+        let reusableUseLimit: Int = request.reusableUses
+        reusableUses = reusableUseLimit
         scopeSummary = Self.scopeSummary(
-            reusableUses: request.reusableUses,
-            compactTimeRemaining: compactTimeRemaining
+            uses: reusableUseLimit,
+            remaining: compactTimeRemaining,
+            expired: isExpired
         )
-        allowReusableTitle = "Allow same command briefly\n\(compactTimeRemaining) or \(request.reusableUses) uses"
-        printsEnvironmentWarning = Self.environmentPrinter(
-            command: request.command,
-            resolvedExecutable: request.resolvedExecutable
+        allowReusableTitle = Self.allowReusableTitle(
+            uses: reusableUseLimit,
+            remaining: compactTimeRemaining,
+            expired: isExpired
         )
+        printsEnvironmentWarning = Self.environmentWarning(for: request)
         overrideWarning = Self.overrideWarning(for: request)
-        footerMessage = Self.footerMessage(secretCount: secretPresentation.count)
+        footerMessage = Self.footerMessage(secretCount: secretPresentation.count, expired: isExpired)
         renderedText = Self.renderedText(
             for: request,
             viewModel: SelfRenderInput(
@@ -165,26 +171,6 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
             return "\(secret.alias) [\(accountLabel)] -> \(secret.ref)"
         }
         return "\(secret.alias) -> \(secret.ref)"
-    }
-
-    private static func promptQuestion(secretCount: Int) -> String {
-        if secretCount == 1 {
-            return "Allow this command to use the following secret?"
-        }
-        return "Allow this command to use the following \(secretCount) secrets?"
-    }
-
-    private static func accessSummary() -> String {
-        "wants temporary access."
-    }
-
-    private static func footerMessage(secretCount: Int) -> String {
-        let noun: String = secretCount == 1 ? "secret is" : "secrets are"
-        let pronoun: String = secretCount == 1 ? "It is" : "They are"
-        return """
-        The \(noun) injected into the approved process only.
-        \(pronoun) never shown to the agent or stored on disk.
-        """
     }
 
     private static func renderedText(
@@ -244,10 +230,6 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         return URL(fileURLWithPath: path).lastPathComponent
     }
 
-    private static func scopeSummary(reusableUses: Int, compactTimeRemaining: String) -> String {
-        "Same command only • max \(reusableUses) uses • expires in \(compactTimeRemaining)"
-    }
-
     private static func displayPath(_ path: String) -> String {
         guard let home: String = ProcessInfo.processInfo.environment["HOME"], !home.isEmpty else {
             return path
@@ -282,5 +264,9 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         let executableName: String = URL(fileURLWithPath: resolvedExecutable ?? command.first ?? "")
             .lastPathComponent
         return executableName == "env" || executableName == "printenv"
+    }
+
+    private static func environmentWarning(for request: ApprovalRequest) -> Bool {
+        environmentPrinter(command: request.command, resolvedExecutable: request.resolvedExecutable)
     }
 }

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
@@ -252,20 +252,11 @@ final class ApprovalControllerTests: XCTestCase {
         XCTAssertEqual(viewModel.promptQuestion, "Allow this command to use the following secret?")
         XCTAssertEqual(viewModel.accessSummary, "wants temporary access.")
         XCTAssertEqual(viewModel.compactTimeRemaining, "2 minutes")
+        XCTAssertFalse(viewModel.isExpired)
         XCTAssertFalse(viewModel.commandNeedsInspector)
         XCTAssertFalse(viewModel.renderedText.contains(Self.canarySecretValue))
         XCTAssertFalse(viewModel.renderedText.contains(request.requestID))
         XCTAssertFalse(viewModel.renderedText.contains(request.nonce))
-    }
-
-    func testViewModelMarksLongCommandsInspectable() {
-        var request: ApprovalRequest = Self.sampleRequest
-        let script = String(repeating: "terraform import cloudflare_record.long_name ", count: 3)
-        request.command = ["/bin/sh", "-c", script]
-        request.resolvedExecutable = "/bin/sh"
-        let viewModel = ApprovalRequestViewModel(request: request, now: Date(timeIntervalSince1970: Self.viewModelNow))
-
-        XCTAssertTrue(viewModel.commandNeedsInspector)
     }
 
     func testViewModelSummarizesManySecretsByVault() {

--- a/approver/Tests/AgentSecretApproverTests/ApprovalPanelDecisionButtonSpecTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalPanelDecisionButtonSpecTests.swift
@@ -7,7 +7,7 @@ import XCTest
         private static let sampleExpiration: TimeInterval = 1_800_000_000
         private static let viewModelNow: TimeInterval = 1_799_999_880
 
-        private static func sampleButtonSpecs() -> [ApprovalPanelDecisionButtonSpec] {
+        private static func sampleButtonSpecs(now: TimeInterval = viewModelNow) -> [ApprovalPanelDecisionButtonSpec] {
             let request = ApprovalRequest(
                 requestID: "req_buttons",
                 nonce: "nonce_buttons",
@@ -22,7 +22,7 @@ import XCTest
             )
             let viewModel = ApprovalRequestViewModel(
                 request: request,
-                now: Date(timeIntervalSince1970: viewModelNow)
+                now: Date(timeIntervalSince1970: now)
             )
             return ApprovalPanelDecisionButtonSpec.makeAll(viewModel: viewModel)
         }
@@ -48,6 +48,8 @@ import XCTest
 
             XCTAssertNil(approveOnce.keyboardShortcut)
             XCTAssertNil(approveReusable.keyboardShortcut)
+            XCTAssertTrue(approveOnce.isEnabled)
+            XCTAssertTrue(approveReusable.isEnabled)
             XCTAssertFalse(approveOnce.subtitle.localizedCaseInsensitiveContains("default"))
             XCTAssertFalse(approveReusable.subtitle.localizedCaseInsensitiveContains("default"))
         }
@@ -61,6 +63,21 @@ import XCTest
             XCTAssertTrue(deny.subtitle.localizedCaseInsensitiveContains("default"))
             XCTAssertTrue(deny.subtitle.localizedCaseInsensitiveContains("return"))
             XCTAssertEqual(deny.keyboardShortcut, .defaultAction)
+        }
+
+        func testExpiredRequestsDisableApprovalActions() throws {
+            let specs = Self.sampleButtonSpecs(now: Self.sampleExpiration)
+            let deny: ApprovalPanelDecisionButtonSpec = try XCTUnwrap(
+                specs.first { spec in spec.decision == ApprovalDecisionKind.deny }
+            )
+            let approvalSpecs: [ApprovalPanelDecisionButtonSpec] = specs.filter(
+                \ApprovalPanelDecisionButtonSpec.decision.requiresUnexpiredRequest
+            )
+
+            XCTAssertTrue(deny.isEnabled)
+            XCTAssertEqual(deny.keyboardShortcut, .defaultAction)
+            XCTAssertEqual(approvalSpecs.map(\.isEnabled), [false, false])
+            XCTAssertTrue(approvalSpecs.allSatisfy { spec in spec.subtitle == "Request expired" })
         }
 
         deinit {

--- a/approver/Tests/AgentSecretApproverTests/ApprovalPromptExpirationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalPromptExpirationTests.swift
@@ -1,0 +1,32 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class ApprovalPromptExpirationTests: XCTestCase {
+    func testExpirationTimesOutWhenPromptClockReachesExpiry() {
+        let expiresAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let expiration = ApprovalPromptExpiration(expiresAt: expiresAt)
+
+        XCTAssertNil(expiration.timeoutDecision(at: expiresAt.addingTimeInterval(-0.001)))
+        XCTAssertEqual(expiration.timeoutDecision(at: expiresAt), .timeout)
+        XCTAssertEqual(expiration.timeoutDecision(at: expiresAt.addingTimeInterval(1)), .timeout)
+    }
+
+    func testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial() {
+        let expiresAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let expiration = ApprovalPromptExpiration(expiresAt: expiresAt)
+
+        XCTAssertEqual(
+            expiration.guardDecision(.approveOnce, at: expiresAt.addingTimeInterval(-0.001)),
+            .approveOnce
+        )
+        XCTAssertEqual(expiration.guardDecision(.approveOnce, at: expiresAt), .timeout)
+        XCTAssertEqual(expiration.guardDecision(.approveReusable, at: expiresAt.addingTimeInterval(1)), .timeout)
+        XCTAssertEqual(expiration.guardDecision(.deny, at: expiresAt.addingTimeInterval(1)), .deny)
+        XCTAssertEqual(expiration.guardDecision(.timeout, at: expiresAt.addingTimeInterval(1)), .timeout)
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}

--- a/approver/Tests/AgentSecretApproverTests/ApprovalRequestViewModelExpirationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalRequestViewModelExpirationTests.swift
@@ -1,0 +1,66 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class ApprovalRequestViewModelExpirationTests: XCTestCase {
+    private static let sampleExpiration: TimeInterval = 1_800_000_000
+    private static let viewModelNow: TimeInterval = 1_799_999_880
+
+    func testViewModelMarksLongCommandsInspectable() {
+        let script = String(repeating: "terraform import cloudflare_record.long_name ", count: 3)
+        let request = ApprovalRequest(
+            requestID: "req_long",
+            nonce: "nonce_long",
+            reason: "Run import",
+            command: ["/bin/sh", "-c", script],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: Self.sampleExpiration),
+            secrets: [
+                RequestedSecret(alias: "DEPLOY_TOKEN", ref: "op://Shared/Deploy/token")
+            ],
+            resolvedExecutable: "/bin/sh"
+        )
+        let viewModel = ApprovalRequestViewModel(request: request, now: Date(timeIntervalSince1970: Self.viewModelNow))
+
+        XCTAssertTrue(viewModel.commandNeedsInspector)
+    }
+
+    func testViewModelUpdatesCountdownAsPromptClockAdvances() {
+        let request = ApprovalRequest(
+            requestID: "req_expiring",
+            nonce: "nonce_expiring",
+            reason: "Run deploy",
+            command: ["/usr/bin/env", "deploy"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: Self.viewModelNow + 2),
+            secrets: [
+                RequestedSecret(alias: "DEPLOY_TOKEN", ref: "op://Shared/Deploy/token")
+            ],
+            resolvedExecutable: "/usr/bin/env"
+        )
+
+        let liveViewModel = ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: Self.viewModelNow)
+        )
+        let expiredViewModel = ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: Self.viewModelNow + 2)
+        )
+
+        XCTAssertFalse(liveViewModel.isExpired)
+        XCTAssertEqual(liveViewModel.compactTimeRemaining, "2 sec")
+        XCTAssertTrue(liveViewModel.scopeSummary.contains("expires in 2 sec"))
+        XCTAssertTrue(expiredViewModel.isExpired)
+        XCTAssertEqual(expiredViewModel.compactTimeRemaining, "expired")
+        XCTAssertEqual(expiredViewModel.promptQuestion, "This secret access request has expired.")
+        XCTAssertEqual(expiredViewModel.accessSummary, "can no longer receive access.")
+        XCTAssertTrue(expiredViewModel.scopeSummary.contains("request expired"))
+        XCTAssertTrue(expiredViewModel.footerMessage.contains("expired before approval"))
+        XCTAssertTrue(expiredViewModel.renderedText.contains("Time remaining: expired"))
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}


### PR DESCRIPTION
## Summary
- drive the native approval panel from a live clock so remaining-time copy updates while open
- close stale prompts by submitting a timeout once the request TTL is reached
- disable approval actions and show expired copy for already-expired requests

## Verification
- \Test Suite 'All tests' started at 2026-05-02 14:26:35.894.
Test Suite 'AgentSecretApproverPackageTests.xctest' started at 2026-05-02 14:26:35.895.
Test Suite 'ApprovalAccountScopeTests' started at 2026-05-02 14:26:35.895.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' started.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' passed (0.001 seconds).
Test Suite 'ApprovalAccountScopeTests' passed at 2026-05-02 14:26:35.896.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalControllerTests' started at 2026-05-02 14:26:35.896.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' passed (0.000 seconds).
Test Suite 'ApprovalControllerTests' passed at 2026-05-02 14:26:35.899.
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
Test Suite 'ApprovalPanelDecisionButtonSpecTests' started at 2026-05-02 14:26:35.899.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' passed (0.000 seconds).
Test Suite 'ApprovalPanelDecisionButtonSpecTests' passed at 2026-05-02 14:26:35.900.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalPanelSecretGroupRowTests' started at 2026-05-02 14:26:35.900.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' passed (0.065 seconds).
Test Suite 'ApprovalPanelSecretGroupRowTests' passed at 2026-05-02 14:26:35.965.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.065 (0.065) seconds
Test Suite 'ApprovalPromptExpirationTests' started at 2026-05-02 14:26:35.965.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' passed (0.000 seconds).
Test Suite 'ApprovalPromptExpirationTests' passed at 2026-05-02 14:26:35.965.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'ApprovalRequestViewModelExpirationTests' started at 2026-05-02 14:26:35.965.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' passed (0.000 seconds).
Test Suite 'ApprovalRequestViewModelExpirationTests' passed at 2026-05-02 14:26:35.966.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'AgentSecretApproverPackageTests.xctest' passed at 2026-05-02 14:26:35.966.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.070 (0.071) seconds
Test Suite 'All tests' passed at 2026-05-02 14:26:35.966.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.070 (0.071) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
- \
- \?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)
Test Suite 'All tests' started at 2026-05-02 14:26:37.265.
Test Suite 'AgentSecretApproverPackageTests.xctest' started at 2026-05-02 14:26:37.265.
Test Suite 'ApprovalAccountScopeTests' started at 2026-05-02 14:26:37.265.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' started.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' passed (0.001 seconds).
Test Suite 'ApprovalAccountScopeTests' passed at 2026-05-02 14:26:37.266.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalControllerTests' started at 2026-05-02 14:26:37.266.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' passed (0.000 seconds).
Test Suite 'ApprovalControllerTests' passed at 2026-05-02 14:26:37.270.
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
Test Suite 'ApprovalPanelDecisionButtonSpecTests' started at 2026-05-02 14:26:37.270.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' passed (0.000 seconds).
Test Suite 'ApprovalPanelDecisionButtonSpecTests' passed at 2026-05-02 14:26:37.271.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalPanelSecretGroupRowTests' started at 2026-05-02 14:26:37.271.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' passed (0.063 seconds).
Test Suite 'ApprovalPanelSecretGroupRowTests' passed at 2026-05-02 14:26:37.334.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.063 (0.064) seconds
Test Suite 'ApprovalPromptExpirationTests' started at 2026-05-02 14:26:37.334.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' passed (0.000 seconds).
Test Suite 'ApprovalPromptExpirationTests' passed at 2026-05-02 14:26:37.335.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'ApprovalRequestViewModelExpirationTests' started at 2026-05-02 14:26:37.335.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' passed (0.000 seconds).
Test Suite 'ApprovalRequestViewModelExpirationTests' passed at 2026-05-02 14:26:37.335.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'AgentSecretApproverPackageTests.xctest' passed at 2026-05-02 14:26:37.335.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.068 (0.070) seconds
Test Suite 'All tests' passed at 2026-05-02 14:26:37.335.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.068 (0.070) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
- \[0/1] Planning build
Building for production...
[0/2] Write swift-version--58304C5D6DBC2206.txt
Build of product 'agent-secret-approver' complete! (0.13s)
/Users/kovyrin/.codex/worktrees/0156/2026-04-28-kovyrin-agent-secret/approver/dist/AgentSecretApprover.app
- \Linting Go module: /Users/kovyrin/.codex/worktrees/0156/2026-04-28-kovyrin-agent-secret
0 issues.
?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)
?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)
Running Go coverage gate: package >= 80%, total >= 80%
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)	coverage: 82.9% of statements
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)	coverage: 86.8% of statements
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)	coverage: 80.2% of statements
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)	coverage: 85.0% of statements
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)	coverage: 83.1% of statements
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)	coverage: 81.8% of statements
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)	coverage: 81.8% of statements
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)	coverage: 83.1% of statements
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)	coverage: 83.3% of statements
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)	coverage: 86.7% of statements
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)	coverage: 84.0% of statements
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)	coverage: 80.6% of statements
coverage: ok, total 82.6%
No vulnerabilities found.
Test Suite 'All tests' started at 2026-05-02 14:26:47.923.
Test Suite 'AgentSecretApproverPackageTests.xctest' started at 2026-05-02 14:26:47.923.
Test Suite 'ApprovalAccountScopeTests' started at 2026-05-02 14:26:47.924.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' started.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' passed (0.001 seconds).
Test Suite 'ApprovalAccountScopeTests' passed at 2026-05-02 14:26:47.925.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalControllerTests' started at 2026-05-02 14:26:47.925.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' passed (0.000 seconds).
Test Suite 'ApprovalControllerTests' passed at 2026-05-02 14:26:47.928.
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
Test Suite 'ApprovalPanelDecisionButtonSpecTests' started at 2026-05-02 14:26:47.928.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' passed (0.000 seconds).
Test Suite 'ApprovalPanelDecisionButtonSpecTests' passed at 2026-05-02 14:26:47.929.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalPanelSecretGroupRowTests' started at 2026-05-02 14:26:47.929.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' passed (0.063 seconds).
Test Suite 'ApprovalPanelSecretGroupRowTests' passed at 2026-05-02 14:26:47.992.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.063 (0.063) seconds
Test Suite 'ApprovalPromptExpirationTests' started at 2026-05-02 14:26:47.992.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' passed (0.000 seconds).
Test Suite 'ApprovalPromptExpirationTests' passed at 2026-05-02 14:26:47.992.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'ApprovalRequestViewModelExpirationTests' started at 2026-05-02 14:26:47.992.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' passed (0.000 seconds).
Test Suite 'ApprovalRequestViewModelExpirationTests' passed at 2026-05-02 14:26:47.993.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'AgentSecretApproverPackageTests.xctest' passed at 2026-05-02 14:26:47.993.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.068 (0.069) seconds
Test Suite 'All tests' passed at 2026-05-02 14:26:47.993.
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.068 (0.070) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
- \?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)

Closes #12.