### PR TITLE
Return errors for random ID failures

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -24,6 +24,7 @@ type App struct {
 	Manager      daemon.Manager
 	InstallCLI   func(install.CLIOptions) (install.CLIResult, error)
 	InstallSkill func(install.SkillOptions) (install.SkillResult, error)
+	RandomReader io.Reader
 	Stdout       io.Writer
 	Stderr       io.Writer
 }
@@ -40,6 +41,7 @@ func NewApp(manager daemon.Manager, stdout io.Writer, stderr io.Writer) App {
 		Manager:      manager,
 		InstallCLI:   install.InstallCLI,
 		InstallSkill: install.InstallSkill,
+		RandomReader: rand.Reader,
 		Stdout:       stdout,
 		Stderr:       stderr,
 	}
@@ -92,8 +94,16 @@ func (a App) runExec(ctx context.Context, command Command) int {
 	}
 	defer func() { _ = client.Close() }()
 
-	requestID := randomID("req")
-	nonce := randomID("nonce")
+	requestID, err := a.randomID("req")
+	if err != nil {
+		a.stderrf("agent-secret: generate request id: %v\n", err)
+		return 1
+	}
+	nonce, err := a.randomID("nonce")
+	if err != nil {
+		a.stderrf("agent-secret: generate request nonce: %v\n", err)
+		return 1
+	}
 	payload, err := client.RequestExec(ctx, requestID, nonce, command.ExecRequest)
 	if err != nil {
 		a.stderrf("agent-secret: request rejected: %v\n", err)
@@ -255,10 +265,17 @@ func isProtocolFailure(err error) bool {
 	return errors.As(err, &protocolErr)
 }
 
-func randomID(prefix string) string {
-	var data [16]byte
-	if _, err := rand.Read(data[:]); err != nil {
-		panic(fmt.Sprintf("generate random id: %v", err))
+func (a App) randomID(prefix string) (string, error) {
+	return randomID(a.RandomReader, prefix)
+}
+
+func randomID(reader io.Reader, prefix string) (string, error) {
+	if reader == nil {
+		reader = rand.Reader
 	}
-	return prefix + "_" + hex.EncodeToString(data[:])
+	var data [16]byte
+	if _, err := io.ReadFull(reader, data[:]); err != nil {
+		return "", fmt.Errorf("generate random id: %w", err)
+	}
+	return prefix + "_" + hex.EncodeToString(data[:]), nil
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -281,6 +281,43 @@ func TestAppExecReportsDaemonStartFailureBeforeSpawn(t *testing.T) {
 	}
 }
 
+func TestAppExecReportsRandomIDFailureBeforeRequest(t *testing.T) {
+	ref := "op://Example/Item/token"
+	client, cleanup := startAppTestServer(t, daemon.BrokerOptions{
+		Approver: &appApprover{decision: daemon.ApprovalDecision{Approved: true}},
+		Resolver: &appResolver{values: map[string]string{ref: "synthetic-secret-value"}},
+		Audit:    &appAudit{},
+	})
+	defer cleanup()
+
+	entropyErr := errors.New("entropy unavailable")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := NewApp(daemon.Manager{SocketPath: client.SocketPath}, &stdout, &stderr)
+	app.RandomReader = failingRandomReader{err: entropyErr}
+	t.Setenv("AGENT_SECRET_APP_EXEC_HELPER", "1")
+
+	code := app.Run(context.Background(), []string{
+		"exec",
+		"--reason", "Run helper",
+		"--secret", "TOKEN=" + ref,
+		"--",
+		os.Args[0], "-test.run=TestAppExecReportsRandomIDFailureBeforeRequest", "--", "child",
+	})
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "generate request id") || !strings.Contains(stderr.String(), entropyErr.Error()) {
+		t.Fatalf("stderr = %q, want random id failure", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "synthetic-secret-value") {
+		t.Fatalf("stderr leaked secret: %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no child output", stdout.String())
+	}
+}
+
 func TestNewAppDefaultsWritersAndHelpRun(t *testing.T) {
 	app := NewApp(daemon.Manager{}, nil, nil)
 	if app.Stdout == nil || app.Stderr == nil {
@@ -364,6 +401,14 @@ func (a *appAudit) ApprovalReused(_ context.Context, _ policy.ReuseAuditEvent) e
 
 func (a *appAudit) Preflight(context.Context) error {
 	return nil
+}
+
+type failingRandomReader struct {
+	err error
+}
+
+func (r failingRandomReader) Read(_ []byte) (int, error) {
+	return 0, r.err
 }
 
 type appAllowPeer struct{}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"slices"
 	"sync"
 	"time"
@@ -39,6 +40,7 @@ type ReuseAuditEvent struct {
 type Store struct {
 	mu        sync.Mutex
 	now       func() time.Time
+	random    io.Reader
 	approvals map[string]*ReusableApproval
 	sessions  map[string]*Session
 }
@@ -106,6 +108,7 @@ func NewStore(now func() time.Time) *Store {
 
 	return &Store{
 		now:       now,
+		random:    rand.Reader,
 		approvals: make(map[string]*ReusableApproval),
 		sessions:  make(map[string]*Session),
 	}
@@ -116,10 +119,18 @@ func (s *Store) AddReusable(req request.ExecRequest, id string, nonce string) (R
 	defer s.mu.Unlock()
 
 	if id == "" {
-		id = randomID("appr")
+		var err error
+		id, err = s.randomID("appr")
+		if err != nil {
+			return ReusableApproval{}, fmt.Errorf("generate reusable approval id: %w", err)
+		}
 	}
 	if nonce == "" {
-		nonce = randomID("nonce")
+		var err error
+		nonce, err = s.randomID("nonce")
+		if err != nil {
+			return ReusableApproval{}, fmt.Errorf("generate reusable approval nonce: %w", err)
+		}
 	}
 
 	approval := &ReusableApproval{
@@ -204,19 +215,30 @@ func (s *Store) CreateSession(id string, nonce string, expiresAt time.Time, gran
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if id == "" {
-		id = randomID("sess")
-	}
-	if nonce == "" {
-		nonce = randomID("nonce")
-	}
 	if maxReads <= 0 {
 		return Session{}, ErrReadExhausted
+	}
+	if id == "" {
+		var err error
+		id, err = s.randomID("sess")
+		if err != nil {
+			return Session{}, fmt.Errorf("generate session id: %w", err)
+		}
+	}
+	if nonce == "" {
+		var err error
+		nonce, err = s.randomID("nonce")
+		if err != nil {
+			return Session{}, fmt.Errorf("generate session nonce: %w", err)
+		}
 	}
 
 	handles := make(map[string]*Handle, len(grants))
 	for _, grant := range grants {
-		handleID := randomID("h")
+		handleID, err := s.randomID("h")
+		if err != nil {
+			return Session{}, fmt.Errorf("generate secret handle id: %w", err)
+		}
 		handles[handleID] = &Handle{
 			ID:       handleID,
 			Alias:    grant.Alias,
@@ -425,10 +447,17 @@ func cloneSession(session *Session) Session {
 	return clone
 }
 
-func randomID(prefix string) string {
-	var data [16]byte
-	if _, err := rand.Read(data[:]); err != nil {
-		panic(fmt.Sprintf("generate random id: %v", err))
+func (s *Store) randomID(prefix string) (string, error) {
+	return randomID(s.random, prefix)
+}
+
+func randomID(reader io.Reader, prefix string) (string, error) {
+	if reader == nil {
+		reader = rand.Reader
 	}
-	return prefix + "_" + hex.EncodeToString(data[:])
+	var data [16]byte
+	if _, err := io.ReadFull(reader, data[:]); err != nil {
+		return "", fmt.Errorf("generate random id: %w", err)
+	}
+	return prefix + "_" + hex.EncodeToString(data[:]), nil
 }

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -436,6 +436,9 @@ func TestAddReusableAndCreateSessionGenerateIdentifiers(t *testing.T) {
 	if !strings.HasPrefix(approval.ID, "appr_") || !strings.HasPrefix(approval.Nonce, "nonce_") {
 		t.Fatalf("generated approval identifiers = %+v", approval)
 	}
+	if len(approval.ID) != len("appr_")+32 || len(approval.Nonce) != len("nonce_")+32 {
+		t.Fatalf("generated approval identifier lengths = id:%d nonce:%d", len(approval.ID), len(approval.Nonce))
+	}
 
 	session, err := store.CreateSession("", "", now.Add(time.Minute), []SecretGrant{
 		{Alias: "TOKEN", Ref: "op://Example Vault/Item/token"},
@@ -445,6 +448,85 @@ func TestAddReusableAndCreateSessionGenerateIdentifiers(t *testing.T) {
 	}
 	if !strings.HasPrefix(session.ID, "sess_") || !strings.HasPrefix(session.Nonce, "nonce_") {
 		t.Fatalf("generated session identifiers = %+v", session)
+	}
+	if len(session.ID) != len("sess_")+32 || len(session.Nonce) != len("nonce_")+32 {
+		t.Fatalf("generated session identifier lengths = id:%d nonce:%d", len(session.ID), len(session.Nonce))
+	}
+	handleID := onlyHandleID(t, session)
+	if !strings.HasPrefix(handleID, "h_") || len(handleID) != len("h_")+32 {
+		t.Fatalf("generated handle id = %q", handleID)
+	}
+}
+
+func TestStoreRandomIDFailuresReturnErrors(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	entropyErr := errors.New("entropy unavailable")
+	grants := []SecretGrant{{Alias: "TOKEN", Ref: "op://Example Vault/Item/token"}}
+	tests := []struct {
+		name string
+		run  func(*testing.T, *Store) error
+		want string
+	}{
+		{
+			name: "reusable approval id",
+			run: func(t *testing.T, store *Store) error {
+				t.Helper()
+				_, err := store.AddReusable(testRequest(t, now), "", "nonce_1")
+				return err
+			},
+			want: "generate reusable approval id",
+		},
+		{
+			name: "reusable approval nonce",
+			run: func(t *testing.T, store *Store) error {
+				t.Helper()
+				_, err := store.AddReusable(testRequest(t, now), "appr_1", "")
+				return err
+			},
+			want: "generate reusable approval nonce",
+		},
+		{
+			name: "session id",
+			run: func(_ *testing.T, store *Store) error {
+				_, err := store.CreateSession("", "nonce_1", now.Add(time.Minute), grants, 1)
+				return err
+			},
+			want: "generate session id",
+		},
+		{
+			name: "session nonce",
+			run: func(_ *testing.T, store *Store) error {
+				_, err := store.CreateSession("sess_1", "", now.Add(time.Minute), grants, 1)
+				return err
+			},
+			want: "generate session nonce",
+		},
+		{
+			name: "secret handle id",
+			run: func(_ *testing.T, store *Store) error {
+				_, err := store.CreateSession("sess_1", "nonce_1", now.Add(time.Minute), grants, 1)
+				return err
+			},
+			want: "generate secret handle id",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := NewStore(func() time.Time { return now })
+			store.random = failingRandomReader{err: entropyErr}
+			err := tc.run(t, store)
+			if !errors.Is(err, entropyErr) {
+				t.Fatalf("expected entropy error, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want %q", err.Error(), tc.want)
+			}
+		})
 	}
 }
 
@@ -478,6 +560,14 @@ func onlyHandleID(t *testing.T, session Session) string {
 		return id
 	}
 	panic("unreachable")
+}
+
+type failingRandomReader struct {
+	err error
+}
+
+func (r failingRandomReader) Read(_ []byte) (int, error) {
+	return 0, r.err
 }
 
 func containsCanary(data []byte) bool {


### PR DESCRIPTION
## Summary

Fixes #21.

- changes CLI request ID/nonce generation to return and report errors instead of panicking
- gives policy store ID generation an injectable random reader and propagates ID, nonce, and handle generation errors
- keeps generated ID prefixes and 16-byte hex format unchanged
- adds failing-random-source tests for CLI request setup and every policy-generated identifier

## Verification

- `mise exec -- go test ./internal/cli ./internal/policy -run 'TestAppExecReportsRandomIDFailureBeforeRequest|TestStoreRandomIDFailuresReturnErrors|TestAddReusableAndCreateSessionGenerateIdentifiers' -count=1`
- `mise run test`
- `mise run build`
- `mise run lint`
- `mise run test:race`
