### PR TITLE
Implement doctor health checks

### DIFF
--- a/approver/Sources/AgentSecretApproverApp/main.swift
+++ b/approver/Sources/AgentSecretApproverApp/main.swift
@@ -20,6 +20,10 @@ private let kUsageExitCode: Int32 = 64
 private let kArguments: [String] = Array(CommandLine.arguments.dropFirst())
 
 do {
+    if kArguments == ["--health-check"] {
+        print("agent-secret-approver: ok")
+        exit(0)
+    }
     guard let socketPath: String = try socketPath(from: kArguments) else {
         MainActor.assumeIsolated {
             runSetupDialog()

--- a/approver/Tests/AgentSecretApproverTests/ApproverAppEntrypointTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApproverAppEntrypointTests.swift
@@ -9,6 +9,7 @@ final class ApproverAppEntrypointTests: XCTestCase {
     private static let mockRequestFlag: String = "--mock-request"
     private static let packageDirectoryName: String = "approver"
     private static let smokeEntrypointPath: String = "Sources/AgentSecretApproverSmoke/main.swift"
+    private static let healthCheckFlag: String = "--health-check"
 
     private static func packageRootURL() -> URL? {
         var url = URL(fileURLWithPath: #filePath)
@@ -37,6 +38,13 @@ final class ApproverAppEntrypointTests: XCTestCase {
         XCTAssertFalse(source.contains(Self.mockDecisionFlag))
         XCTAssertFalse(source.contains(Self.mockClientSymbol))
         XCTAssertFalse(source.contains(Self.mockPresenterSymbol))
+    }
+
+    func testShippedApproverEntrypointProvidesNonSecretHealthCheck() throws {
+        let source: String = try Self.sourceText(at: Self.appEntrypointPath)
+
+        XCTAssertTrue(source.contains(Self.healthCheckFlag))
+        XCTAssertTrue(source.contains("agent-secret-approver: ok"))
     }
 
     func testSmokeEntrypointOwnsMockOnlySurface() throws {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -17,16 +17,19 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon"
 	"github.com/kovyrin/agent-secret/internal/execwrap"
 	"github.com/kovyrin/agent-secret/internal/install"
+	"github.com/kovyrin/agent-secret/internal/opresolver"
 )
 
 type App struct {
-	Parser       Parser
-	Manager      daemon.Manager
-	InstallCLI   func(install.CLIOptions) (install.CLIResult, error)
-	InstallSkill func(install.SkillOptions) (install.SkillResult, error)
-	RandomReader io.Reader
-	Stdout       io.Writer
-	Stderr       io.Writer
+	Parser                 Parser
+	Manager                daemon.Manager
+	InstallCLI             func(install.CLIOptions) (install.CLIResult, error)
+	InstallSkill           func(install.SkillOptions) (install.SkillResult, error)
+	RandomReader           io.Reader
+	DoctorApproverCheck    func(context.Context) error
+	DoctorOnePasswordCheck func(context.Context) error
+	Stdout                 io.Writer
+	Stderr                 io.Writer
 }
 
 func NewApp(manager daemon.Manager, stdout io.Writer, stderr io.Writer) App {
@@ -37,13 +40,15 @@ func NewApp(manager daemon.Manager, stdout io.Writer, stderr io.Writer) App {
 		stderr = os.Stderr
 	}
 	return App{
-		Parser:       NewParser(time.Now),
-		Manager:      manager,
-		InstallCLI:   install.InstallCLI,
-		InstallSkill: install.InstallSkill,
-		RandomReader: rand.Reader,
-		Stdout:       stdout,
-		Stderr:       stderr,
+		Parser:                 NewParser(time.Now),
+		Manager:                manager,
+		InstallCLI:             install.InstallCLI,
+		InstallSkill:           install.InstallSkill,
+		RandomReader:           rand.Reader,
+		DoctorApproverCheck:    checkApproverHealth,
+		DoctorOnePasswordCheck: checkOnePasswordDesktopIntegration,
+		Stdout:                 stdout,
+		Stderr:                 stderr,
 	}
 }
 
@@ -173,21 +178,87 @@ func (a App) runDaemonStop(ctx context.Context) int {
 }
 
 func (a App) runDoctor(ctx context.Context) int {
-	auditPath, auditErr := audit.DefaultPath()
+	healthy := true
 	a.stdoutln("agent-secret doctor")
 	a.stdoutf("platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 	a.stdoutf("daemon socket: %s\n", a.Manager.SocketPath)
-	if auditErr != nil {
-		a.stdoutf("audit log: unavailable (%v)\n", auditErr)
+	if auditPath, err := checkAuditLogWritable(ctx); err != nil {
+		healthy = false
+		if auditPath == "" {
+			a.stdoutf("audit log: failed (%v)\n", err)
+		} else {
+			a.stdoutf("audit log: failed %s (%v)\n", auditPath, err)
+		}
 	} else {
-		a.stdoutf("audit log: %s\n", auditPath)
+		a.stdoutf("audit log: writable %s\n", auditPath)
+	}
+	if err := a.Manager.EnsureRunning(ctx); err != nil {
+		healthy = false
+		a.stdoutf("daemon startup: failed (%v)\n", err)
+	} else {
+		a.stdoutln("daemon startup: ok")
 	}
 	if status, err := a.Manager.Status(ctx); err == nil {
 		a.stdoutf("daemon: running pid=%d\n", status.PID)
 	} else {
-		a.stdoutf("daemon: stopped (%v)\n", err)
+		healthy = false
+		a.stdoutf("daemon: failed (%v)\n", err)
+	}
+	if err := daemon.ValidateSocketDirectory(a.Manager.SocketPath); err != nil {
+		healthy = false
+		a.stdoutf("socket directory: failed (%v)\n", err)
+	} else {
+		a.stdoutln("socket directory: private")
+	}
+	if check := a.DoctorApproverCheck; check != nil {
+		if err := check(ctx); err != nil {
+			healthy = false
+			a.stdoutf("native approver: failed (%v)\n", err)
+		} else {
+			a.stdoutln("native approver: ok")
+		}
+	}
+	if check := a.DoctorOnePasswordCheck; check != nil {
+		if err := check(ctx); err != nil {
+			healthy = false
+			a.stdoutf("1password desktop integration: failed (%v)\n", err)
+		} else {
+			a.stdoutln("1password desktop integration: ok")
+		}
+	}
+	if !healthy {
+		return 1
 	}
 	return 0
+}
+
+func checkAuditLogWritable(ctx context.Context) (string, error) {
+	path, err := audit.DefaultPath()
+	if err != nil {
+		return "", err
+	}
+	writer, err := audit.OpenDefault(nil)
+	if err != nil {
+		return path, err
+	}
+	defer func() { _ = writer.Close() }()
+	if err := writer.Preflight(ctx); err != nil {
+		return path, err
+	}
+	return path, nil
+}
+
+func checkApproverHealth(ctx context.Context) error {
+	return (daemon.ProcessApproverLauncher{}).CheckHealth(ctx)
+}
+
+func checkOnePasswordDesktopIntegration(ctx context.Context) error {
+	_, err := opresolver.NewDesktopResolver(ctx, opresolver.ClientOptions{
+		Account:            os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT"),
+		IntegrationName:    "Agent Secret Doctor",
+		IntegrationVersion: "dev",
+	})
+	return err
 }
 
 func (a App) runInstallCLI(command Command) int {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -130,6 +130,7 @@ func TestAppExecStopsBeforeSpawnOnApprovalDenial(t *testing.T) {
 }
 
 func TestAppDaemonStatusAndDoctor(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	client, cleanup := startAppTestServer(t, daemon.BrokerOptions{
 		Approver: &appApprover{decision: daemon.ApprovalDecision{Approved: true}},
 		Resolver: &appResolver{values: map[string]string{"op://Example/Item/token": "value"}},
@@ -139,6 +140,8 @@ func TestAppDaemonStatusAndDoctor(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	app := NewApp(daemon.Manager{SocketPath: client.SocketPath}, &stdout, &stderr)
+	app.DoctorApproverCheck = func(context.Context) error { return nil }
+	app.DoctorOnePasswordCheck = func(context.Context) error { return nil }
 
 	if code := app.Run(context.Background(), []string{"daemon", "status"}); code != 0 {
 		t.Fatalf("daemon status exit=%d stderr=%q", code, stderr.String())
@@ -150,8 +153,40 @@ func TestAppDaemonStatusAndDoctor(t *testing.T) {
 	if code := app.Run(context.Background(), []string{"doctor"}); code != 0 {
 		t.Fatalf("doctor exit=%d stderr=%q", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "audit log:") || !strings.Contains(stdout.String(), "daemon socket:") {
+	if !strings.Contains(stdout.String(), "audit log: writable") ||
+		!strings.Contains(stdout.String(), "daemon startup: ok") ||
+		!strings.Contains(stdout.String(), "socket directory: private") ||
+		!strings.Contains(stdout.String(), "native approver: ok") ||
+		!strings.Contains(stdout.String(), "1password desktop integration: ok") {
 		t.Fatalf("doctor output missing diagnostics: %q", stdout.String())
+	}
+}
+
+func TestAppDoctorReportsFailureWithoutSecretValues(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	client, cleanup := startAppTestServer(t, daemon.BrokerOptions{
+		Approver: &appApprover{decision: daemon.ApprovalDecision{Approved: true}},
+		Resolver: &appResolver{values: map[string]string{"op://Example/Item/token": "synthetic-secret-value"}},
+		Audit:    &appAudit{},
+	})
+	defer cleanup()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := NewApp(daemon.Manager{SocketPath: client.SocketPath}, &stdout, &stderr)
+	app.DoctorApproverCheck = func(context.Context) error { return nil }
+	app.DoctorOnePasswordCheck = func(context.Context) error {
+		return errors.New("desktop integration unavailable")
+	}
+
+	code := app.Run(context.Background(), []string{"doctor"})
+	if code != 1 {
+		t.Fatalf("doctor exit=%d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "1password desktop integration: failed") {
+		t.Fatalf("doctor stdout = %q, want 1Password failure", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "synthetic-secret-value") || strings.Contains(stderr.String(), "synthetic-secret-value") {
+		t.Fatalf("doctor leaked secret: stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -630,8 +630,8 @@ Daemon stop clears daemon-owned in-memory approvals, sessions, counters, nonces,
 
 func DoctorHelp() string {
 	return strings.TrimSpace(`
-agent-secret doctor prints non-secret local diagnostics: expected daemon socket path, audit log path, current platform, and whether the daemon responds.
-It never prints secret values or reads 1Password items.
+agent-secret doctor starts the daemon if needed and prints non-secret local diagnostics: platform, socket directory privacy, audit log writability, daemon status, native approver health, and 1Password desktop integration readiness.
+It never prints secret values or resolves 1Password item references.
 `)
 }
 

--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -216,6 +218,42 @@ func (a *SocketApprover) SubmitDecision(
 type ProcessApproverLauncher struct {
 	AppPath        string
 	IdentityPolicy ApproverIdentityPolicy
+}
+
+func (l ProcessApproverLauncher) CheckHealth(ctx context.Context) error {
+	executable, err := l.executablePath()
+	if err != nil {
+		return err
+	}
+	identity, err := l.identityPolicy().ValidateApproverExecutable(executable)
+	if err != nil {
+		return err
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	//nolint:gosec // G204: executable was canonicalized and validated by the approver identity policy above.
+	cmd := exec.CommandContext(checkCtx, identity.ExecutablePath, "--health-check")
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("%w: open /dev/null: %w", ErrApproverLaunchFailed, err)
+	}
+	defer func() { _ = devNull.Close() }()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdin = devNull
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if errors.Is(checkCtx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("%w: health check timed out", ErrApproverLaunchFailed)
+		}
+		return fmt.Errorf("%w: health check failed: %w", ErrApproverLaunchFailed, err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "agent-secret-approver: ok" {
+		return fmt.Errorf("%w: unexpected health check response %q", ErrApproverLaunchFailed, got)
+	}
+	return nil
 }
 
 func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string, _ ApprovalRequestPayload) (ExpectedApprover, error) {

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -375,6 +375,40 @@ func TestProcessApproverLauncherLaunchesBinary(t *testing.T) {
 	}
 }
 
+func TestProcessApproverLauncherHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	helper := filepath.Join(t.TempDir(), "approver-helper")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nif [ \"$1\" = \"--health-check\" ]; then echo 'agent-secret-approver: ok'; exit 0; fi\nexit 64\n"), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+
+	err := (ProcessApproverLauncher{
+		AppPath:        helper,
+		IdentityPolicy: allowApproverIdentityPolicy{},
+	}).CheckHealth(context.Background())
+	if err != nil {
+		t.Fatalf("CheckHealth returned error: %v", err)
+	}
+}
+
+func TestProcessApproverLauncherHealthCheckRejectsUnexpectedOutput(t *testing.T) {
+	t.Parallel()
+
+	helper := filepath.Join(t.TempDir(), "approver-helper")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\necho nope\n"), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+
+	err := (ProcessApproverLauncher{
+		AppPath:        helper,
+		IdentityPolicy: allowApproverIdentityPolicy{},
+	}).CheckHealth(context.Background())
+	if !errors.Is(err, ErrApproverLaunchFailed) {
+		t.Fatalf("CheckHealth error = %v, want ErrApproverLaunchFailed", err)
+	}
+}
+
 func TestProcessApproverLauncherRejectsBareBinaryByDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -53,6 +53,10 @@ func prepareSocketDirectory(path string) error {
 	return prepareCustomSocketDirectory(filepath.Dir(path))
 }
 
+func ValidateSocketDirectory(path string) error {
+	return rejectInsecureSocketDirectory(filepath.Dir(path))
+}
+
 func prepareDefaultSocketDirectory(dir string) error {
 	//nolint:gosec // G703: dir is the managed default socket directory under Application Support.
 	if err := os.MkdirAll(dir, 0o700); err != nil {


### PR DESCRIPTION
## Summary
- make `agent-secret doctor` start the daemon through `EnsureRunning` and report daemon status, socket directory privacy, and audit log writability
- add a shipped native approver `--health-check` path and validate it through the existing approver identity checks
- verify 1Password desktop SDK/client readiness without resolving any `op://` reference, with value-free healthy/failing CLI coverage

Closes #23

## Verification
- `mise exec -- go test ./internal/cli ./internal/daemon -run 'TestAppDaemonStatusAndDoctor|TestAppDoctorReportsFailureWithoutSecretValues|TestProcessApproverLauncherHealthCheck|TestProcessApproverLauncherHealthCheckRejectsUnexpectedOutput'`\n- `mise exec -- swift test --package-path approver --filter ApproverAppEntrypointTests`\n- `mise run test`\n- `mise run build`\n- `mise run lint`\n- `mise run test:race`\n- `"dist/Agent Secret.app/Contents/MacOS/Agent Secret" --health-check`