### PR TITLE
Make approval presenter main-actor safe

### DIFF
--- a/approver/Sources/AgentSecretApprover/AppKitApprovalPresenter.swift
+++ b/approver/Sources/AgentSecretApprover/AppKitApprovalPresenter.swift
@@ -77,11 +77,11 @@ public final class AppKitApprovalPresenter: ApprovalPresenter {
     #endif
 
     /// Presents the request and returns the operator decision.
+    @preconcurrency
+    @MainActor
     public func decide(for request: ApprovalRequest) -> ApprovalDecisionKind {
         #if canImport(AppKit)
-            MainActor.assumeIsolated {
-                Self.decideOnMain(for: request)
-            }
+            Self.decideOnMain(for: request)
         #else
             .timeout
         #endif

--- a/approver/Sources/AgentSecretApprover/ApprovalController.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalController.swift
@@ -20,6 +20,8 @@ public final class ApprovalController {
     }
 
     /// Executes one approval interaction and returns the submitted decision.
+    @preconcurrency
+    @MainActor
     public func run() throws -> ApprovalDecision {
         logger.record("approval_request_fetch_started", requestID: nil)
         let request: ApprovalRequest = try client.fetchPendingRequest()

--- a/approver/Sources/AgentSecretApprover/ApprovalPresenter.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPresenter.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 /// Presents an approval request and returns the operator decision.
+@preconcurrency
+@MainActor
 public protocol ApprovalPresenter {
     /// Returns the decision selected for a request.
     func decide(for request: ApprovalRequest) -> ApprovalDecisionKind

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
@@ -112,6 +112,7 @@ final class ApprovalControllerTests: XCTestCase {
         Data(#"{"type":"ok","version":1}"#.utf8)
     }
 
+    @MainActor
     func testReusableDecisionCarriesThreeUseLimit() throws {
         let request: ApprovalRequest = Self.sampleRequest
         let client = MockDaemonClient(request: request)
@@ -125,6 +126,13 @@ final class ApprovalControllerTests: XCTestCase {
 
         XCTAssertEqual(decision.decision, .approveReusable)
         XCTAssertEqual(decision.reusableUses, Self.expectedReusableUses)
+    }
+
+    @MainActor
+    func testPresenterContractIsMainActorAccessible() {
+        let presenter: ApprovalPresenter = StaticDecisionPresenter(decision: .deny)
+
+        XCTAssertEqual(presenter.decide(for: Self.sampleRequest), .deny)
     }
 
     func testSharedApprovalFixturesDecode() throws {
@@ -201,6 +209,7 @@ final class ApprovalControllerTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testSubmitsApproveOnceDecisionWithoutSecretValues() throws {
         let request: ApprovalRequest = Self.sampleRequest
         let client = MockDaemonClient(request: request)


### PR DESCRIPTION
## Summary

- mark the approval presenter contract as main-actor isolated so callers cannot synchronously drive AppKit off the main actor
- remove `MainActor.assumeIsolated` from `AppKitApprovalPresenter` and call the already-main-actor presenter path directly
- update controller tests and add a protocol-level presenter test that compiles only from a main-actor context

## Verification

- `cd approver && swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `cd approver && swift test -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `cd approver && swift test`
- `mise run lint:swift`
- `mise run test`
- `mise run build`
- `mise run lint`
- `mise run test:race`

Closes #14.
