### PR TITLE
Render approval command argv safely

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
@@ -121,8 +121,8 @@ import Foundation
             }
             return {
                 textInspection = ApprovalPanelTextInspection(
-                    title: "Full command",
-                    text: viewModel.command
+                    title: "Command arguments",
+                    text: viewModel.commandInspectionText
                 )
             }
         }

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Expiration.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Expiration.swift
@@ -37,7 +37,7 @@ extension ApprovalRequestViewModel {
         return "Same command only • max \(uses) uses • expires in \(remaining)"
     }
 
-    static func allowReusableTitle(uses: Int, remaining: String, expired: Bool) -> String {
+    static func reuseTitle(uses: Int, remaining: String, expired: Bool) -> String {
         if expired {
             return "Allow same command briefly\nRequest expired"
         }

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
@@ -14,6 +14,7 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         let title: String
         let reason: String
         let command: String
+        let commandArgumentRows: [String]
         let cwd: String
         let scopeSummary: String
         let resolvedExecutable: String?
@@ -30,10 +31,14 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
     public let title: String
     /// Request reason.
     public let reason: String
-    /// Shell-rendered command display.
+    /// Shell-escaped compact argv display.
     public let command: String
     /// True when the command should expose a full-text inspector affordance.
     public let commandNeedsInspector: Bool
+    /// Structured argv rows for the full command inspector.
+    public let commandInspectionText: String
+    /// One view model per argv element.
+    let commandArguments: [CommandArgumentViewModel]
     /// Executable path displayed in the approval summary.
     public let executable: String
     /// Working directory display.
@@ -84,8 +89,10 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         title = "Secret Access Request"
         reason = request.reason
         executable = Self.executableName(request.resolvedExecutable ?? request.command.first)
-        command = Self.commandDisplay(request.command, resolvedExecutable: request.resolvedExecutable)
-        commandNeedsInspector = Self.commandNeedsInspector(command)
+        commandArguments = Self.commandArguments(request.command)
+        command = Self.commandDisplay(commandArguments)
+        commandNeedsInspector = Self.commandNeedsInspector(command, arguments: commandArguments)
+        commandInspectionText = Self.commandInspectionText(commandArguments)
         cwd = request.cwd
         projectFolder = Self.displayPath(request.cwd)
         resolvedExecutable = request.resolvedExecutable
@@ -104,16 +111,9 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         compactTimeRemaining = timeRemaining
         let reusableUseLimit: Int = request.reusableUses
         reusableUses = reusableUseLimit
-        scopeSummary = Self.scopeSummary(
-            uses: reusableUseLimit,
-            remaining: compactTimeRemaining,
-            expired: isExpired
-        )
-        allowReusableTitle = Self.allowReusableTitle(
-            uses: reusableUseLimit,
-            remaining: compactTimeRemaining,
-            expired: isExpired
-        )
+        let remainingText: String = compactTimeRemaining
+        scopeSummary = Self.scopeSummary(uses: reusableUseLimit, remaining: remainingText, expired: isExpired)
+        allowReusableTitle = Self.reuseTitle(uses: reusableUseLimit, remaining: remainingText, expired: isExpired)
         printsEnvironmentWarning = Self.environmentWarning(for: request)
         overrideWarning = Self.overrideWarning(for: request)
         footerMessage = Self.footerMessage(secretCount: secretPresentation.count, expired: isExpired)
@@ -123,6 +123,7 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
                 title: title,
                 reason: reason,
                 command: command,
+                commandArgumentRows: commandArguments.map(\.inspectorLine),
                 cwd: cwd,
                 scopeSummary: scopeSummary,
                 resolvedExecutable: resolvedExecutable,
@@ -181,9 +182,13 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
             viewModel.title,
             "Reason: \(viewModel.reason)",
             "Command: \(viewModel.command)",
+            "Command argv:"
+        ]
+        lines.append(contentsOf: viewModel.commandArgumentRows)
+        lines.append(contentsOf: [
             "Working directory: \(viewModel.cwd)",
             "Scope: \(viewModel.scopeSummary)"
-        ]
+        ])
         if let resolvedExecutable: String = viewModel.resolvedExecutable, !resolvedExecutable.isEmpty {
             lines.append("Resolved binary: \(resolvedExecutable)")
         }
@@ -207,20 +212,25 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         return "Will replace existing variables: \(request.overriddenAliases.joined(separator: ", "))"
     }
 
-    private static func commandDisplay(_ command: [String], resolvedExecutable: String?) -> String {
-        guard !command.isEmpty else {
-            return "unknown command"
+    private static func commandArguments(_ command: [String]) -> [CommandArgumentViewModel] {
+        command.enumerated().map { index, value in
+            CommandArgumentViewModel(index: index, value: value)
         }
-        guard let resolvedExecutable: String, !resolvedExecutable.isEmpty else {
-            return command.joined(separator: " ")
-        }
-        var parts: [String] = command
-        parts[0] = resolvedExecutable
-        return parts.joined(separator: " ")
     }
 
-    private static func commandNeedsInspector(_ command: String) -> Bool {
-        command.count > commandInspectorThreshold || command.contains("\n")
+    private static func commandDisplay(_ arguments: [CommandArgumentViewModel]) -> String {
+        guard !arguments.isEmpty else {
+            return "unknown command"
+        }
+        return arguments.map(\.escaped).joined(separator: " ")
+    }
+
+    private static func commandInspectionText(_ arguments: [CommandArgumentViewModel]) -> String {
+        arguments.map(\.inspectorLine).joined(separator: "\n")
+    }
+
+    private static func commandNeedsInspector(_ command: String, arguments: [CommandArgumentViewModel]) -> Bool {
+        command.count > commandInspectorThreshold || arguments.contains(where: \.needsInspector)
     }
 
     private static func executableName(_ path: String?) -> String {

--- a/approver/Sources/AgentSecretApprover/CommandArgumentViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/CommandArgumentViewModel.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+struct CommandArgumentViewModel: Equatable {
+    private enum ScalarCode {
+        static let backspace: UInt32 = 8
+        static let backslash: UInt32 = 92
+        static let bell: UInt32 = 7
+        static let carriageReturn: UInt32 = 13
+        static let controlDelete: UInt32 = 127
+        static let escape: UInt32 = 27
+        static let horizontalTab: UInt32 = 9
+        static let lineFeed: UInt32 = 10
+        static let printableHighStart: UInt32 = 128
+        static let printablePrefixEnd: UInt32 = 38
+        static let printablePrefixStart: UInt32 = 32
+        static let printableSuffixEnd: UInt32 = 126
+        static let printableSuffixStart: UInt32 = 93
+        static let printableWithoutBackslashEnd: UInt32 = 91
+        static let printableWithoutBackslashStart: UInt32 = 40
+        static let singleQuote: UInt32 = 39
+    }
+
+    let index: Int
+    let value: String
+    let escaped: String
+    let needsInspector: Bool
+
+    var inspectorLine: String {
+        "argv[\(index)]: \(escaped)"
+    }
+
+    init(index: Int, value: String) {
+        self.index = index
+        self.value = value
+        escaped = Self.shellEscaped(value)
+        needsInspector = Self.needsInspector(value)
+    }
+
+    private static func shellEscaped(_ value: String) -> String {
+        if value.isEmpty {
+            return "''"
+        }
+        if value.unicodeScalars.contains(where: { scalar in Self.isASCIIControlCharacter(scalar) }) {
+            return "$'\(ansiCEscaped(value))'"
+        }
+        return "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    private static func ansiCEscaped(_ value: String) -> String {
+        let escaped = value.unicodeScalars.map { scalar -> String in
+            switch scalar.value {
+            case ScalarCode.bell:
+                return "\\a"
+
+            case ScalarCode.backspace:
+                return "\\b"
+
+            case ScalarCode.horizontalTab:
+                return "\\t"
+
+            case ScalarCode.lineFeed:
+                return "\\n"
+
+            case ScalarCode.carriageReturn:
+                return "\\r"
+
+            case ScalarCode.escape:
+                return "\\e"
+
+            case ScalarCode.singleQuote:
+                return "\\'"
+
+            case ScalarCode.backslash:
+                return "\\\\"
+
+            default:
+                if Self.isPrintableLiteral(scalar) {
+                    return String(scalar)
+                }
+                return String(format: "\\x%02X", scalar.value)
+            }
+        }
+        return escaped.joined()
+    }
+
+    private static func needsInspector(_ value: String) -> Bool {
+        if value.isEmpty || value.hasPrefix("-") {
+            return true
+        }
+        let shellMetacharacters = CharacterSet(charactersIn: "|&;<>()$`\\\"'*!?[]{}")
+        return value.rangeOfCharacter(from: .whitespacesAndNewlines) != nil ||
+            value.rangeOfCharacter(from: .controlCharacters) != nil ||
+            value.rangeOfCharacter(from: shellMetacharacters) != nil
+    }
+
+    private static func isASCIIControlCharacter(_ scalar: Unicode.Scalar) -> Bool {
+        scalar.value < ScalarCode.printablePrefixStart || scalar.value == ScalarCode.controlDelete
+    }
+
+    private static func isPrintableLiteral(_ scalar: Unicode.Scalar) -> Bool {
+        let value = scalar.value
+        return (ScalarCode.printablePrefixStart ... ScalarCode.printablePrefixEnd).contains(value) ||
+            (ScalarCode.printableWithoutBackslashStart ... ScalarCode.printableWithoutBackslashEnd).contains(value) ||
+            (ScalarCode.printableSuffixStart ... ScalarCode.printableSuffixEnd).contains(value) ||
+            value >= ScalarCode.printableHighStart
+    }
+}

--- a/approver/Tests/AgentSecretApproverTests/ApprovalCommandRenderingTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalCommandRenderingTests.swift
@@ -1,0 +1,87 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class ApprovalCommandRenderingTests: XCTestCase {
+    private static let sampleExpiration: TimeInterval = 1_800_000_000
+    private static let viewModelNow: TimeInterval = 1_799_999_880
+
+    private static func viewModel(
+        command: [String],
+        resolvedExecutable: String? = nil
+    ) -> ApprovalRequestViewModel {
+        let request = ApprovalRequest(
+            requestID: "req_command",
+            nonce: "nonce_command",
+            reason: "Review argv",
+            command: command,
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: sampleExpiration),
+            secrets: [
+                RequestedSecret(alias: "DEPLOY_TOKEN", ref: "op://Shared/Deploy/token")
+            ],
+            resolvedExecutable: resolvedExecutable
+        )
+        return ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: viewModelNow)
+        )
+    }
+
+    func testCompactCommandDisplayShellEscapesEveryArgvElement() {
+        let argv = [
+            "/bin/echo",
+            "hello world",
+            "it's",
+            "line\nbreak",
+            "--flag",
+            "$(rm -rf /)",
+            "snowman ☃",
+            "bell\u{0007}",
+            "\u{001F}unit"
+        ]
+        let viewModel = Self.viewModel(command: argv)
+
+        XCTAssertEqual(
+            viewModel.command,
+            "'/bin/echo' 'hello world' 'it'\\''s' $'line\\nbreak' '--flag' " +
+                "'$(rm -rf /)' 'snowman ☃' $'bell\\a' $'\\x1Funit'"
+        )
+        XCTAssertNotEqual(viewModel.command, argv.joined(separator: " "))
+        XCTAssertFalse(viewModel.command.contains("\n"))
+        XCTAssertFalse(viewModel.command.contains("\u{0007}"))
+        XCTAssertFalse(viewModel.command.contains("\u{001F}"))
+    }
+
+    func testStructuredCommandInspectorPreservesArgvBoundaries() {
+        let viewModel = Self.viewModel(command: [
+            "/usr/bin/env",
+            "NAME=value with space",
+            "--",
+            "printf",
+            "%s\n",
+            "emoji-🚀"
+        ])
+
+        XCTAssertTrue(viewModel.commandNeedsInspector)
+        XCTAssertEqual(viewModel.commandArguments.map(\.index), [0, 1, 2, 3, 4, 5])
+        XCTAssertTrue(viewModel.commandInspectionText.contains("argv[1]: 'NAME=value with space'"))
+        XCTAssertTrue(viewModel.commandInspectionText.contains("argv[2]: '--'"))
+        XCTAssertTrue(viewModel.commandInspectionText.contains("argv[4]: $'%s\\n'"))
+        XCTAssertTrue(viewModel.commandInspectionText.contains("argv[5]: 'emoji-🚀'"))
+    }
+
+    func testCommandDisplayKeepsOriginalArgvZeroSeparateFromResolvedBinary() {
+        let viewModel = Self.viewModel(
+            command: ["terraform", "plan"],
+            resolvedExecutable: "/opt/homebrew/bin/terraform"
+        )
+
+        XCTAssertEqual(viewModel.command, "'terraform' 'plan'")
+        XCTAssertTrue(viewModel.renderedText.contains("Resolved binary: /opt/homebrew/bin/terraform"))
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}


### PR DESCRIPTION
## Summary
- replace plain argv joining with deterministic shell-escaped argument rendering
- add structured command-argument inspector rows with argv indexes
- preserve original argv[0] separately from the resolved executable display

## Verification
- \Test Suite 'All tests' started at 2026-05-02 14:33:24.461.
Test Suite 'AgentSecretApproverPackageTests.xctest' started at 2026-05-02 14:33:24.461.
Test Suite 'ApprovalAccountScopeTests' started at 2026-05-02 14:33:24.461.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' started.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' passed (0.001 seconds).
Test Suite 'ApprovalAccountScopeTests' passed at 2026-05-02 14:33:24.462.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalCommandRenderingTests' started at 2026-05-02 14:33:24.462.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCommandDisplayKeepsOriginalArgvZeroSeparateFromResolvedBinary]' started.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCommandDisplayKeepsOriginalArgvZeroSeparateFromResolvedBinary]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCompactCommandDisplayShellEscapesEveryArgvElement]' started.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCompactCommandDisplayShellEscapesEveryArgvElement]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testStructuredCommandInspectorPreservesArgvBoundaries]' started.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testStructuredCommandInspectorPreservesArgvBoundaries]' passed (0.000 seconds).
Test Suite 'ApprovalCommandRenderingTests' passed at 2026-05-02 14:33:24.463.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalControllerTests' started at 2026-05-02 14:33:24.463.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' passed (0.002 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' passed (0.000 seconds).
Test Suite 'ApprovalControllerTests' passed at 2026-05-02 14:33:24.466.
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
Test Suite 'ApprovalPanelDecisionButtonSpecTests' started at 2026-05-02 14:33:24.466.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' passed (0.000 seconds).
Test Suite 'ApprovalPanelDecisionButtonSpecTests' passed at 2026-05-02 14:33:24.467.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalPanelSecretGroupRowTests' started at 2026-05-02 14:33:24.467.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' passed (0.055 seconds).
Test Suite 'ApprovalPanelSecretGroupRowTests' passed at 2026-05-02 14:33:24.522.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.055 (0.056) seconds
Test Suite 'ApprovalPromptExpirationTests' started at 2026-05-02 14:33:24.522.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' passed (0.000 seconds).
Test Suite 'ApprovalPromptExpirationTests' passed at 2026-05-02 14:33:24.523.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'ApprovalRequestViewModelExpirationTests' started at 2026-05-02 14:33:24.523.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' passed (0.000 seconds).
Test Suite 'ApprovalRequestViewModelExpirationTests' passed at 2026-05-02 14:33:24.523.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'AgentSecretApproverPackageTests.xctest' passed at 2026-05-02 14:33:24.523.
	 Executed 20 tests, with 0 failures (0 unexpected) in 0.061 (0.062) seconds
Test Suite 'All tests' passed at 2026-05-02 14:33:24.523.
	 Executed 20 tests, with 0 failures (0 unexpected) in 0.061 (0.063) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
- \
- \?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)
Test Suite 'All tests' started at 2026-05-02 14:33:25.778.
Test Suite 'AgentSecretApproverPackageTests.xctest' started at 2026-05-02 14:33:25.778.
Test Suite 'ApprovalAccountScopeTests' started at 2026-05-02 14:33:25.778.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' started.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' passed (0.001 seconds).
Test Suite 'ApprovalAccountScopeTests' passed at 2026-05-02 14:33:25.779.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalCommandRenderingTests' started at 2026-05-02 14:33:25.779.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCommandDisplayKeepsOriginalArgvZeroSeparateFromResolvedBinary]' started.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCommandDisplayKeepsOriginalArgvZeroSeparateFromResolvedBinary]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCompactCommandDisplayShellEscapesEveryArgvElement]' started.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCompactCommandDisplayShellEscapesEveryArgvElement]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testStructuredCommandInspectorPreservesArgvBoundaries]' started.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testStructuredCommandInspectorPreservesArgvBoundaries]' passed (0.000 seconds).
Test Suite 'ApprovalCommandRenderingTests' passed at 2026-05-02 14:33:25.780.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalControllerTests' started at 2026-05-02 14:33:25.780.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' passed (0.000 seconds).
Test Suite 'ApprovalControllerTests' passed at 2026-05-02 14:33:25.783.
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
Test Suite 'ApprovalPanelDecisionButtonSpecTests' started at 2026-05-02 14:33:25.783.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' passed (0.000 seconds).
Test Suite 'ApprovalPanelDecisionButtonSpecTests' passed at 2026-05-02 14:33:25.784.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalPanelSecretGroupRowTests' started at 2026-05-02 14:33:25.784.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' passed (0.054 seconds).
Test Suite 'ApprovalPanelSecretGroupRowTests' passed at 2026-05-02 14:33:25.838.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.054 (0.054) seconds
Test Suite 'ApprovalPromptExpirationTests' started at 2026-05-02 14:33:25.838.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' passed (0.000 seconds).
Test Suite 'ApprovalPromptExpirationTests' passed at 2026-05-02 14:33:25.839.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'ApprovalRequestViewModelExpirationTests' started at 2026-05-02 14:33:25.839.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' passed (0.000 seconds).
Test Suite 'ApprovalRequestViewModelExpirationTests' passed at 2026-05-02 14:33:25.839.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'AgentSecretApproverPackageTests.xctest' passed at 2026-05-02 14:33:25.839.
	 Executed 20 tests, with 0 failures (0 unexpected) in 0.060 (0.061) seconds
Test Suite 'All tests' passed at 2026-05-02 14:33:25.839.
	 Executed 20 tests, with 0 failures (0 unexpected) in 0.060 (0.061) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
- \[0/1] Planning build
Building for production...
[0/2] Write swift-version--58304C5D6DBC2206.txt
Build of product 'agent-secret-approver' complete! (0.12s)
/Users/kovyrin/.codex/worktrees/0156/2026-04-28-kovyrin-agent-secret/approver/dist/AgentSecretApprover.app
- \Linting Go module: /Users/kovyrin/.codex/worktrees/0156/2026-04-28-kovyrin-agent-secret
0 issues.
?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)
?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)
Running Go coverage gate: package >= 80%, total >= 80%
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)	coverage: 82.9% of statements
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)	coverage: 86.8% of statements
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)	coverage: 80.2% of statements
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)	coverage: 85.0% of statements
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)	coverage: 83.1% of statements
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)	coverage: 81.8% of statements
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)	coverage: 81.8% of statements
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)	coverage: 83.1% of statements
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)	coverage: 83.3% of statements
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)	coverage: 86.7% of statements
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)	coverage: 84.0% of statements
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)	coverage: 80.6% of statements
coverage: ok, total 82.6%
No vulnerabilities found.
Test Suite 'All tests' started at 2026-05-02 14:33:34.953.
Test Suite 'AgentSecretApproverPackageTests.xctest' started at 2026-05-02 14:33:34.954.
Test Suite 'ApprovalAccountScopeTests' started at 2026-05-02 14:33:34.954.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' started.
Test Case '-[AgentSecretApproverTests.ApprovalAccountScopeTests testViewModelDistinguishesSameReferenceAcrossAccounts]' passed (0.001 seconds).
Test Suite 'ApprovalAccountScopeTests' passed at 2026-05-02 14:33:34.955.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalCommandRenderingTests' started at 2026-05-02 14:33:34.955.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCommandDisplayKeepsOriginalArgvZeroSeparateFromResolvedBinary]' started.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCommandDisplayKeepsOriginalArgvZeroSeparateFromResolvedBinary]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCompactCommandDisplayShellEscapesEveryArgvElement]' started.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testCompactCommandDisplayShellEscapesEveryArgvElement]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testStructuredCommandInspectorPreservesArgvBoundaries]' started.
Test Case '-[AgentSecretApproverTests.ApprovalCommandRenderingTests testStructuredCommandInspectorPreservesArgvBoundaries]' passed (0.000 seconds).
Test Suite 'ApprovalCommandRenderingTests' passed at 2026-05-02 14:33:34.955.
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalControllerTests' started at 2026-05-02 14:33:34.955.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testReusableDecisionCarriesThreeUseLimit]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSharedApprovalFixturesDecode]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientFetchesAndSubmitsDecision]' passed (0.001 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSocketDaemonClientReportsDaemonErrors]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testSubmitsApproveOnceDecisionWithoutSecretValues]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalControllerTests testViewModelSummarizesManySecretsByVault]' passed (0.000 seconds).
Test Suite 'ApprovalControllerTests' passed at 2026-05-02 14:33:34.958.
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
Test Suite 'ApprovalPanelDecisionButtonSpecTests' started at 2026-05-02 14:33:34.958.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testApprovalActionsRequirePointerSelection]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyCopyDescribesReturnKeyDefault]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testDenyIsTheOnlyDefaultApprovalPanelAction]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelDecisionButtonSpecTests testExpiredRequestsDisableApprovalActions]' passed (0.000 seconds).
Test Suite 'ApprovalPanelDecisionButtonSpecTests' passed at 2026-05-02 14:33:34.959.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ApprovalPanelSecretGroupRowTests' started at 2026-05-02 14:33:34.959.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPanelSecretGroupRowTests testExpandedSecretGroupRowAllocatesReadableListSpace]' passed (0.056 seconds).
Test Suite 'ApprovalPanelSecretGroupRowTests' passed at 2026-05-02 14:33:35.015.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.056 (0.056) seconds
Test Suite 'ApprovalPromptExpirationTests' started at 2026-05-02 14:33:35.015.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testExpirationTimesOutWhenPromptClockReachesExpiry]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' started.
Test Case '-[AgentSecretApproverTests.ApprovalPromptExpirationTests testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial]' passed (0.000 seconds).
Test Suite 'ApprovalPromptExpirationTests' passed at 2026-05-02 14:33:35.016.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'ApprovalRequestViewModelExpirationTests' started at 2026-05-02 14:33:35.016.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelMarksLongCommandsInspectable]' passed (0.000 seconds).
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' started.
Test Case '-[AgentSecretApproverTests.ApprovalRequestViewModelExpirationTests testViewModelUpdatesCountdownAsPromptClockAdvances]' passed (0.000 seconds).
Test Suite 'ApprovalRequestViewModelExpirationTests' passed at 2026-05-02 14:33:35.016.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'AgentSecretApproverPackageTests.xctest' passed at 2026-05-02 14:33:35.016.
	 Executed 20 tests, with 0 failures (0 unexpected) in 0.061 (0.062) seconds
Test Suite 'All tests' passed at 2026-05-02 14:33:35.016.
	 Executed 20 tests, with 0 failures (0 unexpected) in 0.061 (0.063) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
- \?   	github.com/kovyrin/agent-secret/cmd/agent-secret	[no test files]
ok  	github.com/kovyrin/agent-secret/cmd/agent-secretd	(cached)
ok  	github.com/kovyrin/agent-secret/internal/audit	(cached)
ok  	github.com/kovyrin/agent-secret/internal/cli	(cached)
ok  	github.com/kovyrin/agent-secret/internal/daemon	(cached)
ok  	github.com/kovyrin/agent-secret/internal/envfile	(cached)
ok  	github.com/kovyrin/agent-secret/internal/execwrap	(cached)
ok  	github.com/kovyrin/agent-secret/internal/opresolver	(cached)
ok  	github.com/kovyrin/agent-secret/internal/peercred	(cached)
ok  	github.com/kovyrin/agent-secret/internal/policy	(cached)
ok  	github.com/kovyrin/agent-secret/internal/processhardening	(cached)
ok  	github.com/kovyrin/agent-secret/internal/profileconfig	(cached)
ok  	github.com/kovyrin/agent-secret/internal/request	(cached)
ok  	github.com/kovyrin/agent-secret/internal/secretmem	(cached)

Closes #13.