### PR TITLE
ASR-002: Harden trusted client identity

### DIFF
--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -526,10 +526,10 @@ func TestDefaultApproverIdentityMatchesBundleMetadata(t *testing.T) {
 }
 
 func TestDefaultApproverIdentityPolicyUsesBuildConfiguredTeamID(t *testing.T) {
-	previous := defaultApproverExpectedTeamID
-	defaultApproverExpectedTeamID = " B6L7QLWTZW "
+	previous := defaultDeveloperIDTeamID
+	defaultDeveloperIDTeamID = " B6L7QLWTZW "
 	t.Cleanup(func() {
-		defaultApproverExpectedTeamID = previous
+		defaultDeveloperIDTeamID = previous
 	})
 
 	policy := DefaultApproverIdentityPolicy()

--- a/internal/daemon/approver_identity.go
+++ b/internal/daemon/approver_identity.go
@@ -18,8 +18,8 @@ const (
 	DefaultApproverExecutable = "Agent Secret"
 )
 
-//nolint:gochecknoglobals // Release builds set this with -ldflags to bind the approver to the signing Team ID.
-var defaultApproverExpectedTeamID string
+//nolint:gochecknoglobals // Release builds set this with -ldflags to bind local helpers to the signing Team ID.
+var defaultDeveloperIDTeamID string
 
 type BundleApproverIdentityPolicy struct {
 	ExpectedBundleID   string
@@ -32,9 +32,13 @@ func DefaultApproverIdentityPolicy() BundleApproverIdentityPolicy {
 	return BundleApproverIdentityPolicy{
 		ExpectedBundleID:   DefaultApproverBundleID,
 		ExpectedExecutable: DefaultApproverExecutable,
-		ExpectedTeamID:     strings.TrimSpace(defaultApproverExpectedTeamID),
+		ExpectedTeamID:     defaultExpectedTeamID(),
 		VerifySignature:    runtime.GOOS == "darwin",
 	}
+}
+
+func defaultExpectedTeamID() string {
+	return strings.TrimSpace(defaultDeveloperIDTeamID)
 }
 
 func (p BundleApproverIdentityPolicy) ValidateApproverExecutable(path string) (ApproverIdentity, error) {

--- a/internal/daemon/trusted_client.go
+++ b/internal/daemon/trusted_client.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
+	"runtime"
 	"strings"
 
 	"github.com/kovyrin/agent-secret/internal/peercred"
@@ -18,12 +18,23 @@ type ExecPeerValidator interface {
 }
 
 type TrustedExecutableValidator struct {
-	paths []string
+	entries        []trustedExecutable
+	expectedTeamID string
+}
+
+type trustedExecutable struct {
+	path       string
+	fileInfo   os.FileInfo
+	bundlePath string
 }
 
 func NewTrustedExecutableValidator(paths []string) TrustedExecutableValidator {
+	return newTrustedExecutableValidator(paths, defaultExpectedTeamID())
+}
+
+func newTrustedExecutableValidator(paths []string, expectedTeamID string) TrustedExecutableValidator {
 	seen := make(map[string]struct{}, len(paths))
-	normalized := make([]string, 0, len(paths))
+	entries := make([]trustedExecutable, 0, len(paths))
 	for _, path := range paths {
 		path = strings.TrimSpace(path)
 		if path == "" {
@@ -33,11 +44,24 @@ func NewTrustedExecutableValidator(paths []string) TrustedExecutableValidator {
 		if _, ok := seen[path]; ok {
 			continue
 		}
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
 		seen[path] = struct{}{}
-		normalized = append(normalized, path)
+		entry := trustedExecutable{
+			path:     path,
+			fileInfo: info,
+		}
+		if bundlePath, ok := trustedClientBundlePath(path); ok {
+			entry.bundlePath = bundlePath
+		}
+		entries = append(entries, entry)
 	}
-	slices.Sort(normalized)
-	return TrustedExecutableValidator{paths: normalized}
+	return TrustedExecutableValidator{
+		entries:        entries,
+		expectedTeamID: strings.TrimSpace(expectedTeamID),
+	}
 }
 
 func DefaultTrustedClientPaths() []string {
@@ -45,14 +69,10 @@ func DefaultTrustedClientPaths() []string {
 	if err != nil {
 		return nil
 	}
-	home := ""
-	if userHome, err := os.UserHomeDir(); err == nil {
-		home = userHome
-	}
-	return trustedClientPathsForExecutable(exe, home)
+	return trustedClientPathsForExecutable(exe)
 }
 
-func trustedClientPathsForExecutable(exe string, home string) []string {
+func trustedClientPathsForExecutable(exe string) []string {
 	dir := filepath.Dir(exe)
 	paths := []string{filepath.Join(dir, "agent-secret")}
 	if filepath.Base(exe) == "agent-secret" {
@@ -60,9 +80,6 @@ func trustedClientPathsForExecutable(exe string, home string) []string {
 	}
 	if bundledCLI, ok := bundledCLIPathForDaemonExecutable(exe); ok {
 		paths = append(paths, bundledCLI)
-	}
-	if home != "" {
-		paths = append(paths, filepath.Join(home, ".local", "bin", "agent-secret"))
 	}
 	return paths
 }
@@ -87,6 +104,29 @@ func bundledCLIPathForDaemonExecutable(exe string) (string, bool) {
 	return filepath.Join(hostApp, "Contents", "Resources", "bin", "agent-secret"), true
 }
 
+func trustedClientBundlePath(path string) (string, bool) {
+	if filepath.Base(path) != "agent-secret" {
+		return "", false
+	}
+	binDir := filepath.Dir(path)
+	if filepath.Base(binDir) != "bin" {
+		return "", false
+	}
+	resourcesDir := filepath.Dir(binDir)
+	if filepath.Base(resourcesDir) != "Resources" {
+		return "", false
+	}
+	contentsDir := filepath.Dir(resourcesDir)
+	if filepath.Base(contentsDir) != "Contents" {
+		return "", false
+	}
+	appPath := filepath.Dir(contentsDir)
+	if filepath.Ext(appPath) != ".app" {
+		return "", false
+	}
+	return filepath.Clean(appPath), true
+}
+
 func containingAppBundlePath(path string) (string, bool) {
 	dir := filepath.Dir(path)
 	for {
@@ -105,14 +145,46 @@ func (v TrustedExecutableValidator) ValidateExecPeer(info peercred.Info) error {
 	if info.ExecutablePath == "" {
 		return fmt.Errorf("%w: peer executable path is unavailable", ErrUntrustedClient)
 	}
-	if len(v.paths) == 0 {
+	if len(v.entries) == 0 {
 		return fmt.Errorf("%w: no trusted client executables configured", ErrUntrustedClient)
 	}
 	got := comparablePath(info.ExecutablePath)
-	if _, ok := slices.BinarySearch(v.paths, got); ok {
+	for _, entry := range v.entries {
+		if entry.path != got {
+			continue
+		}
+		if err := entry.validate(got, v.expectedTeamID); err != nil {
+			return err
+		}
 		return nil
 	}
 	return fmt.Errorf("%w: executable %q is not trusted", ErrUntrustedClient, got)
+}
+
+func (e trustedExecutable) validate(path string, expectedTeamID string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("%w: stat trusted executable %q: %w", ErrUntrustedClient, path, err)
+	}
+	if !os.SameFile(info, e.fileInfo) {
+		return fmt.Errorf("%w: executable %q changed since daemon startup", ErrUntrustedClient, path)
+	}
+	if e.bundlePath != "" {
+		currentBundlePath, ok := trustedClientBundlePath(path)
+		if !ok || currentBundlePath != e.bundlePath {
+			return fmt.Errorf("%w: executable %q is outside expected app bundle %q", ErrUntrustedClient, path, e.bundlePath)
+		}
+	}
+	if expectedTeamID != "" && runtime.GOOS == "darwin" {
+		teamID, err := verifyCodeSignature(path)
+		if err != nil {
+			return fmt.Errorf("%w: verify code signature: %w", ErrUntrustedClient, err)
+		}
+		if teamID != expectedTeamID {
+			return fmt.Errorf("%w: team id %q != %q", ErrUntrustedClient, teamID, expectedTeamID)
+		}
+	}
+	return nil
 }
 
 func comparablePath(path string) string {

--- a/internal/daemon/trusted_client_test.go
+++ b/internal/daemon/trusted_client_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/kovyrin/agent-secret/internal/peercred"
@@ -41,6 +42,38 @@ func TestTrustedExecutableValidatorRejectsUnlistedExecutable(t *testing.T) {
 	}
 }
 
+func TestTrustedExecutableValidatorRejectsExecutableReplacedAfterStartup(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	trusted := writeExecutableAt(t, dir, "agent-secret")
+	validator := NewTrustedExecutableValidator([]string{trusted})
+
+	if err := os.Remove(trusted); err != nil {
+		t.Fatalf("remove trusted executable: %v", err)
+	}
+	if err := os.WriteFile(trusted, []byte("#!/bin/sh\nexit 64\n"), 0o755); err != nil {
+		t.Fatalf("replace trusted executable: %v", err)
+	}
+
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted})
+	if !errors.Is(err, ErrUntrustedClient) {
+		t.Fatalf("expected ErrUntrustedClient after replacement, got %v", err)
+	}
+}
+
+func TestTrustedExecutableValidatorSkipsMissingTrustedPath(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "agent-secret")
+	validator := NewTrustedExecutableValidator([]string{missing})
+
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: missing})
+	if !errors.Is(err, ErrUntrustedClient) {
+		t.Fatalf("expected ErrUntrustedClient for missing trusted path, got %v", err)
+	}
+}
+
 func TestDefaultTrustedClientPathsIncludeBundledCLIForDaemonHelper(t *testing.T) {
 	t.Parallel()
 
@@ -58,8 +91,20 @@ func TestDefaultTrustedClientPathsIncludeBundledCLIForDaemonHelper(t *testing.T)
 	)
 	wantCLI := filepath.Join(appPath, "Contents", "Resources", "bin", "agent-secret")
 
-	got := trustedClientPathsForExecutable(daemonExe, "")
+	got := trustedClientPathsForExecutable(daemonExe)
 	if !slices.Contains(got, wantCLI) {
 		t.Fatalf("trusted paths = %v, want bundled CLI %q", got, wantCLI)
+	}
+}
+
+func TestDefaultTrustedClientPathsDoNotIncludeUserLocalBin(t *testing.T) {
+	t.Parallel()
+
+	daemonExe := filepath.Join(t.TempDir(), "agent-secretd")
+	got := trustedClientPathsForExecutable(daemonExe)
+	for _, path := range got {
+		if strings.Contains(path, filepath.Join(".local", "bin", "agent-secret")) {
+			t.Fatalf("trusted paths include mutable user command path: %v", got)
+		}
 	}
 }

--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -203,7 +203,7 @@ if [[ "$codesign_identity" != "-" ]]; then
     echo "build-app-bundle: codesign identity must end with a Team ID in parentheses" >&2
     exit 1
   }
-  go_build_flags+=(-ldflags "-X github.com/kovyrin/agent-secret/internal/daemon.defaultApproverExpectedTeamID=$approver_team_id")
+  go_build_flags+=(-ldflags "-X github.com/kovyrin/agent-secret/internal/daemon.defaultDeveloperIDTeamID=$approver_team_id")
 fi
 go build "${go_build_flags[@]}" -o "$tmp_dir/agent-secret" ./cmd/agent-secret
 go build "${go_build_flags[@]}" -o "$tmp_dir/agent-secretd" ./cmd/agent-secretd


### PR DESCRIPTION
Closes #57.

## Summary
- remove ~/.local/bin/agent-secret from the daemon default trusted-client set
- keep the bundled CLI path derived from the daemon helper app layout
- snapshot trusted executable file identity at daemon startup and re-stat it on each privileged client operation
- require the configured Developer ID Team ID for production trusted-client signature validation

## Verification
- mise exec -- go test ./internal/daemon -run 'TestTrustedExecutableValidator|TestDefaultTrustedClientPaths|TestDefaultApproverIdentityPolicyUsesBuildConfiguredTeamID'\n- mise exec -- go test ./...\n- bash -n scripts/build-app-bundle.sh\n- mise run lint:shell\n- mise run lint\n- mise run build\n- go build -ldflags Team ID smoke confirmed B6L7QLWTZW is embedded\n