### PR TITLE
ASR-005: Expire reusable cache scopes by time

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -59,6 +59,7 @@ type Broker struct {
 	audit      AuditSink
 	fetchLimit int
 	active     map[string]*activeExec
+	expiry     map[string]*time.Timer
 }
 
 type ExecGrant struct {
@@ -122,6 +123,7 @@ func NewBroker(opts BrokerOptions) (*Broker, error) {
 		audit:      opts.Audit,
 		fetchLimit: fetchLimit,
 		active:     make(map[string]*activeExec),
+		expiry:     make(map[string]*time.Timer),
 	}, nil
 }
 
@@ -178,7 +180,7 @@ func (b *Broker) MarkPayloadDelivered(requestID string) error {
 	}
 	approval, err := b.store.FinishReusableAttempt(active.approvalID, policy.DeliveryPayloadDelivered)
 	if err == nil && approval.Uses >= approval.MaxUses {
-		b.cache.ClearScope(approval.ID)
+		b.clearReusableCacheScope(approval.ID)
 	}
 	return err
 }
@@ -253,6 +255,10 @@ func (b *Broker) stopWithAudit(ctx context.Context, event audit.Event) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.active = make(map[string]*activeExec)
+	for id, timer := range b.expiry {
+		timer.Stop()
+		delete(b.expiry, id)
+	}
 	b.cache.Clear()
 	b.store = policy.NewStore(b.now)
 }
@@ -271,7 +277,7 @@ func (b *Broker) reusableGrant(ctx context.Context, req request.ExecRequest) (Ex
 			return ExecGrant{}, err
 		}
 		if approval.ID != "" && (errors.Is(err, policy.ErrExpired) || errors.Is(err, policy.ErrUseExhausted)) {
-			b.cache.ClearScope(approval.ID)
+			b.clearReusableCacheScope(approval.ID)
 		}
 		return ExecGrant{}, nil
 	}
@@ -347,10 +353,11 @@ func (b *Broker) freshGrant(
 		}
 		approvalID = approval.ID
 		if err := b.cacheResolvedValues(approvalID, refValues); err != nil {
-			b.cache.ClearScope(approvalID)
+			b.clearReusableCacheScope(approvalID)
 			b.store.RemoveReusable(approvalID)
 			return ExecGrant{}, err
 		}
+		b.scheduleReusableExpiry(approval.ID, approval.ExpiresAt)
 	}
 
 	return ExecGrant{
@@ -358,6 +365,36 @@ func (b *Broker) freshGrant(
 		SecretAliases: aliases(req.Secrets),
 		ApprovalID:    approvalID,
 	}, nil
+}
+
+func (b *Broker) scheduleReusableExpiry(approvalID string, expiresAt time.Time) {
+	ttl := expiresAt.Sub(b.now())
+	if ttl <= 0 {
+		b.store.RemoveReusable(approvalID)
+		b.clearReusableCacheScope(approvalID)
+		return
+	}
+
+	b.mu.Lock()
+	if previous := b.expiry[approvalID]; previous != nil {
+		previous.Stop()
+	}
+	timer := time.AfterFunc(ttl, func() {
+		b.store.RemoveReusable(approvalID)
+		b.clearReusableCacheScope(approvalID)
+	})
+	b.expiry[approvalID] = timer
+	b.mu.Unlock()
+}
+
+func (b *Broker) clearReusableCacheScope(approvalID string) {
+	b.mu.Lock()
+	if timer := b.expiry[approvalID]; timer != nil {
+		timer.Stop()
+		delete(b.expiry, approvalID)
+	}
+	b.mu.Unlock()
+	b.cache.ClearScope(approvalID)
 }
 
 func (b *Broker) resolveUniqueRefs(ctx context.Context, requestID string, req request.ExecRequest) (map[secretIdentity]string, error) {

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -542,6 +542,40 @@ func TestBrokerClearsReusableCacheOnExpiry(t *testing.T) {
 	}
 }
 
+func TestBrokerReusableCacheExpiresWithoutMatchingRequest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	ref := "op://Example/Item/token"
+	cache := policy.NewSecretCache()
+	broker, err := NewBroker(BrokerOptions{
+		Now:      time.Now,
+		Cache:    cache,
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true}},
+		Resolver: &mockResolver{values: map[string]string{ref: "value"}},
+		Audit:    &memoryAudit{},
+	})
+	if err != nil {
+		t.Fatalf("NewBroker returned error: %v", err)
+	}
+	req := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req.TTL = 100 * time.Millisecond
+	req.ExpiresAt = req.ReceivedAt.Add(req.TTL)
+
+	grant, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if err != nil {
+		t.Fatalf("HandleExec returned error: %v", err)
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); err != nil {
+		t.Fatalf("MarkPayloadDelivered returned error: %v", err)
+	}
+	if _, ok := cache.Get(grant.ApprovalID, ref, ""); !ok {
+		t.Fatal("expected reusable value in cache before expiry")
+	}
+
+	waitForCacheScopeCleared(t, cache, grant.ApprovalID, ref, "")
+}
+
 func TestBrokerClearsReusableCacheOnUseExhaustion(t *testing.T) {
 	t.Parallel()
 
@@ -838,6 +872,18 @@ func containsAuditEvent(events []audit.Event, eventType audit.EventType) bool {
 		}
 	}
 	return false
+}
+
+func waitForCacheScopeCleared(t *testing.T, cache SecretCache, scopeID string, ref string, account string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := cache.Get(scopeID, ref, account); !ok {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("cache scope %q still contained %s after expiry", scopeID, ref)
 }
 
 func receiveBrokerSignal(t *testing.T, ch <-chan struct{}, message string) {


### PR DESCRIPTION
Closes #60.

## Summary
- add per-reusable-approval expiry timers in the broker
- clear cached reusable secret scopes when approval TTL expires even without a later matching request
- stop expiry timers on use exhaustion, explicit expiry/exhaustion cleanup, cache rollback, and daemon stop
- add regression coverage for cache expiry without a matching request

## Verification
- mise exec -- go test ./internal/daemon -run 'TestBrokerReusableCacheExpiresWithoutMatchingRequest|TestBrokerClearsReusableCacheOnExpiry|TestBrokerClearsReusableCacheOnUseExhaustion|TestBrokerStopClearsReusableCache|TestBrokerRollsBackReusableApprovalWhenCacheInsertFails'\n- mise exec -- go test -race ./internal/daemon -run TestBrokerReusableCacheExpiresWithoutMatchingRequest\n- mise exec -- go test ./...\n- mise run lint\n- mise run build\n