### PR TITLE
Align verification docs with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,28 @@ jobs:
       - name: Build commands and app bundle
         run: mise run build
 
+  smoke-tests:
+    name: Smoke Tests
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
+          cache: true
+
+      - name: Trust mise config
+        run: mise trust --yes
+
+      - name: Install project dependencies
+        run: mise run setup
+
+      - name: Run non-secret smoke tests
+        run: mise run test:smoke
+
   draft-release-artifacts:
     name: Draft Release Artifacts
     if: startsWith(github.ref, 'refs/tags/v')

--- a/README.md
+++ b/README.md
@@ -54,32 +54,62 @@ internals, but the repository boundary and module path should remain stable.
 
 ## Current Verification
 
-The current project-local checks are:
+The default local checks match pull request CI:
 
 ```bash
 mise run setup
 mise run lint
 mise run build
+mise run test:smoke
 ```
 
-The underlying commands are:
+`mise run lint` runs the normal static and test gates:
 
 ```bash
 scripts/lint.sh
 go test ./...
-go test -tags integration ./...
-go build ./cmd/agent-secret ./cmd/agent-secretd
+go test -race ./...
+scripts/check-go-coverage.sh
+govulncheck ./...
+gitleaks dir . --redact --no-banner
+shellcheck scripts/*.sh approver/scripts/*.sh
+actionlint .github/workflows/*.yml
+swiftlint lint --strict --no-cache
+npx --no-install markdownlint '**/*.md'
 cd approver && swift test
+```
+
+`mise run build` runs the app bundle build:
+
+```bash
 scripts/build-app-bundle.sh
-scripts/build-release.sh v0.0.0-dev
+```
+
+`mise run test:smoke` runs the non-secret approver smoke executable:
+
+```bash
 swift run agent-secret-approver-smoke
 ```
 
-The integration test skips unless `AGENT_SECRET_LIVE_REF` points at a test-only
-1Password reference. Set `OP_ACCOUNT` or `AGENT_SECRET_1PASSWORD_ACCOUNT` only
-when you want to force a specific 1Password account instead of
-`my.1password.com`. Project config accounts override those defaults for the
-secrets that declare them.
+Live 1Password integration tests are intentionally opt-in and are not part of
+normal pull request CI. Run them only with a test-only reference and Desktop App
+Integration enabled:
+
+```bash
+AGENT_SECRET_LIVE_REF="op://Test Vault/Test Item/token" \
+  go test -tags integration ./...
+```
+
+Set `OP_ACCOUNT` or `AGENT_SECRET_1PASSWORD_ACCOUNT` only when you want to
+force a specific 1Password account instead of `my.1password.com`. Project
+config accounts override those defaults for the secrets that declare them.
+
+Release artifact verification is separate from pull request CI. For a local
+release-candidate check, run:
+
+```bash
+scripts/build-release.sh v0.0.0-dev
+```
 
 ## Development Toolchain
 

--- a/mise.toml
+++ b/mise.toml
@@ -73,6 +73,10 @@ run = "go test -race ./..."
 description = "Run Go tests with coverage floors for internal packages"
 run = "scripts/check-go-coverage.sh"
 
+[tasks."test:smoke"]
+description = "Run non-secret smoke tests"
+run = "cd approver && swift run agent-secret-approver-smoke"
+
 [tasks.build]
 description = "Build the unified macOS Agent Secret app bundle"
 run = "AGENT_SECRET_IN_MISE=1 scripts/build-app-bundle.sh"


### PR DESCRIPTION
## Summary
- document the actual default local and pull request checks instead of mixing in live integration and release commands
- add `mise run test:smoke` for the non-secret approver smoke executable
- add a dedicated CI smoke-test job so the documented smoke check is enforced

Closes #24

## Verification
- `mise run test:smoke`
- `npx --yes markdownlint-cli README.md`
- `mise run lint:toml`
- `mise exec -- actionlint .github/workflows/ci.yml`
- `mise run lint`
- `mise run build`