### PR TITLE
Move approver mock modes to smoke target

### DIFF
--- a/approver/Sources/AgentSecretApproverApp/main.swift
+++ b/approver/Sources/AgentSecretApproverApp/main.swift
@@ -2,127 +2,59 @@ import AgentSecretApprover
 import Foundation
 
 private enum ApproverAppError: Error, CustomStringConvertible {
-    case invalidDecision(String)
-    case missingSocket
     case missingValue(String)
+    case unsupportedArgument(String)
 
     var description: String {
         switch self {
-        case let .invalidDecision(value):
-            "invalid mock decision \(value)"
-
-        case .missingSocket:
-            "missing --socket for daemon approval mode"
-
         case let .missingValue(flag):
             "missing value for \(flag)"
+
+        case let .unsupportedArgument(argument):
+            "unsupported argument \(argument)"
         }
     }
 }
 
-private let kDefaultMockRequestTTL: TimeInterval = 120
 private let kUsageExitCode: Int32 = 64
 private let kArguments: [String] = Array(CommandLine.arguments.dropFirst())
 
 do {
-    let presenter: ApprovalPresenter = if let mockDecision: ApprovalDecisionKind = try mockDecisionFromArguments(
-        kArguments
-    ) {
-        StaticDecisionPresenter(decision: mockDecision)
-    } else {
-        AppKitApprovalPresenter()
-    }
-    let client: ApprovalDaemonClient
-    if let socketPath: String = try value(for: "--socket", in: kArguments) {
-        client = try SocketDaemonClient(socketPath: socketPath)
-    } else if hasMockRequest(kArguments) {
-        client = try MockDaemonClient(request: requestFromArguments(kArguments))
-    } else {
+    guard let socketPath: String = try socketPath(from: kArguments) else {
         MainActor.assumeIsolated {
             runSetupDialog()
         }
         exit(0)
     }
+    let presenter: ApprovalPresenter = AppKitApprovalPresenter()
+    let client: ApprovalDaemonClient = try SocketDaemonClient(socketPath: socketPath)
     let controller = ApprovalController(client: client, presenter: presenter)
-    let decision: ApprovalDecision = try controller.run()
-
-    if hasMockRequest(kArguments) {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        let data: Data = try encoder.encode(decision)
-        FileHandle.standardOutput.write(data)
-        FileHandle.standardOutput.write(Data("\n".utf8))
-    }
+    _ = try controller.run()
 } catch {
     FileHandle.standardError.write(Data("agent-secret-approver: \(error)\n".utf8))
     exit(kUsageExitCode)
 }
 
-private func hasMockRequest(_ arguments: [String]) -> Bool {
-    arguments.contains("--mock-request")
-}
+private func socketPath(from arguments: [String]) throws -> String? {
+    var path: String?
+    var index: [String].Index = arguments.startIndex
+    while index < arguments.endIndex {
+        let argument: String = arguments[index]
+        switch argument {
+        case "--socket":
+            let next: [String].Index = arguments.index(after: index)
+            guard next < arguments.endIndex else {
+                throw ApproverAppError.missingValue(argument)
+            }
+            guard !arguments[next].hasPrefix("--") else {
+                throw ApproverAppError.missingValue(argument)
+            }
+            path = arguments[next]
+            index = arguments.index(after: next)
 
-private func mockDecisionFromArguments(_ arguments: [String]) throws -> ApprovalDecisionKind? {
-    guard let raw: String = try value(for: "--mock-decision", in: arguments) else {
-        return nil
-    }
-
-    switch raw {
-    case "approve", "approve-once":
-        return .approveOnce
-
-    case "deny":
-        return .deny
-
-    case "reuse", "approve-reusable":
-        return .approveReusable
-
-    case "timeout":
-        return .timeout
-
-    default:
-        throw ApproverAppError.invalidDecision(raw)
-    }
-}
-
-private func requestFromArguments(_ arguments: [String]) throws -> ApprovalRequest {
-    if let path: String = try value(for: "--mock-request", in: arguments) {
-        let data: Data = if path == "-" {
-            FileHandle.standardInput.readDataToEndOfFile()
-        } else {
-            try Data(contentsOf: URL(fileURLWithPath: path))
+        default:
+            throw ApproverAppError.unsupportedArgument(argument)
         }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        return try decoder.decode(ApprovalRequest.self, from: data)
     }
-
-    return ApprovalRequest(
-        requestID: "mock-request",
-        nonce: "mock-nonce",
-        reason: "Approve a mock agent-secret request",
-        command: ["/usr/bin/env", "terraform", "plan"],
-        cwd: FileManager.default.currentDirectoryPath,
-        expiresAt: Date().addingTimeInterval(kDefaultMockRequestTTL),
-        secrets: [
-            RequestedSecret(
-                alias: "EXAMPLE_TOKEN",
-                ref: "op://Example Vault/Example Item/token",
-                account: "Work"
-            )
-        ]
-    )
-}
-
-private func value(for flag: String, in arguments: [String]) throws -> String? {
-    guard let index: [String].Index = arguments.firstIndex(of: flag) else {
-        return nil
-    }
-
-    let next: [String].Index = arguments.index(after: index)
-    guard next < arguments.endIndex else {
-        throw ApproverAppError.missingValue(flag)
-    }
-
-    return arguments[next]
+    return path
 }

--- a/approver/Sources/AgentSecretApproverSmoke/main.swift
+++ b/approver/Sources/AgentSecretApproverSmoke/main.swift
@@ -1,38 +1,30 @@
 import AgentSecretApprover
 import Foundation
 
+private let kArguments: [String] = Array(CommandLine.arguments.dropFirst())
 private let kReusableUseLimit: Int = 3
 private let kSampleExpiration: TimeInterval = 1_800_000_000
+private let kOptions = try options(from: kArguments)
 
-private let kRequest: ApprovalRequest = .init(
-    requestID: "req_123",
-    nonce: "nonce_456",
-    reason: "Run Terraform plan for staging",
-    command: ["/opt/homebrew/bin/terraform", "plan"],
-    cwd: "/tmp/project",
-    expiresAt: Date(timeIntervalSince1970: kSampleExpiration),
-    secrets: [
-        RequestedSecret(
-            alias: "EXAMPLE_TOKEN",
-            ref: "op://Example Vault/Example Item/token",
-            account: "Work"
-        )
-    ]
-)
-
+private let kRequest: ApprovalRequest = try request(from: kOptions.requestPath)
 private let kClient: MockDaemonClient = .init(request: kRequest)
 private let kLogger: RecordingLogger = .init()
 private let kController: ApprovalController = .init(
     client: kClient,
-    presenter: StaticDecisionPresenter(decision: .approveReusable),
+    presenter: StaticDecisionPresenter(decision: kOptions.decision),
     logger: kLogger
 )
 private let kDecision: ApprovalDecision = try kController.run()
 
 try assert(kDecision.requestID == kRequest.requestID, "decision request ID mismatch")
 try assert(kDecision.nonce == kRequest.nonce, "decision nonce mismatch")
-try assert(kDecision.decision == .approveReusable, "decision kind mismatch")
-try assert(kDecision.reusableUses == kReusableUseLimit, "reusable use limit mismatch")
+try assert(kDecision.decision == kOptions.decision, "decision kind mismatch")
+if kOptions.decision == .approveReusable {
+    try assert(kDecision.reusableUses == kReusableUseLimit, "reusable use limit mismatch")
+} else {
+    try assert(kDecision.reusableUses == nil, "non-reusable decision carried use limit")
+}
+
 try assert(kClient.submittedDecision == kDecision, "decision was not submitted")
 
 private let kEncodedDecision: String = try String(data: JSONEncoder().encode(kDecision), encoding: .utf8) ?? ""
@@ -47,4 +39,91 @@ private func assert(_ condition: @autoclosure () -> Bool, _ message: String) thr
     if !condition() {
         throw SmokeError(message)
     }
+}
+
+private func options(from arguments: [String]) throws -> (requestPath: String?, decision: ApprovalDecisionKind) {
+    var requestPath: String?
+    var decision: ApprovalDecisionKind = .approveReusable
+    var index: [String].Index = arguments.startIndex
+    while index < arguments.endIndex {
+        let argument: String = arguments[index]
+        switch argument {
+        case "--mock-request":
+            let result = try value(after: index, flag: argument, in: arguments)
+            requestPath = result.value
+            index = result.nextIndex
+
+        case "--mock-decision":
+            let result = try value(after: index, flag: argument, in: arguments)
+            decision = try decisionKind(from: result.value)
+            index = result.nextIndex
+
+        default:
+            throw SmokeError("unsupported argument \(argument)")
+        }
+    }
+    return (requestPath, decision)
+}
+
+private func value(
+    after index: [String].Index,
+    flag: String,
+    in arguments: [String]
+) throws -> (value: String, nextIndex: [String].Index) {
+    let valueIndex: [String].Index = arguments.index(after: index)
+    guard valueIndex < arguments.endIndex else {
+        throw SmokeError("missing value for \(flag)")
+    }
+    guard !arguments[valueIndex].hasPrefix("--") else {
+        throw SmokeError("missing value for \(flag)")
+    }
+    return (arguments[valueIndex], arguments.index(after: valueIndex))
+}
+
+private func decisionKind(from raw: String) throws -> ApprovalDecisionKind {
+    switch raw {
+    case "approve", "approve-once":
+        .approveOnce
+
+    case "deny":
+        .deny
+
+    case "reuse", "approve-reusable":
+        .approveReusable
+
+    case "timeout":
+        .timeout
+
+    default:
+        throw SmokeError("invalid mock decision \(raw)")
+    }
+}
+
+private func request(from path: String?) throws -> ApprovalRequest {
+    guard let path else {
+        return ApprovalRequest(
+            requestID: "req_123",
+            nonce: "nonce_456",
+            reason: "Run Terraform plan for staging",
+            command: ["/opt/homebrew/bin/terraform", "plan"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: kSampleExpiration),
+            secrets: [
+                RequestedSecret(
+                    alias: "EXAMPLE_TOKEN",
+                    ref: "op://Example Vault/Example Item/token",
+                    account: "Work"
+                )
+            ]
+        )
+    }
+
+    let data: Data = if path == "-" {
+        FileHandle.standardInput.readDataToEndOfFile()
+    } else {
+        try Data(contentsOf: URL(fileURLWithPath: path))
+    }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try decoder.decode(ApprovalRequest.self, from: data)
 }

--- a/approver/Tests/AgentSecretApproverTests/ApproverAppEntrypointTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApproverAppEntrypointTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import XCTest
+
+final class ApproverAppEntrypointTests: XCTestCase {
+    private static let appEntrypointPath: String = "Sources/AgentSecretApproverApp/main.swift"
+    private static let mockClientSymbol: String = "MockDaemonClient"
+    private static let mockDecisionFlag: String = "--mock-decision"
+    private static let mockPresenterSymbol: String = "StaticDecisionPresenter"
+    private static let mockRequestFlag: String = "--mock-request"
+    private static let packageDirectoryName: String = "approver"
+    private static let smokeEntrypointPath: String = "Sources/AgentSecretApproverSmoke/main.swift"
+
+    private static func packageRootURL() -> URL? {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.lastPathComponent != packageDirectoryName {
+            let parent = url.deletingLastPathComponent()
+            if parent.path == url.path {
+                return nil
+            }
+            url = parent
+        }
+        return url
+    }
+
+    private static func sourceText(at relativePath: String) throws -> String {
+        let root: URL = try XCTUnwrap(packageRootURL())
+        return try String(
+            contentsOf: root.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    func testShippedApproverEntrypointDoesNotContainMockOnlySurface() throws {
+        let source: String = try Self.sourceText(at: Self.appEntrypointPath)
+
+        XCTAssertFalse(source.contains(Self.mockRequestFlag))
+        XCTAssertFalse(source.contains(Self.mockDecisionFlag))
+        XCTAssertFalse(source.contains(Self.mockClientSymbol))
+        XCTAssertFalse(source.contains(Self.mockPresenterSymbol))
+    }
+
+    func testSmokeEntrypointOwnsMockOnlySurface() throws {
+        let source: String = try Self.sourceText(at: Self.smokeEntrypointPath)
+
+        XCTAssertTrue(source.contains(Self.mockRequestFlag))
+        XCTAssertTrue(source.contains(Self.mockDecisionFlag))
+        XCTAssertTrue(source.contains(Self.mockClientSymbol))
+        XCTAssertTrue(source.contains(Self.mockPresenterSymbol))
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}


### PR DESCRIPTION
## Summary

- remove `--mock-request` and `--mock-decision` handling from the shipped approver app target
- keep setup mode and daemon `--socket` mode as the only shipped approver entrypoints
- move configurable mock request/static decision behavior into `agent-secret-approver-smoke`
- add an entrypoint regression test proving mock-only flags and mock-only symbols are absent from the app target and present in the smoke target

## Verification

- `cd approver && swift test`
- `cd approver && swift run agent-secret-approver-smoke`
- `cd approver && swift run agent-secret-approver-smoke --mock-decision deny`
- `mise run lint:swift`
- `mise run test`
- `mise run build`
- `mise run lint`
- `mise run test:race`
- `if strings 'dist/Agent Secret.app/Contents/MacOS/Agent Secret' | rg -- '--mock-(request|decision)'; then exit 1; fi`

Closes #17.
