### PR TITLE
Honor daemon client context cancellation

### DIFF
--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/kovyrin/agent-secret/internal/request"
 )
@@ -91,12 +92,28 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 	if err != nil {
 		return zero, err
 	}
+	stopCancelWatch := c.closeOnContextCancel(ctx)
+	defer stopCancelWatch()
+	defer c.clearDeadlines()
+
+	if err := c.setWriteDeadline(ctx); err != nil {
+		return zero, fmt.Errorf("set daemon write deadline %s: %w", messageType, err)
+	}
 	if err := c.encoder.Encode(env); err != nil {
+		if ctxErr := contextErrorAfterIOError(ctx, err); ctxErr != nil {
+			return zero, fmt.Errorf("daemon request canceled: %w", ctxErr)
+		}
 		return zero, fmt.Errorf("send daemon message %s: %w", messageType, err)
 	}
 
+	if err := c.setReadDeadline(ctx); err != nil {
+		return zero, fmt.Errorf("set daemon read deadline %s: %w", messageType, err)
+	}
 	var resp Envelope
 	if err := c.decoder.Decode(&resp); err != nil {
+		if ctxErr := contextErrorAfterIOError(ctx, err); ctxErr != nil {
+			return zero, fmt.Errorf("daemon request canceled: %w", ctxErr)
+		}
 		return zero, fmt.Errorf("read daemon response %s: %w", messageType, err)
 	}
 	if err := validateEnvelope(resp); err != nil {
@@ -126,6 +143,64 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 		return zero, fmt.Errorf("%w: %w", ErrMalformedEnvelope, err)
 	}
 	return out, nil
+}
+
+func (c *Client) closeOnContextCancel(ctx context.Context) func() {
+	done := ctx.Done()
+	if done == nil || c.conn == nil {
+		return func() {}
+	}
+	stop := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		select {
+		case <-done:
+			_ = c.Close()
+		case <-stop:
+		}
+	}()
+	return func() {
+		close(stop)
+		<-stopped
+	}
+}
+
+func (c *Client) setWriteDeadline(ctx context.Context) error {
+	return c.setContextDeadline(ctx, c.conn.SetWriteDeadline)
+}
+
+func (c *Client) setReadDeadline(ctx context.Context) error {
+	return c.setContextDeadline(ctx, c.conn.SetReadDeadline)
+}
+
+func (c *Client) setContextDeadline(ctx context.Context, set func(time.Time) error) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return nil
+	}
+	return set(deadline)
+}
+
+func (c *Client) clearDeadlines() {
+	if c.conn == nil {
+		return
+	}
+	_ = c.conn.SetDeadline(time.Time{})
+}
+
+func contextErrorAfterIOError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		deadline, ok := ctx.Deadline()
+		if ok && !time.Now().Before(deadline) {
+			return context.DeadlineExceeded
+		}
+	}
+	return nil
 }
 
 func IsProtocolError(err error, code string) bool {

--- a/internal/daemon/protocol_test.go
+++ b/internal/daemon/protocol_test.go
@@ -5,7 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/request"
 )
 
 func TestProtocolHelpersRejectMalformedPayloads(t *testing.T) {
@@ -57,6 +62,146 @@ func TestClientProtocolErrorsAndCloseNil(t *testing.T) {
 	}
 }
 
+func TestClientRoundTripHonorsContextCancellationWaitingForResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		wantType string
+		prepare  func(*testing.T) func(context.Context, *Client) error
+	}{
+		{
+			name:     "status",
+			wantType: TypeDaemonStatus,
+			prepare: func(_ *testing.T) func(context.Context, *Client) error {
+				return func(ctx context.Context, client *Client) error {
+					_, err := client.Status(ctx)
+					return err
+				}
+			},
+		},
+		{
+			name:     "stop",
+			wantType: TypeDaemonStop,
+			prepare: func(_ *testing.T) func(context.Context, *Client) error {
+				return func(ctx context.Context, client *Client) error {
+					_, err := client.Stop(ctx)
+					return err
+				}
+			},
+		},
+		{
+			name:     "fetch pending approval",
+			wantType: TypeApprovalPending,
+			prepare: func(_ *testing.T) func(context.Context, *Client) error {
+				return func(ctx context.Context, client *Client) error {
+					_, err := client.FetchPendingApproval(ctx)
+					return err
+				}
+			},
+		},
+		{
+			name:     "submit approval decision",
+			wantType: TypeApprovalDecision,
+			prepare: func(_ *testing.T) func(context.Context, *Client) error {
+				return func(ctx context.Context, client *Client) error {
+					return client.SubmitApprovalDecision(ctx, ApprovalDecisionPayload{
+						RequestID: "req_1",
+						Nonce:     "nonce_1",
+						Decision:  "approve_once",
+					})
+				}
+			},
+		},
+		{
+			name:     "request exec",
+			wantType: TypeRequestExec,
+			prepare: func(t *testing.T) func(context.Context, *Client) error {
+				t.Helper()
+
+				req := testExecRequest(t, []request.SecretSpec{
+					{Alias: "TOKEN", Ref: "op://Example/Item/token"},
+				})
+				return func(ctx context.Context, client *Client) error {
+					_, err := client.RequestExec(ctx, "req_1", "nonce_1", req)
+					return err
+				}
+			},
+		},
+		{
+			name:     "report started",
+			wantType: TypeCommandStarted,
+			prepare: func(_ *testing.T) func(context.Context, *Client) error {
+				return func(ctx context.Context, client *Client) error {
+					return client.ReportStarted(ctx, "req_1", "nonce_1", 1234)
+				}
+			},
+		},
+		{
+			name:     "report completed",
+			wantType: TypeCommandCompleted,
+			prepare: func(_ *testing.T) func(context.Context, *Client) error {
+				return func(ctx context.Context, client *Client) error {
+					return client.ReportCompleted(ctx, "req_1", "nonce_1", 0, "")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, requests, cleanup := startStallingDaemonClient(t)
+			defer cleanup()
+			call := tc.prepare(t)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			errc := make(chan error, 1)
+			go func() {
+				errc <- call(ctx, client)
+			}()
+
+			env := receiveStalledRequest(t, requests)
+			if env.Type != tc.wantType {
+				t.Fatalf("request type = %s, want %s", env.Type, tc.wantType)
+			}
+
+			cancel()
+			err := receiveRoundTripError(t, errc)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("expected context canceled error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestClientRoundTripHonorsContextDeadlineWaitingForResponse(t *testing.T) {
+	t.Parallel()
+
+	client, requests, cleanup := startStallingDaemonClient(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	errc := make(chan error, 1)
+	go func() {
+		_, err := client.Status(ctx)
+		errc <- err
+	}()
+
+	env := receiveStalledRequest(t, requests)
+	if env.Type != TypeDaemonStatus {
+		t.Fatalf("request type = %s, want %s", env.Type, TypeDaemonStatus)
+	}
+
+	err := receiveRoundTripError(t, errc)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded error, got %v", err)
+	}
+}
+
 func TestSameUIDValidatorRejectsInspectFailure(t *testing.T) {
 	t.Parallel()
 
@@ -64,4 +209,93 @@ func TestSameUIDValidatorRejectsInspectFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid unix connection error")
 	}
+}
+
+func startStallingDaemonClient(t *testing.T) (*Client, <-chan Envelope, func()) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("/tmp", "agent-secret-stall-")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("secure socket test directory: %v", err)
+	}
+	path := filepath.Join(dir, "daemon.sock")
+	listener, err := ListenUnix(path)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+
+	requests := make(chan Envelope, 1)
+	release := make(chan struct{})
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		var env Envelope
+		if err := json.NewDecoder(conn).Decode(&env); err != nil {
+			serverDone <- err
+			return
+		}
+		requests <- env
+		<-release
+		serverDone <- nil
+	}()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		_ = listener.Close()
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	client := NewClient(conn)
+
+	return client, requests, func() {
+		_ = client.Close()
+		close(release)
+		_ = listener.Close()
+		defer func() { _ = os.RemoveAll(dir) }()
+		select {
+		case err := <-serverDone:
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				t.Fatalf("stalling daemon returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("stalling daemon did not stop")
+		}
+	}
+}
+
+func receiveStalledRequest(t *testing.T, requests <-chan Envelope) Envelope {
+	t.Helper()
+
+	select {
+	case env := <-requests:
+		return env
+	case <-time.After(time.Second):
+		t.Fatal("daemon client did not write request")
+	}
+	return Envelope{}
+}
+
+func receiveRoundTripError(t *testing.T, errc <-chan error) error {
+	t.Helper()
+
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("expected round trip error")
+		}
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("daemon client did not return after context cancellation")
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #18.

- closes the daemon Unix connection when a request context is canceled so blocked response reads unblock promptly
- applies context deadlines to daemon socket writes and reads, and maps deadline socket timeouts back to `context.DeadlineExceeded`
- covers every public daemon client round-trip path with a stalled peer that accepts and reads the request but never sends a response

## Verification

- `mise exec -- go test ./internal/daemon -run 'TestClientRoundTripHonorsContext|TestClientProtocolErrorsAndCloseNil|TestServerExecProtocolLifecycle' -count=1`
- `mise run test`
- `mise run build`
- `mise run lint`
- `mise run test:race`
