### PR TITLE
Cancel remaining secret fetches after failure

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -362,27 +362,56 @@ func (b *Broker) resolveUniqueRefs(ctx context.Context, requestID string, req re
 		return nil, err
 	}
 
+	fetchCtx, cancelFetches := context.WithCancel(ctx)
+	defer cancelFetches()
+
 	sem := make(chan struct{}, b.fetchLimit)
 	results := make(chan result, len(identities))
+	var wg sync.WaitGroup
 	for _, identity := range identities {
-		sem <- struct{}{}
+		wg.Add(1)
 		go func(identity secretIdentity) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-fetchCtx.Done():
+				return
+			}
 			defer func() { <-sem }()
-			value, err := b.resolver.Resolve(ctx, identity.ref, identity.account)
+
+			value, err := b.resolver.Resolve(fetchCtx, identity.ref, identity.account)
 			results <- result{identity: identity, value: value, err: err}
 		}(identity)
 	}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
 
 	resolved := make(map[secretIdentity]string, len(identities))
-	for range identities {
-		got := <-results
+	var firstErr error
+	for got := range results {
 		if got.err != nil {
-			if err := b.recordSecretFetchFailed(ctx, requestID, secrets, got.identity, got.err); err != nil {
-				return nil, err
+			if firstErr == nil {
+				cancelFetches()
+				if err := b.recordSecretFetchFailed(ctx, requestID, secrets, got.identity, got.err); err != nil {
+					firstErr = err
+				} else {
+					firstErr = fmt.Errorf("resolve approved ref: %w", got.err)
+				}
 			}
-			return nil, fmt.Errorf("resolve approved ref: %w", got.err)
+			continue
 		}
-		resolved[got.identity] = got.value
+		if firstErr == nil {
+			resolved[got.identity] = got.value
+		}
+	}
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	if err := fetchCtx.Err(); err != nil {
+		return nil, fmt.Errorf("resolve approved ref: %w", err)
 	}
 
 	return resolved, nil

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -68,6 +68,39 @@ func (m *mockResolver) Calls() []string {
 	return slices.Clone(m.calls)
 }
 
+type cancelObservingResolver struct {
+	failRef      string
+	failErr      error
+	slowRef      string
+	slowStarted  chan struct{}
+	slowCanceled chan struct{}
+}
+
+func (r *cancelObservingResolver) Resolve(ctx context.Context, ref string, _ string) (string, error) {
+	switch ref {
+	case r.failRef:
+		select {
+		case <-r.slowStarted:
+			return "", r.failErr
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(time.Second):
+			return "", errors.New("slow resolver did not start")
+		}
+	case r.slowRef:
+		close(r.slowStarted)
+		select {
+		case <-ctx.Done():
+			close(r.slowCanceled)
+			return "", ctx.Err()
+		case <-time.After(time.Second):
+			return "", errors.New("slow resolver was not canceled")
+		}
+	default:
+		return canarySecretValue, nil
+	}
+}
+
 type failingSecretCache struct {
 	err           error
 	failPuts      int
@@ -350,6 +383,52 @@ func TestBrokerPartialFetchFailureReturnsNoPayload(t *testing.T) {
 	assertAuditEventsValueFree(t, events)
 	if err := broker.MarkPayloadDelivered("req_1"); !errors.Is(err, ErrUnknownRequest) {
 		t.Fatalf("request should not become active after failed fetch, got %v", err)
+	}
+}
+
+func TestBrokerCancelsOutstandingFetchesAfterFirstFailure(t *testing.T) {
+	t.Parallel()
+
+	failRef := "op://Example/Item/a_fail"
+	slowRef := "op://Example/Item/z_slow"
+	failErr := errors.New("unreadable secret")
+	resolver := &cancelObservingResolver{
+		failRef:      failRef,
+		failErr:      failErr,
+		slowRef:      slowRef,
+		slowStarted:  make(chan struct{}),
+		slowCanceled: make(chan struct{}),
+	}
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, BrokerOptions{
+		Approver:   &mockApprover{decision: ApprovalDecision{Approved: true}},
+		Resolver:   resolver,
+		Audit:      aud,
+		FetchLimit: 2,
+	})
+
+	_, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", testExecRequest(t, []request.SecretSpec{
+		{Alias: "FAIL", Ref: failRef},
+		{Alias: "SLOW", Ref: slowRef},
+	}))
+	if !errors.Is(err, failErr) {
+		t.Fatalf("expected failing ref error, got %v", err)
+	}
+	receiveBrokerSignal(t, resolver.slowCanceled, "slow resolver did not observe cancellation")
+
+	events := aud.Events()
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventSecretFetchFailed,
+	}
+	if got := auditEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+	failure := events[len(events)-1]
+	if len(failure.SecretRefs) != 1 || failure.SecretRefs[0].Alias != "FAIL" || failure.SecretRefs[0].Ref != failRef {
+		t.Fatalf("fetch failure refs = %+v", failure.SecretRefs)
 	}
 }
 
@@ -759,6 +838,16 @@ func containsAuditEvent(events []audit.Event, eventType audit.EventType) bool {
 		}
 	}
 	return false
+}
+
+func receiveBrokerSignal(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
 }
 
 func auditEventTypes(events []audit.Event) []audit.EventType {


### PR DESCRIPTION
## Summary

Fixes #20.

- gives `resolveUniqueRefs` a child context for resolver fan-out
- cancels outstanding resolver calls after the first decisive fetch failure
- waits for started workers to finish and closes the result stream explicitly
- adds a regression where a slow in-flight resolver observes cancellation after another ref fails

## Verification

- `mise exec -- go test ./internal/daemon -run 'TestBrokerCancelsOutstandingFetchesAfterFirstFailure|TestBrokerPartialFetchFailureReturnsNoPayload|TestBrokerApprovesBeforeResolvingAndAuditsBeforePayload' -count=1`
- `mise run test`
- `mise run build`
- `mise run lint`
- `mise run test:race`
