### PR TITLE
ASR-001: Fix production daemon trust inputs

### DIFF
--- a/cmd/agent-secretd/main.go
+++ b/cmd/agent-secretd/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -26,19 +26,8 @@ func run() int {
 		return 1
 	}
 
-	socketPath, err := daemon.DefaultSocketPath()
+	config, err := parseDaemonConfig(os.Args[1:])
 	if err != nil {
-		stderrf("agent-secretd: resolve default socket path: %v\n", err)
-		return 1
-	}
-
-	flags := flag.NewFlagSet("agent-secretd", flag.ExitOnError)
-	flags.StringVar(&socketPath, "socket", socketPath, "daemon socket path")
-	var trustedClients stringListFlag
-	flags.Var(&trustedClients, "trusted-client", "trusted agent-secret executable path; repeatable")
-	approverPath := flags.String("approver", defaultApproverFlagValue(), "approver executable or .app path")
-	accountName := flags.String("account", os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT"), "1Password account sign-in address, name, or UUID; empty uses OP_ACCOUNT or my.1password.com")
-	if err := flags.Parse(os.Args[1:]); err != nil {
 		stderrf("agent-secretd: parse flags: %v\n", err)
 		return 2
 	}
@@ -51,8 +40,8 @@ func run() int {
 	defer func() { _ = auditWriter.Close() }()
 
 	approver, err := daemon.NewSocketApprover(
-		socketPath,
-		daemon.ProcessApproverLauncher{AppPath: *approverPath},
+		config.socketPath,
+		daemon.ProcessApproverLauncher{},
 		nil,
 	)
 	if err != nil {
@@ -62,54 +51,61 @@ func run() int {
 
 	broker, err := daemon.NewBroker(daemon.BrokerOptions{
 		Approver: approver,
-		Resolver: newResolver(*accountName),
+		Resolver: newResolver(config.accountName),
 		Audit:    auditWriter,
 	})
 	if err != nil {
 		stderrf("agent-secretd: initialize broker: %v\n", err)
 		return 1
 	}
-	trustedClientPaths := []string(trustedClients)
-	if len(trustedClientPaths) == 0 {
-		trustedClientPaths = daemon.DefaultTrustedClientPaths()
-	}
 	server, err := daemon.NewServer(daemon.ServerOptions{
 		Broker:        broker,
 		Approvals:     approver,
-		ExecValidator: daemon.NewTrustedExecutableValidator(trustedClientPaths),
+		ExecValidator: daemon.NewTrustedExecutableValidator(daemon.DefaultTrustedClientPaths()),
 	})
 	if err != nil {
 		stderrf("agent-secretd: initialize server: %v\n", err)
 		return 1
 	}
-	if err := server.ListenAndServe(context.Background(), socketPath); err != nil {
+	if err := server.ListenAndServe(context.Background(), config.socketPath); err != nil {
 		stderrf("agent-secretd: %v\n", err)
 		return 1
 	}
 	return 0
 }
 
+type daemonConfig struct {
+	socketPath  string
+	accountName string
+}
+
+func parseDaemonConfig(args []string) (daemonConfig, error) {
+	socketPath, err := daemon.DefaultSocketPath()
+	if err != nil {
+		return daemonConfig{}, fmt.Errorf("resolve default socket path: %w", err)
+	}
+
+	config := daemonConfig{}
+	flags := flag.NewFlagSet("agent-secretd", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.StringVar(&config.socketPath, "socket", socketPath, "daemon socket path")
+	flags.StringVar(
+		&config.accountName,
+		"account",
+		os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT"),
+		"1Password account sign-in address, name, or UUID; empty uses OP_ACCOUNT or my.1password.com",
+	)
+	if err := flags.Parse(args); err != nil {
+		return daemonConfig{}, err
+	}
+	if flags.NArg() != 0 {
+		return daemonConfig{}, fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	return config, nil
+}
+
 func stderrf(format string, args ...any) {
 	_, _ = fmt.Fprintf(os.Stderr, format, args...)
-}
-
-func defaultApproverFlagValue() string {
-	return ""
-}
-
-type stringListFlag []string
-
-func (f *stringListFlag) String() string {
-	return strings.Join(*f, ",")
-}
-
-func (f *stringListFlag) Set(value string) error {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return errors.New("trusted client path is required")
-	}
-	*f = append(*f, value)
-	return nil
 }
 
 type desktopResolver struct {

--- a/cmd/agent-secretd/main_test.go
+++ b/cmd/agent-secretd/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -10,11 +11,28 @@ import (
 	"github.com/kovyrin/agent-secret/internal/opresolver"
 )
 
-func TestDefaultApproverFlagValueIgnoresEnvironmentOverride(t *testing.T) {
+func TestParseDaemonConfigRejectsCallerSelectedTrustInputs(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		{"--approver", "/tmp/fake-approver.app"},
+		{"--trusted-client", "/tmp/fake-agent-secret"},
+	} {
+		_, err := parseDaemonConfig(args)
+		if err == nil {
+			t.Fatalf("parseDaemonConfig(%v) returned nil error", args)
+		}
+		if !strings.Contains(err.Error(), "flag provided but not defined") {
+			t.Fatalf("parseDaemonConfig(%v) error = %v, want unknown flag", args, err)
+		}
+	}
+}
+
+func TestParseDaemonConfigDoesNotReadApproverEnvironmentOverride(t *testing.T) {
 	t.Setenv("AGENT_SECRET_APPROVER_PATH", "/tmp/fake-approver")
 
-	if got := defaultApproverFlagValue(); got != "" {
-		t.Fatalf("default approver flag value = %q, want empty", got)
+	if _, err := parseDaemonConfig([]string{}); err != nil {
+		t.Fatalf("parseDaemonConfig returned error: %v", err)
 	}
 }
 

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -525,6 +525,19 @@ func TestDefaultApproverIdentityMatchesBundleMetadata(t *testing.T) {
 	}
 }
 
+func TestDefaultApproverIdentityPolicyUsesBuildConfiguredTeamID(t *testing.T) {
+	previous := defaultApproverExpectedTeamID
+	defaultApproverExpectedTeamID = " B6L7QLWTZW "
+	t.Cleanup(func() {
+		defaultApproverExpectedTeamID = previous
+	})
+
+	policy := DefaultApproverIdentityPolicy()
+	if policy.ExpectedTeamID != "B6L7QLWTZW" {
+		t.Fatalf("ExpectedTeamID = %q, want configured Developer ID Team ID", policy.ExpectedTeamID)
+	}
+}
+
 func TestBundleApproverIdentityPolicyRejectsWrongBundleID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/approver_identity.go
+++ b/internal/daemon/approver_identity.go
@@ -18,6 +18,9 @@ const (
 	DefaultApproverExecutable = "Agent Secret"
 )
 
+//nolint:gochecknoglobals // Release builds set this with -ldflags to bind the approver to the signing Team ID.
+var defaultApproverExpectedTeamID string
+
 type BundleApproverIdentityPolicy struct {
 	ExpectedBundleID   string
 	ExpectedExecutable string
@@ -29,6 +32,7 @@ func DefaultApproverIdentityPolicy() BundleApproverIdentityPolicy {
 	return BundleApproverIdentityPolicy{
 		ExpectedBundleID:   DefaultApproverBundleID,
 		ExpectedExecutable: DefaultApproverExecutable,
+		ExpectedTeamID:     strings.TrimSpace(defaultApproverExpectedTeamID),
 		VerifySignature:    runtime.GOOS == "darwin",
 	}
 }

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -11,11 +11,10 @@ import (
 )
 
 type Manager struct {
-	SocketPath         string
-	DaemonPath         string
-	DaemonArgs         []string
-	TrustedClientPaths []string
-	StartupTimeout     time.Duration
+	SocketPath     string
+	DaemonPath     string
+	DaemonArgs     []string
+	StartupTimeout time.Duration
 }
 
 func NewManager(socketPath string) (Manager, error) {
@@ -31,10 +30,9 @@ func NewManager(socketPath string) (Manager, error) {
 		return Manager{}, err
 	}
 	return Manager{
-		SocketPath:         socketPath,
-		DaemonPath:         daemonPath,
-		TrustedClientPaths: CurrentExecutableTrustedClientPaths(),
-		StartupTimeout:     3 * time.Second,
+		SocketPath:     socketPath,
+		DaemonPath:     daemonPath,
+		StartupTimeout: 3 * time.Second,
 	}, nil
 }
 
@@ -130,14 +128,7 @@ func (m Manager) stopped(ctx context.Context) bool {
 
 func (m Manager) daemonArgs() []string {
 	if len(m.DaemonArgs) == 0 {
-		args := []string{"--socket", m.SocketPath}
-		for _, path := range m.TrustedClientPaths {
-			if strings.TrimSpace(path) == "" {
-				continue
-			}
-			args = append(args, "--trusted-client", path)
-		}
-		return args
+		return []string{"--socket", m.SocketPath}
 	}
 	args := make([]string, 0, len(m.DaemonArgs))
 	for _, arg := range m.DaemonArgs {

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -123,9 +123,6 @@ func TestNewManagerIgnoresDaemonPathEnvironmentOverride(t *testing.T) {
 	if manager.DaemonPath == "/tmp/agent-secretd-test" {
 		t.Fatalf("DaemonPath honored requester-controlled env override: %q", manager.DaemonPath)
 	}
-	if !slices.Equal(manager.TrustedClientPaths, CurrentExecutableTrustedClientPaths()) {
-		t.Fatalf("TrustedClientPaths = %v, want current executable", manager.TrustedClientPaths)
-	}
 	if manager.StartupTimeout != 3*time.Second {
 		t.Fatalf("StartupTimeout = %s, want 3s", manager.StartupTimeout)
 	}
@@ -137,19 +134,6 @@ func TestManagerDaemonArgsReplaceSocketPlaceholder(t *testing.T) {
 	manager := Manager{SocketPath: "/tmp/agent-secret.sock"}
 	if got := manager.daemonArgs(); !slices.Equal(got, []string{"--socket", "/tmp/agent-secret.sock"}) {
 		t.Fatalf("default daemon args = %v", got)
-	}
-
-	manager.TrustedClientPaths = []string{"/usr/local/bin/agent-secret", "/opt/agent-secret"}
-	wantTrusted := []string{
-		"--socket",
-		"/tmp/agent-secret.sock",
-		"--trusted-client",
-		"/usr/local/bin/agent-secret",
-		"--trusted-client",
-		"/opt/agent-secret",
-	}
-	if got := manager.daemonArgs(); !slices.Equal(got, wantTrusted) {
-		t.Fatalf("trusted daemon args = %v, want %v", got, wantTrusted)
 	}
 
 	manager.DaemonArgs = []string{"--listen", "{socket}", "--verbose"}

--- a/internal/daemon/trusted_client.go
+++ b/internal/daemon/trusted_client.go
@@ -45,12 +45,23 @@ func DefaultTrustedClientPaths() []string {
 	if err != nil {
 		return nil
 	}
+	home := ""
+	if userHome, err := os.UserHomeDir(); err == nil {
+		home = userHome
+	}
+	return trustedClientPathsForExecutable(exe, home)
+}
+
+func trustedClientPathsForExecutable(exe string, home string) []string {
 	dir := filepath.Dir(exe)
 	paths := []string{filepath.Join(dir, "agent-secret")}
 	if filepath.Base(exe) == "agent-secret" {
 		paths = append(paths, exe)
 	}
-	if home, err := os.UserHomeDir(); err == nil {
+	if bundledCLI, ok := bundledCLIPathForDaemonExecutable(exe); ok {
+		paths = append(paths, bundledCLI)
+	}
+	if home != "" {
 		paths = append(paths, filepath.Join(home, ".local", "bin", "agent-secret"))
 	}
 	return paths
@@ -62,6 +73,32 @@ func CurrentExecutableTrustedClientPaths() []string {
 		return nil
 	}
 	return []string{exe}
+}
+
+func bundledCLIPathForDaemonExecutable(exe string) (string, bool) {
+	bundlePath, ok := containingAppBundlePath(exe)
+	if !ok || filepath.Base(bundlePath) != "AgentSecretDaemon.app" {
+		return "", false
+	}
+	hostApp := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(bundlePath))))
+	if filepath.Ext(hostApp) != ".app" {
+		return "", false
+	}
+	return filepath.Join(hostApp, "Contents", "Resources", "bin", "agent-secret"), true
+}
+
+func containingAppBundlePath(path string) (string, bool) {
+	dir := filepath.Dir(path)
+	for {
+		if filepath.Ext(dir) == ".app" {
+			return filepath.Clean(dir), true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
 }
 
 func (v TrustedExecutableValidator) ValidateExecPeer(info peercred.Info) error {

--- a/internal/daemon/trusted_client_test.go
+++ b/internal/daemon/trusted_client_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/kovyrin/agent-secret/internal/peercred"
@@ -37,5 +38,28 @@ func TestTrustedExecutableValidatorRejectsUnlistedExecutable(t *testing.T) {
 	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: other})
 	if !errors.Is(err, ErrUntrustedClient) {
 		t.Fatalf("expected ErrUntrustedClient, got %v", err)
+	}
+}
+
+func TestDefaultTrustedClientPathsIncludeBundledCLIForDaemonHelper(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	appPath := filepath.Join(root, "Agent Secret.app")
+	daemonExe := filepath.Join(
+		appPath,
+		"Contents",
+		"Library",
+		"Helpers",
+		"AgentSecretDaemon.app",
+		"Contents",
+		"MacOS",
+		"Agent Secret",
+	)
+	wantCLI := filepath.Join(appPath, "Contents", "Resources", "bin", "agent-secret")
+
+	got := trustedClientPathsForExecutable(daemonExe, "")
+	if !slices.Contains(got, wantCLI) {
+		t.Fatalf("trusted paths = %v, want bundled CLI %q", got, wantCLI)
 	}
 }

--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -18,6 +18,7 @@ USAGE
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 # shellcheck source=scripts/bundle-metadata.sh
+# shellcheck disable=SC1091
 source "$project_root/scripts/bundle-metadata.sh"
 
 if [[ "${AGENT_SECRET_IN_MISE:-}" != "1" ]]; then
@@ -135,6 +136,17 @@ sign_path() {
   codesign "${args[@]}" >/dev/null
 }
 
+codesign_team_id() {
+  local identity="$1"
+
+  if [[ "$identity" =~ \(([A-Za-z0-9]+)\)$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return
+  fi
+
+  return 1
+}
+
 build_daemon_app() {
   local binary_path="$1"
   local bundle="$2"
@@ -185,8 +197,16 @@ PLIST
 
 echo "Building Go commands..."
 cd "$project_root"
-go build -trimpath -o "$tmp_dir/agent-secret" ./cmd/agent-secret
-go build -trimpath -o "$tmp_dir/agent-secretd" ./cmd/agent-secretd
+go_build_flags=(-trimpath)
+if [[ "$codesign_identity" != "-" ]]; then
+  approver_team_id="$(codesign_team_id "$codesign_identity")" || {
+    echo "build-app-bundle: codesign identity must end with a Team ID in parentheses" >&2
+    exit 1
+  }
+  go_build_flags+=(-ldflags "-X github.com/kovyrin/agent-secret/internal/daemon.defaultApproverExpectedTeamID=$approver_team_id")
+fi
+go build "${go_build_flags[@]}" -o "$tmp_dir/agent-secret" ./cmd/agent-secret
+go build "${go_build_flags[@]}" -o "$tmp_dir/agent-secretd" ./cmd/agent-secretd
 
 echo "Building Swift app executable..."
 cd "$project_root/approver"


### PR DESCRIPTION
Closes #56.

## Summary
- remove production daemon flags that let callers select approver and trusted-client paths
- stop the daemon manager from forwarding trusted-client paths at startup
- derive the bundled CLI trust path from the daemon helper app layout
- embed a release signing Team ID into signed app builds and require it during approver identity validation

## Verification
- mise exec -- go test ./cmd/agent-secretd ./internal/daemon
- mise exec -- go test ./...
- mise run lint:shell
- mise run lint
- mise run build
- built daemon rejects --trusted-client with exit 2
- built daemon rejects --approver with exit 2
- go build -ldflags Team ID smoke confirmed B6L7QLWTZW is embedded
