### PR TITLE
Validate Swift daemon response envelopes

### DIFF
--- a/approver/Sources/AgentSecretApprover/SocketDaemonClient.swift
+++ b/approver/Sources/AgentSecretApprover/SocketDaemonClient.swift
@@ -24,6 +24,8 @@ public final class SocketDaemonClient: ApprovalDaemonClient {
     }
 
     private static let protocolVersion: Int = 1
+    private static let typeError: String = "error"
+    private static let typeOK: String = "ok"
 
     private let transport: LineTransport
     private let decoder: JSONDecoder
@@ -53,21 +55,15 @@ public final class SocketDaemonClient: ApprovalDaemonClient {
             version: Self.protocolVersion
         )
         try send(request)
-        let data: Data = try transport.readLine()
-        let header: DaemonHeader = try decoder.decode(DaemonHeader.self, from: data)
-        if header.type == "error" {
-            throw try daemonError(from: data)
-        }
-        guard header.type == "ok" else {
-            throw SocketDaemonClientError.invalidResponse("unexpected response type \(header.type)")
-        }
-        let response: DaemonEnvelope<ApprovalRequest> = try decoder.decode(
-            DaemonEnvelope<ApprovalRequest>.self,
-            from: data
-        )
+        let response: DaemonEnvelope<ApprovalRequest> = try readOKEnvelope()
         guard let payload: ApprovalRequest = response.payload else {
             throw SocketDaemonClientError.invalidResponse("missing approval request payload")
         }
+        try validateCorrelation(
+            response,
+            requestID: payload.requestID,
+            nonce: payload.nonce
+        )
         return payload
     }
 
@@ -81,13 +77,45 @@ public final class SocketDaemonClient: ApprovalDaemonClient {
             version: Self.protocolVersion
         )
         try send(request)
+        let response: DaemonEnvelope<EmptyPayload> = try readOKEnvelope()
+        try validateCorrelation(
+            response,
+            requestID: decision.requestID,
+            nonce: decision.nonce
+        )
+    }
+
+    private func readOKEnvelope<Payload: Codable>() throws -> DaemonEnvelope<Payload> {
         let data: Data = try transport.readLine()
         let header: DaemonHeader = try decoder.decode(DaemonHeader.self, from: data)
-        if header.type == "error" {
+        try validateHeader(header)
+        if header.type == Self.typeError {
             throw try daemonError(from: data)
         }
-        guard header.type == "ok" else {
+        guard header.type == Self.typeOK else {
             throw SocketDaemonClientError.invalidResponse("unexpected response type \(header.type)")
+        }
+        return try decoder.decode(DaemonEnvelope<Payload>.self, from: data)
+    }
+
+    private func validateHeader(_ header: DaemonHeader) throws {
+        guard header.version == Self.protocolVersion else {
+            throw SocketDaemonClientError.invalidResponse(
+                "unsupported protocol version \(header.version)"
+            )
+        }
+    }
+
+    private func validateCorrelation(
+        _ response: DaemonEnvelope<some Codable>,
+        requestID: String,
+        nonce: String
+    ) throws {
+        guard response.requestID == requestID else {
+            throw SocketDaemonClientError.invalidResponse("response request id mismatch")
+        }
+        guard response.nonce == nonce else {
+            throw SocketDaemonClientError.invalidResponse("response nonce mismatch")
         }
     }
 

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
@@ -3,30 +3,6 @@ import Foundation
 import XCTest
 
 final class ApprovalControllerTests: XCTestCase {
-    private final class MemoryLineTransport: LineTransport {
-        private var reads: [Data]
-        private(set) var writtenStrings: [String] = []
-
-        init(reads: [Data]) {
-            self.reads = reads
-        }
-
-        func readLine() throws -> Data {
-            guard !reads.isEmpty else {
-                throw SocketDaemonClientError.disconnected
-            }
-            return reads.removeFirst()
-        }
-
-        func writeLine(_ data: Data) {
-            writtenStrings.append(String(data: data, encoding: .utf8) ?? "")
-        }
-
-        deinit {
-            /* Required by SwiftLint. */
-        }
-    }
-
     private final class RecordingLogger: ApprovalLogger {
         private(set) var events: [String] = []
 
@@ -91,25 +67,9 @@ final class ApprovalControllerTests: XCTestCase {
         ]
     }
 
-    private static func daemonEnvelope(
-        type: String,
-        requestID: String,
-        nonce: String,
-        payload: String
-    ) -> Data {
-        let json = """
-        {"nonce":"\(nonce)","payload":\(payload),"request_id":"\(requestID)","type":"\(type)","version":1}
-        """
-        return Data(json.utf8)
-    }
-
     private static func fixtureData(_ name: String) throws -> Data {
         let url: URL = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: "json"))
         return try Data(contentsOf: url)
-    }
-
-    private static func okEnvelope() -> Data {
-        Data(#"{"type":"ok","version":1}"#.utf8)
     }
 
     @MainActor
@@ -160,53 +120,6 @@ final class ApprovalControllerTests: XCTestCase {
         XCTAssertEqual(decision.nonce, "nonce_456")
         XCTAssertEqual(decision.decision, .approveReusable)
         XCTAssertEqual(decision.reusableUses, Self.expectedReusableUses)
-    }
-
-    func testSocketDaemonClientFetchesAndSubmitsDecision() throws {
-        let payload: String = try String(data: Self.fixtureData("approval_request"), encoding: .utf8)?
-            .replacingOccurrences(
-                of: #""expiresAt": "2027-01-15T08:00:00Z""#,
-                with: #""expiresAt": "2027-01-15T08:00:00.123456Z""#
-            ) ?? "{}"
-        let requestData: Data = Self.daemonEnvelope(
-            type: "ok",
-            requestID: "req_123",
-            nonce: "nonce_456",
-            payload: payload
-        )
-        let transport = MemoryLineTransport(reads: [requestData, Self.okEnvelope()])
-        let client = SocketDaemonClient(transport: transport)
-
-        let request: ApprovalRequest = try client.fetchPendingRequest()
-        XCTAssertEqual(request.requestID, "req_123")
-        try client.submit(
-            ApprovalDecision(
-                requestID: request.requestID,
-                nonce: request.nonce,
-                decision: .approveOnce
-            )
-        )
-
-        let written: String = transport.writtenStrings.joined(separator: "\n")
-        XCTAssertTrue(written.contains("approval.pending"))
-        XCTAssertTrue(written.contains("approval.decision"))
-        XCTAssertFalse(written.contains(Self.canarySecretValue))
-    }
-
-    func testSocketDaemonClientReportsDaemonErrors() {
-        let errorLine = Data(
-            """
-            {"payload":{"code":"stale_approval","message":"stale approval response"},"type":"error","version":1}
-            """.utf8
-        )
-        let client = SocketDaemonClient(transport: MemoryLineTransport(reads: [errorLine]))
-
-        XCTAssertThrowsError(try client.fetchPendingRequest()) { error in
-            XCTAssertEqual(
-                error as? SocketDaemonClientError,
-                .daemonError("stale_approval", "stale approval response")
-            )
-        }
     }
 
     @MainActor

--- a/approver/Tests/AgentSecretApproverTests/SocketDaemonClientTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/SocketDaemonClientTests.swift
@@ -1,0 +1,269 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class SocketDaemonClientTests: XCTestCase {
+    private final class MemoryLineTransport: LineTransport {
+        private var reads: [Data]
+        private(set) var writtenStrings: [String] = []
+
+        init(reads: [Data]) {
+            self.reads = reads
+        }
+
+        func readLine() throws -> Data {
+            guard !reads.isEmpty else {
+                throw SocketDaemonClientError.disconnected
+            }
+            return reads.removeFirst()
+        }
+
+        func writeLine(_ data: Data) {
+            writtenStrings.append(String(data: data, encoding: .utf8) ?? "")
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+
+    private static let expectedProtocolVersion: Int = 1
+    private static let requestID: String = "req_123"
+    private static let responseOK: String = "ok"
+    private static let sampleExpiration: TimeInterval = 1_800_000_000
+    private static let secretCanary: String = "synthetic-secret-value"
+    private static let staleNonce: String = "nonce_stale"
+    private static let staleRequestID: String = "req_stale"
+    private static let unsupportedProtocolVersion: Int = 99
+
+    private static var sampleDecision: ApprovalDecision {
+        ApprovalDecision(
+            requestID: requestID,
+            nonce: "nonce_456",
+            decision: .approveOnce
+        )
+    }
+
+    private static var sampleRequest: ApprovalRequest {
+        ApprovalRequest(
+            requestID: requestID,
+            nonce: "nonce_456",
+            reason: "Run Terraform plan for staging",
+            command: ["/opt/homebrew/bin/terraform", "plan"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: sampleExpiration),
+            secrets: [
+                RequestedSecret(alias: "EXAMPLE_TOKEN", ref: "op://Example Vault/Example Item/token")
+            ],
+            resolvedExecutable: "/opt/homebrew/bin/terraform"
+        )
+    }
+
+    private static func approvalResponse(
+        version: Int,
+        type: String,
+        envelopeRequestID: String,
+        envelopeNonce: String
+    ) throws -> Data {
+        try encode(
+            DaemonEnvelope(
+                nonce: envelopeNonce,
+                payload: sampleRequest,
+                requestID: envelopeRequestID,
+                type: type,
+                version: version
+            )
+        )
+    }
+
+    private static func decisionResponse(
+        requestID: String,
+        nonce: String
+    ) throws -> Data {
+        try encode(
+            DaemonEnvelope<EmptyPayload>(
+                nonce: nonce,
+                payload: nil,
+                requestID: requestID,
+                type: responseOK,
+                version: expectedProtocolVersion
+            )
+        )
+    }
+
+    private static func errorResponse() -> Data {
+        Data(
+            """
+            {"payload":{"code":"stale_approval","message":"stale approval response"},"type":"error","version":1}
+            """.utf8
+        )
+    }
+
+    private static func encode(_ envelope: DaemonEnvelope<some Any>) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(envelope)
+    }
+
+    private func assertInvalidResponse(
+        _ expected: String,
+        _ expression: () throws -> Void
+    ) {
+        XCTAssertThrowsError(try expression()) { error in
+            XCTAssertEqual(error as? SocketDaemonClientError, .invalidResponse(expected))
+        }
+    }
+
+    func testFetchRejectsUnsupportedProtocolVersion() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [
+                    Self.approvalResponse(
+                        version: Self.unsupportedProtocolVersion,
+                        type: Self.responseOK,
+                        envelopeRequestID: Self.requestID,
+                        envelopeNonce: Self.sampleDecision.nonce
+                    )
+                ]
+            )
+        )
+
+        assertInvalidResponse("unsupported protocol version 99") {
+            _ = try client.fetchPendingRequest()
+        }
+    }
+
+    func testFetchRejectsUnexpectedResponseType() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [
+                    Self.approvalResponse(
+                        version: Self.expectedProtocolVersion,
+                        type: "approval.pending",
+                        envelopeRequestID: Self.requestID,
+                        envelopeNonce: Self.sampleDecision.nonce
+                    )
+                ]
+            )
+        )
+
+        assertInvalidResponse("unexpected response type approval.pending") {
+            _ = try client.fetchPendingRequest()
+        }
+    }
+
+    func testFetchRejectsMismatchedResponseRequestID() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [
+                    Self.approvalResponse(
+                        version: Self.expectedProtocolVersion,
+                        type: Self.responseOK,
+                        envelopeRequestID: Self.staleRequestID,
+                        envelopeNonce: Self.sampleDecision.nonce
+                    )
+                ]
+            )
+        )
+
+        assertInvalidResponse("response request id mismatch") {
+            _ = try client.fetchPendingRequest()
+        }
+    }
+
+    func testFetchRejectsMismatchedResponseNonce() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [
+                    Self.approvalResponse(
+                        version: Self.expectedProtocolVersion,
+                        type: Self.responseOK,
+                        envelopeRequestID: Self.requestID,
+                        envelopeNonce: Self.staleNonce
+                    )
+                ]
+            )
+        )
+
+        assertInvalidResponse("response nonce mismatch") {
+            _ = try client.fetchPendingRequest()
+        }
+    }
+
+    func testSubmitRejectsMismatchedResponseRequestID() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [
+                    Self.decisionResponse(
+                        requestID: Self.staleRequestID,
+                        nonce: Self.sampleDecision.nonce
+                    )
+                ]
+            )
+        )
+
+        assertInvalidResponse("response request id mismatch") {
+            try client.submit(Self.sampleDecision)
+        }
+    }
+
+    func testSubmitRejectsMismatchedResponseNonce() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [
+                    Self.decisionResponse(
+                        requestID: Self.requestID,
+                        nonce: Self.staleNonce
+                    )
+                ]
+            )
+        )
+
+        assertInvalidResponse("response nonce mismatch") {
+            try client.submit(Self.sampleDecision)
+        }
+    }
+
+    func testFetchesAndSubmitsCorrelatedDecision() throws {
+        let transport = try MemoryLineTransport(
+            reads: [
+                Self.approvalResponse(
+                    version: Self.expectedProtocolVersion,
+                    type: Self.responseOK,
+                    envelopeRequestID: Self.requestID,
+                    envelopeNonce: Self.sampleDecision.nonce
+                ),
+                Self.decisionResponse(
+                    requestID: Self.requestID,
+                    nonce: Self.sampleDecision.nonce
+                )
+            ]
+        )
+        let client = SocketDaemonClient(transport: transport)
+
+        let request: ApprovalRequest = try client.fetchPendingRequest()
+        XCTAssertEqual(request.requestID, Self.requestID)
+        try client.submit(Self.sampleDecision)
+
+        let written: String = transport.writtenStrings.joined(separator: "\n")
+        XCTAssertTrue(written.contains("approval.pending"))
+        XCTAssertTrue(written.contains("approval.decision"))
+        XCTAssertFalse(written.contains(Self.secretCanary))
+    }
+
+    func testReportsDaemonErrors() {
+        let client = SocketDaemonClient(transport: MemoryLineTransport(reads: [Self.errorResponse()]))
+
+        XCTAssertThrowsError(try client.fetchPendingRequest()) { error in
+            XCTAssertEqual(
+                error as? SocketDaemonClientError,
+                .daemonError("stale_approval", "stale approval response")
+            )
+        }
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}


### PR DESCRIPTION
## Summary

- validate Swift daemon response protocol versions before accepting `ok` or `error` envelopes
- require correlated request IDs and nonces for approval fetch responses and decision-submit acknowledgements
- move socket-client tests into a dedicated suite with bad-version, bad-type, mismatched request-id, mismatched nonce, daemon-error, and valid correlated-flow coverage

## Verification

- `cd approver && swift test`
- `mise run lint:swift`
- `mise run test`
- `mise run build`
- `mise run lint`
- `mise run test:race`

Closes #15.
