### PR TITLE
Align dev install discovery with app bundle

### DIFF
--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -226,8 +226,10 @@ Expected lookup order:
 
 2. If running through the symlink, resolve the symlink and then use the same
    app-relative path.
-3. In development, keep the current fallback to `~/Applications` or PATH so
-   local builds remain easy to test.
+3. For development installs, look for
+   `~/Applications/Agent Secret.app/Contents/Library/Helpers/AgentSecretDaemon.app`.
+4. For unbundled local test binaries only, keep direct sibling binary discovery
+   so package tests and ad hoc builds remain easy to run.
 
 ### App Setup UI
 

--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -445,10 +445,10 @@ func defaultApproverPath() (string, error) {
 		candidates = append(candidates, filepath.Join(
 			home,
 			"Applications",
-			"AgentSecretApprover.app",
+			"Agent Secret.app",
 			"Contents",
 			"MacOS",
-			"agent-secret-approver",
+			"Agent Secret",
 		))
 	}
 	for _, candidate := range candidates {

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -348,6 +348,26 @@ func TestApproverCandidatesForBundledExecutables(t *testing.T) {
 	}
 }
 
+func TestDefaultApproverPathUsesInstalledUnifiedApp(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	want := filepath.Join(home, "Applications", "Agent Secret.app", "Contents", "MacOS", "Agent Secret")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatalf("create app macos dir: %v", err)
+	}
+	if err := os.WriteFile(want, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write app executable: %v", err)
+	}
+
+	got, err := defaultApproverPath()
+	if err != nil {
+		t.Fatalf("defaultApproverPath returned error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("default approver path = %q, want installed app executable %q", got, want)
+	}
+}
+
 func TestProcessApproverLauncherLaunchesBinary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -185,7 +185,15 @@ func TestManagerRejectsPermissiveCustomSocketParentWithoutChmod(t *testing.T) {
 func TestDaemonAppPathAndStartCommand(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	daemonAppPath := filepath.Join(home, "Applications", "AgentSecretDaemon.app")
+	daemonAppPath := filepath.Join(
+		home,
+		"Applications",
+		"Agent Secret.app",
+		"Contents",
+		"Library",
+		"Helpers",
+		"AgentSecretDaemon.app",
+	)
 	if err := os.MkdirAll(daemonAppPath, 0o755); err != nil {
 		t.Fatalf("mkdir daemon app: %v", err)
 	}
@@ -254,5 +262,21 @@ func TestDaemonAppPathForBundledExecutable(t *testing.T) {
 	got, ok := daemonAppPathForExecutable(cliPath)
 	if !ok || got != daemonAppPath {
 		t.Fatalf("daemon app path = %q, %v, want %q, true", got, ok, daemonAppPath)
+	}
+
+	symlinkPath := filepath.Join(root, "bin", "agent-secret")
+	if err := os.MkdirAll(filepath.Dir(symlinkPath), 0o755); err != nil {
+		t.Fatalf("create symlink dir: %v", err)
+	}
+	if err := os.Symlink(cliPath, symlinkPath); err != nil {
+		t.Fatalf("create cli symlink: %v", err)
+	}
+	resolvedDaemonAppPath, err := filepath.EvalSymlinks(daemonAppPath)
+	if err != nil {
+		t.Fatalf("resolve daemon app path: %v", err)
+	}
+	got, ok = daemonAppPathForExecutable(symlinkPath)
+	if !ok || got != resolvedDaemonAppPath {
+		t.Fatalf("daemon app path through symlink = %q, %v, want %q, true", got, ok, resolvedDaemonAppPath)
 	}
 }

--- a/internal/daemon/process_unix.go
+++ b/internal/daemon/process_unix.go
@@ -44,7 +44,15 @@ func defaultDaemonAppPath() (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	appPath := filepath.Join(home, "Applications", "AgentSecretDaemon.app")
+	appPath := filepath.Join(
+		home,
+		"Applications",
+		"Agent Secret.app",
+		"Contents",
+		"Library",
+		"Helpers",
+		"AgentSecretDaemon.app",
+	)
 	info, err := os.Stat(appPath)
 	if err != nil || !info.IsDir() {
 		return "", false


### PR DESCRIPTION
## Summary
- make the development fallback daemon lookup use `~/Applications/Agent Secret.app/Contents/Library/Helpers/AgentSecretDaemon.app`
- make the installed fallback approver lookup use the top-level `Agent Secret.app` executable instead of the old split approver app
- test nested daemon helper discovery through both bundled and symlinked CLI paths, and test installed release-style approver discovery
- update the distribution plan to mark direct sibling binaries as unbundled local-test fallback only

Closes #26

## Verification
- `mise exec -- go test ./internal/daemon -run 'TestDaemonAppPathAndStartCommand|TestDaemonAppPathForBundledExecutable|TestApproverCandidatesForBundledExecutables|TestDefaultApproverPathUsesInstalledUnifiedApp'`\n- `npx --yes markdownlint-cli docs/macos-distribution-plan.md`\n- temp install topology smoke: `mise exec -- env HOME=$tmp/home AGENT_SECRET_IN_MISE=1 AGENT_SECRET_INSTALL_BIN_DIR=$tmp/bin AGENT_SECRET_INSTALL_APP_DIR=$tmp/Applications scripts/dev-install.sh` plus checks for app executable, nested daemon helper, CLI symlink, and skill symlink\n- `mise run lint`\n- `mise run build`\n- `mise run test:smoke`