### PR TITLE
Audit trusted daemon stop attempts

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -62,6 +62,9 @@ type Event struct {
 	ExitCode           *int                 `json:"exit_code,omitempty"`
 	Signal             string               `json:"signal,omitempty"`
 	ErrorCode          string               `json:"error_code,omitempty"`
+	RequesterPID       *int                 `json:"requester_pid,omitempty"`
+	RequesterUID       *int                 `json:"requester_uid,omitempty"`
+	RequesterPath      string               `json:"requester_path,omitempty"`
 	RemainingTTLMillis *int64               `json:"remaining_ttl_ms,omitempty"`
 	RemainingUses      *int                 `json:"remaining_uses,omitempty"`
 	ForceRefresh       bool                 `json:"force_refresh,omitempty"`

--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -245,12 +245,23 @@ func (b *Broker) ClientDisconnected(ctx context.Context, requestID string) {
 }
 
 func (b *Broker) Stop(ctx context.Context) {
-	_ = b.audit.Record(ctx, audit.Event{Type: audit.EventDaemonStop})
+	b.stopWithAudit(ctx, audit.Event{Type: audit.EventDaemonStop})
+}
+
+func (b *Broker) stopWithAudit(ctx context.Context, event audit.Event) {
+	b.recordDaemonStopAttempt(ctx, event)
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.active = make(map[string]*activeExec)
 	b.cache.Clear()
 	b.store = policy.NewStore(b.now)
+}
+
+func (b *Broker) recordDaemonStopAttempt(ctx context.Context, event audit.Event) {
+	if event.Type == "" {
+		event.Type = audit.EventDaemonStop
+	}
+	_ = b.audit.Record(ctx, event)
 }
 
 func (b *Broker) reusableGrant(ctx context.Context, req request.ExecRequest) (ExecGrant, error) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/kovyrin/agent-secret/internal/audit"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
@@ -111,7 +112,11 @@ func (s *Server) Serve(ctx context.Context, listener *net.UnixListener) error {
 }
 
 func (s *Server) Stop(ctx context.Context) {
-	s.broker.Stop(ctx)
+	s.stopWithAudit(ctx, audit.Event{Type: audit.EventDaemonStop})
+}
+
+func (s *Server) stopWithAudit(ctx context.Context, event audit.Event) {
+	s.broker.stopWithAudit(ctx, event)
 	s.stopOnce.Do(func() { close(s.stop) })
 }
 
@@ -142,12 +147,18 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 		case TypeDaemonStatus:
 			_ = writeOK(encoder, env.RequestID, env.Nonce, StatusPayload{PID: os.Getpid()})
 		case TypeDaemonStop:
-			if err := s.validateTrustedClientPeer(conn); err != nil {
+			peer, err := s.peerInfo(conn)
+			if err != nil {
+				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "peer_rejected", err)
+				continue
+			}
+			if err := s.execValidator.ValidateExecPeer(peer); err != nil {
+				s.broker.recordDaemonStopAttempt(ctx, daemonStopAuditEvent(peer, err))
 				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
 				continue
 			}
 			_ = writeOK(encoder, env.RequestID, env.Nonce, StatusPayload{PID: os.Getpid()})
-			s.Stop(ctx)
+			s.stopWithAudit(ctx, daemonStopAuditEvent(peer, nil))
 			return
 		case TypeApprovalPending:
 			if s.approvals == nil {
@@ -288,6 +299,21 @@ func (s *Server) peerInfo(conn *net.UnixConn) (peercred.Info, error) {
 		return provider.Info(conn)
 	}
 	return peercred.Inspect(conn)
+}
+
+func daemonStopAuditEvent(peer peercred.Info, err error) audit.Event {
+	pid := peer.PID
+	uid := peer.UID
+	event := audit.Event{
+		Type:          audit.EventDaemonStop,
+		RequesterPID:  &pid,
+		RequesterUID:  &uid,
+		RequesterPath: peer.ExecutablePath,
+	}
+	if err != nil {
+		event.ErrorCode = codeForError(err)
+	}
+	return event
 }
 
 func (s *Server) validateTrustedClientPeer(conn *net.UnixConn) error {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -210,12 +210,28 @@ func TestServerClientDisconnectAfterStartAuditsIncompleteLifecycle(t *testing.T)
 func TestServerDaemonStopTerminatesListener(t *testing.T) {
 	t.Parallel()
 
-	client, cleanup := startTestServer(t, BrokerOptions{
-		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
-		Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
-		Audit:    &memoryAudit{},
-	})
-	defer cleanup()
+	exe := currentExecutable(t)
+	peer := peerInfoForTest(t, os.Getpid(), exe)
+	aud := &memoryAudit{}
+	path, stop := startRawServerWithBrokerAndExecValidator(
+		t,
+		newTestBroker(t, BrokerOptions{
+			Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
+			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
+			Audit:    aud,
+		}),
+		nil,
+		staticPeerValidator{info: peer},
+		NewTrustedExecutableValidator([]string{exe}),
+	)
+	defer stop()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	client := NewClient(conn)
+	defer func() { _ = client.Close() }()
 
 	if _, err := client.Status(context.Background()); err != nil {
 		t.Fatalf("Status returned error: %v", err)
@@ -223,6 +239,11 @@ func TestServerDaemonStopTerminatesListener(t *testing.T) {
 	if _, err := client.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop returned error: %v", err)
 	}
+	events := aud.Events()
+	if len(events) != 1 || events[0].Type != audit.EventDaemonStop {
+		t.Fatalf("stop audit events = %+v", events)
+	}
+	assertRequesterAudit(t, events[0], peer, "")
 }
 
 func TestServerRejectsUntrustedDaemonStopPeer(t *testing.T) {
@@ -230,12 +251,13 @@ func TestServerRejectsUntrustedDaemonStopPeer(t *testing.T) {
 
 	exe := currentExecutable(t)
 	peer := peerInfoForTest(t, os.Getpid(), exe)
+	aud := &memoryAudit{}
 	path, stop := startRawServerWithBrokerAndExecValidator(
 		t,
 		newTestBroker(t, BrokerOptions{
 			Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
 			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
-			Audit:    &memoryAudit{},
+			Audit:    aud,
 		}),
 		nil,
 		staticPeerValidator{info: peer},
@@ -259,6 +281,11 @@ func TestServerRejectsUntrustedDaemonStopPeer(t *testing.T) {
 	if _, err := client.Status(context.Background()); err != nil {
 		t.Fatalf("daemon stopped after rejected stop: %v", err)
 	}
+	events := aud.Events()
+	if len(events) != 1 || events[0].Type != audit.EventDaemonStop {
+		t.Fatalf("stop audit events = %+v", events)
+	}
+	assertRequesterAudit(t, events[0], peer, "untrusted_client")
 }
 
 func TestServerApprovalProtocolOverSingleSocket(t *testing.T) {
@@ -711,4 +738,21 @@ func writeExecutableAt(t *testing.T, dir string, name string) string {
 		t.Fatalf("write executable: %v", err)
 	}
 	return path
+}
+
+func assertRequesterAudit(t *testing.T, event audit.Event, peer peercred.Info, wantErrorCode string) {
+	t.Helper()
+
+	if event.RequesterPID == nil || *event.RequesterPID != peer.PID {
+		t.Fatalf("requester pid = %v, want %d", event.RequesterPID, peer.PID)
+	}
+	if event.RequesterUID == nil || *event.RequesterUID != peer.UID {
+		t.Fatalf("requester uid = %v, want %d", event.RequesterUID, peer.UID)
+	}
+	if event.RequesterPath != peer.ExecutablePath {
+		t.Fatalf("requester path = %q, want %q", event.RequesterPath, peer.ExecutablePath)
+	}
+	if event.ErrorCode != wantErrorCode {
+		t.Fatalf("stop error code = %q, want %q", event.ErrorCode, wantErrorCode)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #22.

- keeps daemon stop restricted to the trusted executable validator
- records daemon stop attempts with value-free requester PID, UID, and executable path metadata when peer info is available
- records rejected stop attempts with the protocol error code without stopping the daemon
- expands authorized and unauthorized stop tests to assert trust enforcement and audit metadata

## Verification

- `mise exec -- go test ./internal/daemon ./internal/audit -run 'TestServerDaemonStopTerminatesListener|TestServerRejectsUntrustedDaemonStopPeer|TestBrokerDaemonStopClearsReusableState' -count=1`
- `mise run test`
- `mise run build`
- `mise run lint`
- `mise run test:race`
