### PR TITLE
Avoid global resolver init blocking

### DIFF
--- a/cmd/agent-secretd/main.go
+++ b/cmd/agent-secretd/main.go
@@ -113,9 +113,11 @@ func (f *stringListFlag) Set(value string) error {
 }
 
 type desktopResolver struct {
-	mu      sync.Mutex
-	account string
-	clients map[string]*opresolver.Resolver
+	mu                 sync.Mutex
+	account            string
+	clients            map[string]*opresolver.Resolver
+	inits              map[string]*desktopResolverInit
+	newDesktopResolver desktopResolverFactory
 }
 
 type desktopResolverResult struct {
@@ -123,9 +125,22 @@ type desktopResolverResult struct {
 	err      error
 }
 
+type desktopResolverFactory func(context.Context, opresolver.ClientOptions) (*opresolver.Resolver, error)
+
+type desktopResolverInit struct {
+	done     chan struct{}
+	resolver *opresolver.Resolver
+	err      error
+}
+
 func newResolver(account string) daemon.Resolver {
 	account = strings.TrimSpace(account)
-	return &desktopResolver{account: account, clients: make(map[string]*opresolver.Resolver)}
+	return &desktopResolver{
+		account:            account,
+		clients:            make(map[string]*opresolver.Resolver),
+		inits:              make(map[string]*desktopResolverInit),
+		newDesktopResolver: opresolver.NewDesktopResolver,
+	}
 }
 
 func (r *desktopResolver) Resolve(ctx context.Context, ref string, account string) (string, error) {
@@ -142,17 +157,46 @@ func (r *desktopResolver) Resolve(ctx context.Context, ref string, account strin
 
 func (r *desktopResolver) client(ctx context.Context, accountOverride string) (*opresolver.Resolver, error) {
 	account := r.effectiveAccount(accountOverride)
+	resolver, init, owner := r.startClientInit(account)
+	if resolver != nil {
+		return resolver, nil
+	}
+	if !owner {
+		return waitForClientInit(ctx, init)
+	}
+
+	resolver, err := r.createClient(ctx, account)
+	r.finishClientInit(account, init, resolver, err)
+	return resolver, err
+}
+
+func (r *desktopResolver) startClientInit(account string) (*opresolver.Resolver, *desktopResolverInit, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if resolver := r.clients[account]; resolver != nil {
-		return resolver, nil
+		return resolver, nil, false
 	}
+	if init := r.inits[account]; init != nil {
+		return nil, init, false
+	}
+	if r.inits == nil {
+		r.inits = make(map[string]*desktopResolverInit)
+	}
+	init := &desktopResolverInit{done: make(chan struct{})}
+	r.inits[account] = init
+	return nil, init, true
+}
 
+func (r *desktopResolver) createClient(ctx context.Context, account string) (*opresolver.Resolver, error) {
 	initCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	results := make(chan desktopResolverResult, 1)
+	factory := r.newDesktopResolver
+	if factory == nil {
+		factory = opresolver.NewDesktopResolver
+	}
 	go func() {
-		resolver, err := opresolver.NewDesktopResolver(initCtx, opresolver.ClientOptions{
+		resolver, err := factory(initCtx, opresolver.ClientOptions{
 			Account:            account,
 			IntegrationName:    "Agent Secret Broker",
 			IntegrationVersion: "dev",
@@ -165,13 +209,40 @@ func (r *desktopResolver) client(ctx context.Context, accountOverride string) (*
 		if result.err != nil {
 			return nil, result.err
 		}
-		r.clients[account] = result.resolver
 		return result.resolver, nil
 	case <-initCtx.Done():
 		return nil, fmt.Errorf(
 			"create 1Password SDK client timed out after 30s: unlock or restart 1Password and confirm SDK desktop integration is enabled: %w",
 			initCtx.Err(),
 		)
+	}
+}
+
+func (r *desktopResolver) finishClientInit(account string, init *desktopResolverInit, resolver *opresolver.Resolver, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err == nil {
+		r.clients[account] = resolver
+	}
+	delete(r.inits, account)
+	init.resolver = resolver
+	init.err = err
+	close(init.done)
+}
+
+func waitForClientInit(ctx context.Context, init *desktopResolverInit) (*opresolver.Resolver, error) {
+	select {
+	case <-init.done:
+		return init.resolver, init.err
+	default:
+	}
+
+	select {
+	case <-init.done:
+		return init.resolver, init.err
+	case <-ctx.Done():
+		return nil, fmt.Errorf("create 1Password resolver: %w", ctx.Err())
 	}
 }
 

--- a/cmd/agent-secretd/main_test.go
+++ b/cmd/agent-secretd/main_test.go
@@ -1,6 +1,14 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/opresolver"
+)
 
 func TestDefaultApproverFlagValueIgnoresEnvironmentOverride(t *testing.T) {
 	t.Setenv("AGENT_SECRET_APPROVER_PATH", "/tmp/fake-approver")
@@ -36,4 +44,171 @@ func TestDesktopResolverEffectiveAccountUsesPerSecretOverride(t *testing.T) {
 	if account := resolver.effectiveAccount(" \t "); account != "Fixture" {
 		t.Fatalf("account = %q, want Fixture", account)
 	}
+}
+
+func TestDesktopResolverInitializesDifferentAccountsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	slowStarted := make(chan struct{})
+	releaseSlow := make(chan struct{})
+	slowDone := make(chan error, 1)
+	fastResolver := testDesktopResolver(t)
+	slowResolver := testDesktopResolver(t)
+	resolver := testDesktopResolverWithFactory(func(ctx context.Context, opts opresolver.ClientOptions) (*opresolver.Resolver, error) {
+		switch opts.Account {
+		case "slow":
+			close(slowStarted)
+			select {
+			case <-releaseSlow:
+				return slowResolver, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		case "fast":
+			return fastResolver, nil
+		default:
+			return nil, fmt.Errorf("unexpected account %q", opts.Account)
+		}
+	})
+
+	go func() {
+		_, err := resolver.client(context.Background(), "slow")
+		slowDone <- err
+	}()
+	receiveSignal(t, slowStarted, "slow resolver initialization did not start")
+
+	fastDone := make(chan error, 1)
+	go func() {
+		got, err := resolver.client(context.Background(), "fast")
+		if err == nil && got != fastResolver {
+			err = fmt.Errorf("fast resolver = %p, want %p", got, fastResolver)
+		}
+		fastDone <- err
+	}()
+	receiveNoError(t, fastDone, "fast account initialization was blocked by slow account")
+
+	close(releaseSlow)
+	receiveNoError(t, slowDone, "slow account initialization failed")
+}
+
+func TestDesktopResolverCoalescesConcurrentSameAccountInitialization(t *testing.T) {
+	t.Parallel()
+
+	sharedStarted := make(chan struct{})
+	releaseShared := make(chan struct{})
+	sharedResolver := testDesktopResolver(t)
+	var calls atomic.Int32
+	resolver := testDesktopResolverWithFactory(func(ctx context.Context, opts opresolver.ClientOptions) (*opresolver.Resolver, error) {
+		if opts.Account != "shared" {
+			return nil, fmt.Errorf("unexpected account %q", opts.Account)
+		}
+		if calls.Add(1) == 1 {
+			close(sharedStarted)
+		}
+		select {
+		case <-releaseShared:
+			return sharedResolver, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	})
+
+	firstDone := make(chan clientResult, 1)
+	go func() {
+		got, err := resolver.client(context.Background(), "shared")
+		firstDone <- clientResult{resolver: got, err: err}
+	}()
+	receiveSignal(t, sharedStarted, "shared resolver initialization did not start")
+
+	secondDone := make(chan clientResult, 1)
+	go func() {
+		got, err := resolver.client(context.Background(), "shared")
+		secondDone <- clientResult{resolver: got, err: err}
+	}()
+
+	select {
+	case result := <-secondDone:
+		t.Fatalf("second same-account initialization completed before first finished: %+v", result)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("factory calls before release = %d, want 1", got)
+	}
+
+	close(releaseShared)
+	first := receiveClientResult(t, firstDone, "first same-account initialization failed")
+	second := receiveClientResult(t, secondDone, "second same-account initialization failed")
+	if first != sharedResolver || second != sharedResolver {
+		t.Fatalf("same-account resolvers = %p and %p, want %p", first, second, sharedResolver)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("factory calls = %d, want 1", got)
+	}
+}
+
+type fakeSecretsAPI struct{}
+
+func (fakeSecretsAPI) Resolve(_ context.Context, _ string) (string, error) {
+	return "synthetic-secret-value", nil
+}
+
+type clientResult struct {
+	resolver *opresolver.Resolver
+	err      error
+}
+
+func testDesktopResolver(t *testing.T) *opresolver.Resolver {
+	t.Helper()
+
+	resolver, err := opresolver.NewResolver(fakeSecretsAPI{})
+	if err != nil {
+		t.Fatalf("NewResolver returned error: %v", err)
+	}
+	return resolver
+}
+
+func testDesktopResolverWithFactory(factory desktopResolverFactory) *desktopResolver {
+	return &desktopResolver{
+		clients:            make(map[string]*opresolver.Resolver),
+		inits:              make(map[string]*desktopResolverInit),
+		newDesktopResolver: factory,
+	}
+}
+
+func receiveSignal(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
+}
+
+func receiveNoError(t *testing.T, ch <-chan error, message string) {
+	t.Helper()
+
+	select {
+	case err := <-ch:
+		if err != nil {
+			t.Fatalf("%s: %v", message, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
+}
+
+func receiveClientResult(t *testing.T, ch <-chan clientResult, message string) *opresolver.Resolver {
+	t.Helper()
+
+	select {
+	case result := <-ch:
+		if result.err != nil {
+			t.Fatalf("%s: %v", message, result.err)
+		}
+		return result.resolver
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #19.

- tracks in-flight desktop resolver initialization per account instead of holding the global resolver map mutex while creating the SDK client
- lets unrelated accounts initialize independently when another account is slow or stuck
- keeps same-account concurrent callers coalesced onto one initialization result

## Verification

- `mise exec -- go test ./cmd/agent-secretd -run 'TestDesktopResolver' -count=1`
- `mise run test`
- `mise run build`
- `mise run lint`
- `mise run test:race`
