### PR TITLE
ASR-004: Bound daemon protocol frames

### DIFF
--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -1,12 +1,16 @@
 package daemon
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 )
 
 const ProtocolVersion = 1
+const DefaultMaxProtocolFrameBytes int64 = 1 << 20
 
 const (
 	TypeDaemonStatus     = "daemon.status"
@@ -22,6 +26,7 @@ const (
 
 var (
 	ErrMalformedEnvelope = errors.New("malformed protocol envelope")
+	ErrProtocolFrameSize = errors.New("protocol frame exceeds maximum size")
 	ErrProtocolVersion   = errors.New("unsupported protocol version")
 	ErrProtocolType      = errors.New("unsupported protocol message type")
 )
@@ -90,6 +95,43 @@ func validateEnvelope(env Envelope) error {
 		return fmt.Errorf("%w: missing type", ErrMalformedEnvelope)
 	}
 	return nil
+}
+
+func readEnvelopeFrame(reader *bufio.Reader, maxBytes int64) (Envelope, error) {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxProtocolFrameBytes
+	}
+	var frame []byte
+	for {
+		chunk, err := reader.ReadSlice('\n')
+		if int64(len(frame)+len(chunk)) > maxBytes {
+			return Envelope{}, fmt.Errorf("%w: max %d bytes", ErrProtocolFrameSize, maxBytes)
+		}
+		frame = append(frame, chunk...)
+		if err == nil {
+			break
+		}
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		if errors.Is(err, io.EOF) && len(frame) == 0 {
+			return Envelope{}, io.EOF
+		}
+		if errors.Is(err, io.EOF) {
+			return Envelope{}, fmt.Errorf("%w: unterminated JSON frame", ErrMalformedEnvelope)
+		}
+		return Envelope{}, err
+	}
+
+	frame = bytes.TrimSpace(frame)
+	if len(frame) == 0 {
+		return Envelope{}, fmt.Errorf("%w: empty frame", ErrMalformedEnvelope)
+	}
+	var env Envelope
+	if err := json.Unmarshal(frame, &env); err != nil {
+		return Envelope{}, fmt.Errorf("%w: %w", ErrMalformedEnvelope, err)
+	}
+	return env, nil
 }
 
 func marshalPayload(payload any) (json.RawMessage, error) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/kovyrin/agent-secret/internal/audit"
 	"github.com/kovyrin/agent-secret/internal/peercred"
@@ -40,6 +42,8 @@ type Server struct {
 	approvals     ApprovalEndpoint
 	validator     PeerValidator
 	execValidator ExecPeerValidator
+	maxFrameBytes int64
+	readTimeout   time.Duration
 	stopOnce      sync.Once
 	stop          chan struct{}
 }
@@ -49,7 +53,11 @@ type ServerOptions struct {
 	Approvals     ApprovalEndpoint
 	Validator     PeerValidator
 	ExecValidator ExecPeerValidator
+	MaxFrameBytes int64
+	ReadTimeout   time.Duration
 }
+
+const DefaultProtocolReadTimeout = 30 * time.Second
 
 func NewServer(opts ServerOptions) (*Server, error) {
 	if opts.Broker == nil {
@@ -63,11 +71,21 @@ func NewServer(opts ServerOptions) (*Server, error) {
 	if execValidator == nil {
 		execValidator = NewTrustedExecutableValidator(DefaultTrustedClientPaths())
 	}
+	maxFrameBytes := opts.MaxFrameBytes
+	if maxFrameBytes <= 0 {
+		maxFrameBytes = DefaultMaxProtocolFrameBytes
+	}
+	readTimeout := opts.ReadTimeout
+	if readTimeout <= 0 {
+		readTimeout = DefaultProtocolReadTimeout
+	}
 	return &Server{
 		broker:        opts.Broker,
 		approvals:     opts.Approvals,
 		validator:     validator,
 		execValidator: execValidator,
+		maxFrameBytes: maxFrameBytes,
+		readTimeout:   readTimeout,
 		stop:          make(chan struct{}),
 	}, nil
 }
@@ -127,14 +145,19 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 		return
 	}
 
-	decoder := json.NewDecoder(conn)
+	reader := bufio.NewReader(conn)
 	encoder := json.NewEncoder(conn)
 	activeRequestID := ""
 	for {
-		var env Envelope
-		if err := decoder.Decode(&env); err != nil {
+		env, err := s.readEnvelope(conn, reader)
+		if err != nil {
 			if activeRequestID != "" {
 				s.broker.ClientDisconnected(ctx, activeRequestID)
+			}
+			if errors.Is(err, ErrProtocolFrameSize) {
+				_ = writeErrorEncoder(encoder, "", "", "frame_too_large", err)
+			} else if errors.Is(err, ErrMalformedEnvelope) {
+				_ = writeErrorEncoder(encoder, "", "", "bad_envelope", err)
 			}
 			return
 		}
@@ -218,6 +241,10 @@ func (s *Server) handleRequestExec(
 	encoder *json.Encoder,
 	env Envelope,
 ) string {
+	if err := s.validateTrustedClientPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return ""
+	}
 	req, err := DecodePayload[request.ExecRequest](env)
 	if err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_request", err)
@@ -225,10 +252,6 @@ func (s *Server) handleRequestExec(
 	}
 	if err := req.ValidateForDaemon(); err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_request", err)
-		return ""
-	}
-	if err := s.validateTrustedClientPeer(conn); err != nil {
-		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
 		return ""
 	}
 	grant, err := s.broker.HandleExec(ctx, env.RequestID, env.Nonce, req)
@@ -252,13 +275,13 @@ func (s *Server) handleCommandStarted(
 	encoder *json.Encoder,
 	env Envelope,
 ) {
+	if err := s.validateTrustedClientPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return
+	}
 	payload, err := DecodePayload[CommandStartedPayload](env)
 	if err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_command_started", err)
-		return
-	}
-	if err := s.validateTrustedClientPeer(conn); err != nil {
-		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
 		return
 	}
 	if err := s.broker.ReportStarted(ctx, env.RequestID, env.Nonce, payload.ChildPID); err != nil {
@@ -274,13 +297,13 @@ func (s *Server) handleCommandCompleted(
 	encoder *json.Encoder,
 	env Envelope,
 ) bool {
+	if err := s.validateTrustedClientPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return false
+	}
 	payload, err := DecodePayload[CommandCompletedPayload](env)
 	if err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_command_completed", err)
-		return false
-	}
-	if err := s.validateTrustedClientPeer(conn); err != nil {
-		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
 		return false
 	}
 	if err := s.broker.ReportCompleted(ctx, env.RequestID, env.Nonce, payload.ExitCode, payload.Signal); err != nil {
@@ -299,6 +322,16 @@ func (s *Server) peerInfo(conn *net.UnixConn) (peercred.Info, error) {
 		return provider.Info(conn)
 	}
 	return peercred.Inspect(conn)
+}
+
+func (s *Server) readEnvelope(conn *net.UnixConn, reader *bufio.Reader) (Envelope, error) {
+	if s.readTimeout > 0 {
+		if err := conn.SetReadDeadline(time.Now().Add(s.readTimeout)); err != nil {
+			return Envelope{}, fmt.Errorf("set daemon read deadline: %w", err)
+		}
+		defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+	}
+	return readEnvelopeFrame(reader, s.maxFrameBytes)
 }
 
 func daemonStopAuditEvent(peer peercred.Info, err error) audit.Event {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,6 +136,120 @@ func TestServerMalformedEnvelopeReturnsProtocolError(t *testing.T) {
 	}
 	if payload.Code != "bad_envelope" {
 		t.Fatalf("error code = %q, want bad_envelope", payload.Code)
+	}
+}
+
+func TestServerRejectsOversizedProtocolFrame(t *testing.T) {
+	t.Parallel()
+
+	path, stop := startRawServerWithOptions(t, ServerOptions{
+		Broker:        newTestBroker(t, BrokerOptions{Approver: &mockApprover{}, Resolver: &mockResolver{}, Audit: &memoryAudit{}}),
+		Validator:     allowPeerValidator{},
+		MaxFrameBytes: 96,
+		ReadTimeout:   time.Second,
+	})
+	defer stop()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	frame := `{"version":1,"type":"daemon.status","payload":"` + strings.Repeat("x", 128) + `"}` + "\n"
+	if _, err := conn.Write([]byte(frame)); err != nil {
+		t.Fatalf("write oversized frame: %v", err)
+	}
+
+	var resp Envelope
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		t.Fatalf("decode oversized frame response: %v", err)
+	}
+	if resp.Type != TypeError {
+		t.Fatalf("oversized frame response type = %s", resp.Type)
+	}
+	payload, err := DecodePayload[ErrorPayload](resp)
+	if err != nil {
+		t.Fatalf("decode oversized frame error payload: %v", err)
+	}
+	if payload.Code != "frame_too_large" {
+		t.Fatalf("oversized frame error code = %q, want frame_too_large", payload.Code)
+	}
+}
+
+func TestServerClosesSlowPartialProtocolFrame(t *testing.T) {
+	t.Parallel()
+
+	path, stop := startRawServerWithOptions(t, ServerOptions{
+		Broker:        newTestBroker(t, BrokerOptions{Approver: &mockApprover{}, Resolver: &mockResolver{}, Audit: &memoryAudit{}}),
+		Validator:     allowPeerValidator{},
+		ReadTimeout:   25 * time.Millisecond,
+		MaxFrameBytes: 1024,
+	})
+	defer stop()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.Write([]byte(`{"version":`)); err != nil {
+		t.Fatalf("write partial frame: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	_, err = conn.Read(buf)
+	if err == nil {
+		t.Fatal("expected connection close for slow partial frame")
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		t.Fatalf("server did not close slow partial frame before client deadline: %v", err)
+	}
+}
+
+func TestServerValidatesExecPeerBeforeDecodingPayload(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	peer := peerInfoForTest(t, os.Getpid(), exe)
+	path, stop := startRawServerWithOptions(t, ServerOptions{
+		Broker:        newTestBroker(t, BrokerOptions{Approver: &mockApprover{}, Resolver: &mockResolver{}, Audit: &memoryAudit{}}),
+		Validator:     staticPeerValidator{info: peer},
+		ExecValidator: NewTrustedExecutableValidator([]string{writeExecutableAt(t, t.TempDir(), "agent-secret")}),
+		MaxFrameBytes: 4096,
+		ReadTimeout:   time.Second,
+	})
+	defer stop()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	env := Envelope{
+		Version:   ProtocolVersion,
+		Type:      TypeRequestExec,
+		RequestID: "req_1",
+		Nonce:     "nonce_1",
+		Payload:   json.RawMessage(`{"not":"a valid exec request"}`),
+	}
+	if err := json.NewEncoder(conn).Encode(env); err != nil {
+		t.Fatalf("encode untrusted exec request: %v", err)
+	}
+	var resp Envelope
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		t.Fatalf("decode untrusted exec response: %v", err)
+	}
+	payload, err := DecodePayload[ErrorPayload](resp)
+	if err != nil {
+		t.Fatalf("decode untrusted exec error payload: %v", err)
+	}
+	if payload.Code != "untrusted_client" {
+		t.Fatalf("untrusted exec error code = %q, want untrusted_client", payload.Code)
 	}
 }
 
@@ -757,6 +872,16 @@ func startRawServerWithBrokerAndExecValidator(
 	execValidator ExecPeerValidator,
 ) (string, func()) {
 	t.Helper()
+	return startRawServerWithOptions(t, ServerOptions{
+		Broker:        broker,
+		Approvals:     approvals,
+		Validator:     validator,
+		ExecValidator: execValidator,
+	})
+}
+
+func startRawServerWithOptions(t *testing.T, opts ServerOptions) (string, func()) {
+	t.Helper()
 	dir, err := os.MkdirTemp("/tmp", "agent-secret-test-")
 	if err != nil {
 		t.Fatalf("MkdirTemp returned error: %v", err)
@@ -766,12 +891,7 @@ func startRawServerWithBrokerAndExecValidator(
 	if err != nil {
 		t.Fatalf("ListenUnix returned error: %v", err)
 	}
-	server, err := NewServer(ServerOptions{
-		Broker:        broker,
-		Approvals:     approvals,
-		Validator:     validator,
-		ExecValidator: execValidator,
-	})
+	server, err := NewServer(opts)
 	if err != nil {
 		t.Fatalf("NewServer returned error: %v", err)
 	}


### PR DESCRIPTION
Closes #59.

## Summary
- replace unbounded daemon JSON socket reads with newline-delimited frame reads capped at 1 MiB by default
- add an idle read timeout for accepted daemon connections
- return explicit protocol errors for oversized and malformed frames
- validate trusted client identity before decoding privileged request.exec / command lifecycle payloads

## Verification
- mise exec -- go test ./internal/daemon -run 'TestServerRejectsOversizedProtocolFrame|TestServerClosesSlowPartialProtocolFrame|TestServerValidatesExecPeerBeforeDecodingPayload|TestProtocolHelpers'\n- mise exec -- go test ./...\n- mise run lint\n- mise run build\n