### PR TITLE
Bound Swift Unix socket transport

### DIFF
--- a/approver/Sources/AgentSecretApprover/SocketDaemonClientError.swift
+++ b/approver/Sources/AgentSecretApprover/SocketDaemonClientError.swift
@@ -8,16 +8,22 @@ public enum SocketDaemonClientError: Error, CustomStringConvertible, Equatable {
     case daemonError(String, String)
     /// The daemon closed the connection before a full line arrived.
     case disconnected
+    /// The daemon socket line exceeded the configured frame limit.
+    case frameTooLarge(Int)
     /// The daemon returned an unexpected response shape.
     case invalidResponse(String)
     /// The socket path does not fit in a Unix socket address.
     case pathTooLong(String)
     /// The socket read syscall failed.
     case readFailed(Int32)
+    /// The daemon did not send a complete response before the read timeout.
+    case readTimedOut
     /// Unix sockets are unavailable on this platform.
     case socketUnavailable
     /// The socket write syscall failed.
     case writeFailed(Int32)
+    /// The daemon did not accept the request before the write timeout.
+    case writeTimedOut
 
     /// Human-readable error message for CLI output.
     public var description: String {
@@ -31,6 +37,9 @@ public enum SocketDaemonClientError: Error, CustomStringConvertible, Equatable {
         case .disconnected:
             "daemon disconnected"
 
+        case let .frameTooLarge(maxBytes):
+            "daemon frame exceeds maximum size of \(maxBytes) bytes"
+
         case let .invalidResponse(message):
             "invalid daemon response: \(message)"
 
@@ -40,11 +49,17 @@ public enum SocketDaemonClientError: Error, CustomStringConvertible, Equatable {
         case let .readFailed(errnoValue):
             "read failed: errno \(errnoValue)"
 
+        case .readTimedOut:
+            "read timed out waiting for daemon response"
+
         case .socketUnavailable:
             "unix sockets are unavailable on this platform"
 
         case let .writeFailed(errnoValue):
             "write failed: errno \(errnoValue)"
+
+        case .writeTimedOut:
+            "write timed out sending daemon request"
         }
     }
 }

--- a/approver/Sources/AgentSecretApprover/UnixSocketLineTransport.swift
+++ b/approver/Sources/AgentSecretApprover/UnixSocketLineTransport.swift
@@ -6,21 +6,59 @@ import Foundation
 
 final class UnixSocketLineTransport: LineTransport {
     #if canImport(Darwin)
+        private static let defaultIOTimeout: TimeInterval = 5
+        private static let defaultMaxFrameBytes: Int = 1_048_576
         private static let lineFeedByte: UInt8 = 10
         private static let pathTerminatorByte: UInt8 = 0
+        private static let readChunkBytes: Int = 0x1000
         private static let singleAddressCapacity: Int = 1
-        private static let singleByteCount: Int = 1
+        private static let timevalMicrosecondsPerSecond: Int = 1_000_000
 
+        private let maxFrameBytes: Int
         private let socketFileDescriptor: Int32
+        private var bufferedReadData = Data()
     #endif
 
-    init(path: String) throws {
+    convenience init(path: String) throws {
+        try self.init(
+            path: path,
+            maxFrameBytes: Self.defaultMaxFrameBytes,
+            ioTimeout: Self.defaultIOTimeout
+        )
+    }
+
+    #if canImport(Darwin)
+        init(
+            socketFileDescriptor descriptor: Int32,
+            maxFrameBytes: Int = defaultMaxFrameBytes,
+            ioTimeout: TimeInterval = defaultIOTimeout
+        ) throws {
+            try Self.validate(maxFrameBytes: maxFrameBytes)
+            do {
+                try Self.configureTimeouts(
+                    for: descriptor,
+                    ioTimeout: ioTimeout
+                )
+            } catch {
+                close(descriptor)
+                throw error
+            }
+            self.maxFrameBytes = maxFrameBytes
+            socketFileDescriptor = descriptor
+        }
+    #endif
+
+    private init(
+        path: String,
+        maxFrameBytes: Int,
+        ioTimeout: TimeInterval
+    ) throws {
         #if canImport(Darwin)
+            try Self.validate(maxFrameBytes: maxFrameBytes)
             let descriptor: Int32 = socket(AF_UNIX, SOCK_STREAM, 0)
             guard descriptor >= 0 else {
                 throw SocketDaemonClientError.connectFailed(errno)
             }
-            socketFileDescriptor = descriptor
 
             var address = sockaddr_un()
             address.sun_family = sa_family_t(AF_UNIX)
@@ -28,7 +66,7 @@ final class UnixSocketLineTransport: LineTransport {
             pathBytes.append(Self.pathTerminatorByte)
             let capacity: Int = MemoryLayout.size(ofValue: address.sun_path)
             guard pathBytes.count <= capacity else {
-                close(socketFileDescriptor)
+                close(descriptor)
                 throw SocketDaemonClientError.pathTooLong(path)
             }
             withUnsafeMutableBytes(of: &address.sun_path) { rawBuffer in
@@ -37,36 +75,124 @@ final class UnixSocketLineTransport: LineTransport {
 
             let status: Int32 = withUnsafePointer(to: &address) { pointer in
                 pointer.withMemoryRebound(to: sockaddr.self, capacity: Self.singleAddressCapacity) { sockaddrPointer in
-                    connect(socketFileDescriptor, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+                    connect(descriptor, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
                 }
             }
             guard status == 0 else {
                 let errnoValue: Int32 = errno
-                close(socketFileDescriptor)
+                close(descriptor)
                 throw SocketDaemonClientError.connectFailed(errnoValue)
             }
+            do {
+                try Self.configureTimeouts(
+                    for: descriptor,
+                    ioTimeout: ioTimeout
+                )
+            } catch {
+                close(descriptor)
+                throw error
+            }
+            self.maxFrameBytes = maxFrameBytes
+            socketFileDescriptor = descriptor
         #else
             _ = path
+            _ = maxFrameBytes
+            _ = ioTimeout
             throw SocketDaemonClientError.socketUnavailable
         #endif
     }
 
+    #if canImport(Darwin)
+        private static func validate(maxFrameBytes: Int) throws {
+            guard maxFrameBytes > 0 else {
+                throw SocketDaemonClientError.invalidResponse("invalid maximum frame size")
+            }
+        }
+
+        private static func configureTimeouts(
+            for descriptor: Int32,
+            ioTimeout: TimeInterval
+        ) throws {
+            try configureTimeout(
+                for: descriptor,
+                option: SO_RCVTIMEO,
+                timeout: ioTimeout,
+                error: SocketDaemonClientError.readFailed
+            )
+            try configureTimeout(
+                for: descriptor,
+                option: SO_SNDTIMEO,
+                timeout: ioTimeout,
+                error: SocketDaemonClientError.writeFailed
+            )
+        }
+
+        private static func configureTimeout(
+            for descriptor: Int32,
+            option: Int32,
+            timeout: TimeInterval,
+            error: (Int32) -> SocketDaemonClientError
+        ) throws {
+            var value = socketTimeval(from: timeout)
+            let status: Int32 = withUnsafePointer(to: &value) { pointer in
+                pointer.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<timeval>.size) { rawPointer in
+                    setsockopt(
+                        descriptor,
+                        SOL_SOCKET,
+                        option,
+                        rawPointer,
+                        socklen_t(MemoryLayout<timeval>.size)
+                    )
+                }
+            }
+            guard status == 0 else {
+                throw error(errno)
+            }
+        }
+
+        private static func socketTimeval(from timeout: TimeInterval) -> timeval {
+            let totalMicroseconds = max(
+                1,
+                Int(timeout * TimeInterval(Self.timevalMicrosecondsPerSecond))
+            )
+            return Darwin.timeval(
+                tv_sec: totalMicroseconds / Self.timevalMicrosecondsPerSecond,
+                tv_usec: Int32(totalMicroseconds % Self.timevalMicrosecondsPerSecond)
+            )
+        }
+
+        private static func isTimeout(_ errnoValue: Int32) -> Bool {
+            errnoValue == EAGAIN || errnoValue == EWOULDBLOCK
+        }
+    #endif
+
     func readLine() throws -> Data {
         #if canImport(Darwin)
-            var output = Data()
-            var byte: UInt8 = 0
+            var readBuffer = [UInt8](repeating: 0, count: Self.readChunkBytes)
             while true {
-                let count: Int = Darwin.read(socketFileDescriptor, &byte, Self.singleByteCount)
+                if let line: Data = try consumeBufferedLine() {
+                    return line
+                }
+                if bufferedReadData.count > maxFrameBytes {
+                    throw SocketDaemonClientError.frameTooLarge(maxFrameBytes)
+                }
+                let bufferCapacity: Int = readBuffer.count
+                let count: Int = readBuffer.withUnsafeMutableBytes { rawBuffer -> Int in
+                    guard let baseAddress = rawBuffer.baseAddress else {
+                        return 0
+                    }
+                    return Darwin.read(socketFileDescriptor, baseAddress, bufferCapacity)
+                }
                 if count == 0 {
                     throw SocketDaemonClientError.disconnected
                 }
                 guard count > 0 else {
+                    if Self.isTimeout(errno) {
+                        throw SocketDaemonClientError.readTimedOut
+                    }
                     throw SocketDaemonClientError.readFailed(errno)
                 }
-                if byte == Self.lineFeedByte {
-                    return output
-                }
-                output.append(byte)
+                bufferedReadData.append(contentsOf: readBuffer.prefix(count))
             }
         #else
             throw SocketDaemonClientError.socketUnavailable
@@ -75,6 +201,9 @@ final class UnixSocketLineTransport: LineTransport {
 
     func writeLine(_ data: Data) throws {
         #if canImport(Darwin)
+            guard data.count <= maxFrameBytes else {
+                throw SocketDaemonClientError.frameTooLarge(maxFrameBytes)
+            }
             var bytes: [UInt8] = Array(data)
             bytes.append(Self.lineFeedByte)
             var written = 0
@@ -90,6 +219,9 @@ final class UnixSocketLineTransport: LineTransport {
                     )
                 }
                 guard count > 0 else {
+                    if Self.isTimeout(errno) {
+                        throw SocketDaemonClientError.writeTimedOut
+                    }
                     throw SocketDaemonClientError.writeFailed(errno)
                 }
                 written += count
@@ -99,6 +231,21 @@ final class UnixSocketLineTransport: LineTransport {
             throw SocketDaemonClientError.socketUnavailable
         #endif
     }
+
+    #if canImport(Darwin)
+        private func consumeBufferedLine() throws -> Data? {
+            guard let lineFeedIndex: Data.Index = bufferedReadData.firstIndex(of: Self.lineFeedByte) else {
+                return nil
+            }
+            let line = bufferedReadData[..<lineFeedIndex]
+            guard line.count <= maxFrameBytes else {
+                throw SocketDaemonClientError.frameTooLarge(maxFrameBytes)
+            }
+            let output = Data(line)
+            bufferedReadData.removeSubrange(bufferedReadData.startIndex ... lineFeedIndex)
+            return output
+        }
+    #endif
 
     deinit {
         #if canImport(Darwin)

--- a/approver/Tests/AgentSecretApproverTests/UnixSocketLineTransportTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/UnixSocketLineTransportTests.swift
@@ -1,0 +1,148 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+#if canImport(Darwin)
+    import Darwin
+
+    final class UnixSocketLineTransportTests: XCTestCase {
+        private static let shortTimeout: TimeInterval = 0.05
+        private static let smallFrameBytes: Int = 4
+        private static let testFrameBytes: Int = 64
+
+        private static func writeString(_ value: String, to descriptor: Int32) throws {
+            let data = Data(value.utf8)
+            let written: Int = data.withUnsafeBytes { rawBuffer -> Int in
+                guard let baseAddress = rawBuffer.baseAddress else {
+                    return 0
+                }
+                return Darwin.write(descriptor, baseAddress, data.count)
+            }
+            guard written == data.count else {
+                throw SocketDaemonClientError.writeFailed(errno)
+            }
+        }
+
+        private static func readString(from descriptor: Int32) throws -> String {
+            var buffer = [UInt8](repeating: 0, count: Self.testFrameBytes)
+            let bufferCapacity: Int = buffer.count
+            let count: Int = buffer.withUnsafeMutableBytes { rawBuffer -> Int in
+                guard let baseAddress = rawBuffer.baseAddress else {
+                    return 0
+                }
+                return Darwin.read(descriptor, baseAddress, bufferCapacity)
+            }
+            guard count > 0 else {
+                throw SocketDaemonClientError.readFailed(errno)
+            }
+            guard let output = String(bytes: buffer.prefix(count), encoding: .utf8) else {
+                throw SocketDaemonClientError.invalidResponse("invalid utf8 test response")
+            }
+            return output
+        }
+
+        private static func string(from data: Data) throws -> String {
+            guard let output = String(bytes: data, encoding: .utf8) else {
+                throw SocketDaemonClientError.invalidResponse("invalid utf8 test response")
+            }
+            return output
+        }
+
+        private func makeTransportPair(
+            maxFrameBytes: Int? = nil,
+            ioTimeout: TimeInterval? = nil
+        ) throws -> (transport: UnixSocketLineTransport, peer: Int32) {
+            var descriptors = [Int32](repeating: -1, count: 2)
+            guard socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0 else {
+                throw SocketDaemonClientError.connectFailed(errno)
+            }
+            let frameBytes: Int = maxFrameBytes ?? Self.testFrameBytes
+            let timeout: TimeInterval = ioTimeout ?? Self.shortTimeout
+            do {
+                let transport = try UnixSocketLineTransport(
+                    socketFileDescriptor: descriptors[0],
+                    maxFrameBytes: frameBytes,
+                    ioTimeout: timeout
+                )
+                return (transport, descriptors[1])
+            } catch {
+                close(descriptors[0])
+                close(descriptors[1])
+                throw error
+            }
+        }
+
+        private func assertTransportError(
+            _ expected: SocketDaemonClientError,
+            _ expression: () throws -> Void
+        ) {
+            XCTAssertThrowsError(try expression()) { error in
+                XCTAssertEqual(error as? SocketDaemonClientError, expected)
+            }
+        }
+
+        func testReadLineReturnsNormalResponseAndKeepsBufferedLine() throws {
+            let pair = try makeTransportPair()
+            defer {
+                close(pair.peer)
+            }
+
+            try Self.writeString("first\nsecond\n", to: pair.peer)
+
+            XCTAssertEqual(try Self.string(from: pair.transport.readLine()), "first")
+            XCTAssertEqual(try Self.string(from: pair.transport.readLine()), "second")
+        }
+
+        func testReadLineRejectsOversizedFrame() throws {
+            let pair = try makeTransportPair(maxFrameBytes: Self.smallFrameBytes)
+            defer {
+                close(pair.peer)
+            }
+
+            try Self.writeString("abcde\n", to: pair.peer)
+
+            assertTransportError(.frameTooLarge(Self.smallFrameBytes)) {
+                _ = try pair.transport.readLine()
+            }
+        }
+
+        func testReadLineTimesOutWhenPeerNeverSendsNewline() throws {
+            let pair = try makeTransportPair()
+            defer {
+                close(pair.peer)
+            }
+
+            try Self.writeString("partial", to: pair.peer)
+
+            assertTransportError(.readTimedOut) {
+                _ = try pair.transport.readLine()
+            }
+        }
+
+        func testWriteLineAppendsNewline() throws {
+            let pair = try makeTransportPair()
+            defer {
+                close(pair.peer)
+            }
+
+            try pair.transport.writeLine(Data("hello".utf8))
+
+            XCTAssertEqual(try Self.readString(from: pair.peer), "hello\n")
+        }
+
+        func testWriteLineRejectsOversizedFrame() throws {
+            let pair = try makeTransportPair(maxFrameBytes: Self.smallFrameBytes)
+            defer {
+                close(pair.peer)
+            }
+
+            assertTransportError(.frameTooLarge(Self.smallFrameBytes)) {
+                try pair.transport.writeLine(Data("abcde".utf8))
+            }
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- add a maximum newline-delimited frame size to the Swift Unix socket transport
- configure receive/send timeouts and return explicit timeout/oversize transport errors
- read socket data in bounded chunks while preserving buffered bytes after a newline
- add Darwin socket-pair tests for normal reads, buffered lines, oversized frames, missing-newline timeouts, and write framing

## Verification

- `cd approver && swift test`
- `mise run lint:swift`
- `mise run test`
- `mise run build`
- `mise run lint`
- `mise run test:race`

Closes #16.
