### PR TITLE
ASR-003: Verify installer release identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ AGENT_SECRET_BIN_DIR="$HOME/.local/bin"
 AGENT_SECRET_SKILLS_DIR="$HOME/.agents/skills"
 ```
 
+The unattended installer verifies the DMG checksum, DMG code signature,
+Gatekeeper assessment, notarization ticket, and the mounted app bundle before
+copying anything into place. For local unsigned test artifacts only, set
+`AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`. For signed but intentionally
+unstapled local artifacts, set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`.
+
 Unattended uninstall:
 
 ```bash

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -93,7 +93,8 @@ The installer should:
 1. Detect `arm64` or `x86_64`.
 2. Resolve the latest release unless `AGENT_SECRET_VERSION` is set.
 3. Download the matching release artifact.
-4. Verify the checksum.
+4. Verify the checksum, DMG signature, Gatekeeper assessment, notarization
+   ticket, and mounted app bundle identity.
 5. Stop the old per-user daemon if it is running.
 6. Copy `Agent Secret.app` to `/Applications` by default.
 7. Create or refresh the CLI symlink in `~/.local/bin`.
@@ -109,7 +110,9 @@ AGENT_SECRET_SKILLS_DIR="$HOME/.agents/skills" install.sh
 ```
 
 For local smoke tests, `AGENT_SECRET_DMG` and
-`AGENT_SECRET_CHECKSUMS_FILE` can point at a locally built artifact.
+`AGENT_SECRET_CHECKSUMS_FILE` can point at a locally built artifact. Unsigned
+local artifacts must also set `AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`; signed
+but unstapled local artifacts can set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`.
 
 ### Upgrade
 

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,8 @@ version="${AGENT_SECRET_VERSION:-}"
 local_dmg="${AGENT_SECRET_DMG:-}"
 local_checksums="${AGENT_SECRET_CHECKSUMS_FILE:-}"
 no_stop_daemon="${AGENT_SECRET_NO_STOP_DAEMON:-0}"
+allow_unsigned_install="${AGENT_SECRET_ALLOW_UNSIGNED_INSTALL:-0}"
+require_notarization="${AGENT_SECRET_REQUIRE_NOTARIZATION:-1}"
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-install.XXXXXX")"
 mount_dir="$tmp_dir/mount"
@@ -79,6 +81,45 @@ verify_checksum() {
   fi
 }
 
+verify_dmg_identity() {
+  dmg="$1"
+
+  if [ "$allow_unsigned_install" = "1" ]; then
+    echo "Skipping release identity verification because AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1" >&2
+    return
+  fi
+
+  require_command codesign
+  require_command spctl
+  require_command xcrun
+
+  codesign --verify --strict --verbose=2 "$dmg" ||
+    die "DMG code signature verification failed"
+  spctl --assess --type open --context context:primary-signature --verbose "$dmg" ||
+    die "DMG Gatekeeper assessment failed"
+  if [ "$require_notarization" = "1" ]; then
+    xcrun stapler validate "$dmg" ||
+      die "DMG notarization ticket validation failed"
+  fi
+}
+
+verify_app_identity() {
+  app="$1"
+
+  if [ "$allow_unsigned_install" = "1" ]; then
+    return
+  fi
+
+  codesign --verify --deep --strict --verbose=2 "$app" ||
+    die "app code signature verification failed"
+  spctl --assess --type execute --verbose "$app" ||
+    die "app Gatekeeper assessment failed"
+  if [ "$require_notarization" = "1" ]; then
+    xcrun stapler validate "$app" ||
+      die "app notarization ticket validation failed"
+  fi
+}
+
 stop_existing_daemon() {
   if [ "$no_stop_daemon" = "1" ]; then
     return
@@ -129,6 +170,7 @@ else
   download_release_file "checksums.txt" "$checksums_path"
 fi
 verify_checksum "$checksums_path" "$artifact_name" "$dmg_path"
+verify_dmg_identity "$dmg_path"
 
 mkdir -p "$mount_dir"
 hdiutil attach -quiet -nobrowse -readonly -mountpoint "$mount_dir" "$dmg_path"
@@ -136,6 +178,7 @@ mounted=1
 
 source_app="$mount_dir/Agent Secret.app"
 [ -d "$source_app" ] || die "DMG does not contain Agent Secret.app"
+verify_app_identity "$source_app"
 
 target_app="$app_dir/Agent Secret.app"
 tmp_app="$app_dir/.Agent Secret.app.installing.$$"

--- a/mise.toml
+++ b/mise.toml
@@ -75,7 +75,10 @@ run = "scripts/check-go-coverage.sh"
 
 [tasks."test:smoke"]
 description = "Run non-secret smoke tests"
-run = "cd approver && swift run agent-secret-approver-smoke"
+run = """
+AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
+cd approver && swift run agent-secret-approver-smoke
+"""
 
 [tasks.build]
 description = "Build the unified macOS Agent Secret app bundle"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd -- "$script_dir/.." && pwd)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-install-test.XXXXXX")"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "test-install: $*" >&2
+  exit 1
+}
+
+write_fake_tools() {
+  local fake_bin="$1"
+
+  mkdir -p "$fake_bin"
+
+  cat >"$fake_bin/codesign" <<'SCRIPT'
+#!/bin/sh
+printf 'codesign' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+exit "${AGENT_SECRET_INSTALL_TEST_CODESIGN_STATUS:-0}"
+SCRIPT
+
+  cat >"$fake_bin/spctl" <<'SCRIPT'
+#!/bin/sh
+printf 'spctl' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+exit "${AGENT_SECRET_INSTALL_TEST_SPCTL_STATUS:-0}"
+SCRIPT
+
+  cat >"$fake_bin/xcrun" <<'SCRIPT'
+#!/bin/sh
+printf 'xcrun' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+exit "${AGENT_SECRET_INSTALL_TEST_XCRUN_STATUS:-0}"
+SCRIPT
+
+  cat >"$fake_bin/ditto" <<'SCRIPT'
+#!/bin/sh
+cp -R "$1" "$2"
+SCRIPT
+
+  cat >"$fake_bin/hdiutil" <<'SCRIPT'
+#!/bin/sh
+if [ "$1" = "attach" ]; then
+  mount_dir=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-mountpoint" ]; then
+      mount_dir="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  if [ "$mount_dir" = "" ]; then
+    echo "missing -mountpoint" >&2
+    exit 64
+  fi
+  cli="$mount_dir/Agent Secret.app/Contents/Resources/bin/agent-secret"
+  mkdir -p "$(dirname "$cli")"
+  cat >"$cli" <<'APP'
+#!/bin/sh
+case "$1" in
+  install-cli)
+    bin_dir=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--bin-dir" ]; then
+        bin_dir="$2"
+        shift 2
+        continue
+      fi
+      shift
+    done
+    mkdir -p "$bin_dir"
+    cat >"$bin_dir/agent-secret" <<'BIN'
+#!/bin/sh
+if [ "${1:-}" = "doctor" ]; then
+  exit 0
+fi
+exit 0
+BIN
+    chmod 755 "$bin_dir/agent-secret"
+    ;;
+  skill-install)
+    skills_dir=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--skills-dir" ]; then
+        skills_dir="$2"
+        shift 2
+        continue
+      fi
+      shift
+    done
+    mkdir -p "$skills_dir/agent-secret"
+    ;;
+esac
+APP
+  chmod 755 "$cli"
+  exit 0
+fi
+
+if [ "$1" = "detach" ]; then
+  exit 0
+fi
+
+exit 64
+SCRIPT
+
+  chmod 755 "$fake_bin/codesign" "$fake_bin/spctl" "$fake_bin/xcrun" \
+    "$fake_bin/ditto" "$fake_bin/hdiutil"
+}
+
+make_fixture() {
+  local run_dir="$1"
+  local artifact="$run_dir/Agent-Secret-test-macos-arm64.dmg"
+  local checksums="$run_dir/checksums.txt"
+
+  mkdir -p "$run_dir"
+  printf 'synthetic dmg\n' >"$artifact"
+  shasum -a 256 "$artifact" | awk '{ print $1 "  Agent-Secret-test-macos-arm64.dmg" }' >"$checksums"
+}
+
+run_installer() {
+  local name="$1"
+  shift
+  local run_dir="$tmp_dir/$name"
+  local fake_bin="$run_dir/bin"
+  local log="$run_dir/tools.log"
+  local artifact="$run_dir/Agent-Secret-test-macos-arm64.dmg"
+  local checksums="$run_dir/checksums.txt"
+
+  make_fixture "$run_dir"
+  write_fake_tools "$fake_bin"
+  : >"$log"
+
+  env \
+    PATH="$fake_bin:$PATH" \
+    AGENT_SECRET_DMG="$artifact" \
+    AGENT_SECRET_CHECKSUMS_FILE="$checksums" \
+    AGENT_SECRET_APP_DIR="$run_dir/apps" \
+    AGENT_SECRET_BIN_DIR="$run_dir/bin-dir" \
+    AGENT_SECRET_SKILLS_DIR="$run_dir/skills" \
+    AGENT_SECRET_NO_STOP_DAEMON=1 \
+    AGENT_SECRET_INSTALL_TEST_LOG="$log" \
+    "$@" \
+    "$project_root/install.sh"
+}
+
+assert_log_contains() {
+  local log="$1"
+  local pattern="$2"
+
+  if ! grep -F "$pattern" "$log" >/dev/null; then
+    echo "---- tool log ----" >&2
+    cat "$log" >&2
+    fail "missing log pattern: $pattern"
+  fi
+}
+
+test_identity_checks_run() {
+  run_installer signed
+  log="$tmp_dir/signed/tools.log"
+
+  assert_log_contains "$log" "codesign --verify --strict --verbose=2"
+  assert_log_contains "$log" "spctl --assess --type open --context context:primary-signature --verbose"
+  assert_log_contains "$log" "xcrun stapler validate"
+  assert_log_contains "$log" "codesign --verify --deep --strict --verbose=2"
+  assert_log_contains "$log" "spctl --assess --type execute --verbose"
+}
+
+test_identity_failure_stops_install() {
+  if run_installer unsigned-fail AGENT_SECRET_INSTALL_TEST_CODESIGN_STATUS=23; then
+    fail "installer succeeded when codesign failed"
+  fi
+  assert_log_contains "$tmp_dir/unsigned-fail/tools.log" "codesign --verify --strict --verbose=2"
+}
+
+test_unsigned_override_skips_identity_checks() {
+  run_installer unsigned-allowed \
+    AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1 \
+    AGENT_SECRET_INSTALL_TEST_CODESIGN_STATUS=23 \
+    AGENT_SECRET_INSTALL_TEST_SPCTL_STATUS=23 \
+    AGENT_SECRET_INSTALL_TEST_XCRUN_STATUS=23
+
+  log="$tmp_dir/unsigned-allowed/tools.log"
+  if [ -s "$log" ]; then
+    echo "---- tool log ----" >&2
+    cat "$log" >&2
+    fail "unsigned override should not call identity verification tools"
+  fi
+}
+
+test_identity_checks_run
+test_identity_failure_stops_install
+test_unsigned_override_skips_identity_checks
+
+echo "test-install: ok"


### PR DESCRIPTION
Closes #58.

## Summary
- require the unattended installer to verify DMG checksum, DMG code signature, Gatekeeper assessment, notarization ticket, and mounted app bundle identity before copying
- add explicit local/test overrides for unsigned artifacts and intentionally unstapled artifacts
- add a stubbed installer smoke test that proves identity checks run, codesign failure stops install, and the unsigned override skips identity tools
- include the installer smoke test in `mise run test:smoke`

## Verification
- scripts/test-install.sh
- mise run test:smoke
- npx --no-install markdownlint README.md docs/macos-distribution-plan.md
- mise run lint
- mise run build
