### PR TITLE
ASR-007: Enforce request TTL through delivery

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -138,20 +138,33 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 	if req.Expired(b.now()) {
 		return ExecGrant{}, ErrRequestExpired
 	}
-
-	grant, err := b.reusableGrant(ctx, req)
-	if err != nil {
+	execCtx, cancelExec := b.requestContext(ctx, req)
+	defer cancelExec()
+	if err := b.requestActive(execCtx, req); err != nil {
 		return ExecGrant{}, err
 	}
+
+	grant, err := b.reusableGrant(execCtx, req)
+	if err != nil {
+		return ExecGrant{}, b.requestError(execCtx, req, err)
+	}
 	if grant.Env == nil {
-		grant, err = b.freshGrant(ctx, requestID, nonce, req)
+		grant, err = b.freshGrant(execCtx, requestID, nonce, req)
 		if err != nil {
-			return ExecGrant{}, err
+			return ExecGrant{}, b.requestError(execCtx, req, err)
 		}
+	}
+	if err := b.requestActive(execCtx, req); err != nil {
+		b.rollbackReusableApproval(grant.reusableMutationID)
+		return ExecGrant{}, err
 	}
 
 	event := audit.FromExecRequest(audit.EventCommandStarting, requestID, req)
-	if err := b.recordRequiredAudit(ctx, event); err != nil {
+	if err := b.recordRequiredAudit(execCtx, event); err != nil {
+		b.rollbackReusableApproval(grant.reusableMutationID)
+		return ExecGrant{}, err
+	}
+	if err := b.requestActive(execCtx, req); err != nil {
 		b.rollbackReusableApproval(grant.reusableMutationID)
 		return ExecGrant{}, err
 	}
@@ -165,6 +178,37 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 	b.mu.Unlock()
 
 	return grant, nil
+}
+
+func (b *Broker) requestContext(ctx context.Context, req request.ExecRequest) (context.Context, context.CancelFunc) {
+	ttl := req.ExpiresAt.Sub(b.now())
+	return context.WithTimeout(ctx, ttl)
+}
+
+func (b *Broker) requestActive(ctx context.Context, req request.ExecRequest) error {
+	if err := ctx.Err(); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) && req.Expired(b.now()) {
+			return ErrRequestExpired
+		}
+		return err
+	}
+	if req.Expired(b.now()) {
+		return ErrRequestExpired
+	}
+	return nil
+}
+
+func (b *Broker) requestError(ctx context.Context, req request.ExecRequest, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrRequestExpired) {
+		return err
+	}
+	if errors.Is(b.requestActive(ctx, req), ErrRequestExpired) {
+		return ErrRequestExpired
+	}
+	return err
 }
 
 func (b *Broker) MarkPayloadDelivered(requestID string) error {
@@ -283,6 +327,9 @@ func (b *Broker) reusableGrant(ctx context.Context, req request.ExecRequest) (Ex
 		}
 		return ExecGrant{}, nil
 	}
+	if err := b.requestActive(ctx, req); err != nil {
+		return ExecGrant{}, err
+	}
 
 	var values map[string]string
 	var valueErr error
@@ -338,12 +385,21 @@ func (b *Broker) freshGrant(
 		}
 		return ExecGrant{}, ErrApprovalDenied
 	}
+	if err := b.requestActive(ctx, req); err != nil {
+		return ExecGrant{}, err
+	}
 	if err := b.recordRequiredAudit(ctx, audit.FromExecRequest(audit.EventApprovalGranted, requestID, req)); err != nil {
+		return ExecGrant{}, err
+	}
+	if err := b.requestActive(ctx, req); err != nil {
 		return ExecGrant{}, err
 	}
 
 	refValues, err := b.resolveUniqueRefs(ctx, requestID, req)
 	if err != nil {
+		return ExecGrant{}, b.requestError(ctx, req, err)
+	}
+	if err := b.requestActive(ctx, req); err != nil {
 		return ExecGrant{}, err
 	}
 	values := fanoutValues(req.Secrets, refValues)
@@ -490,6 +546,9 @@ func (b *Broker) refreshedReusableValues(
 ) (map[string]string, error) {
 	refValues, err := b.resolveUniqueRefs(ctx, "", req)
 	if err != nil {
+		return nil, b.requestError(ctx, req, err)
+	}
+	if err := b.requestActive(ctx, req); err != nil {
 		return nil, err
 	}
 	values := fanoutValues(req.Secrets, refValues)
@@ -500,6 +559,10 @@ func (b *Broker) refreshedReusableValues(
 	event := audit.FromExecRequest(audit.EventApprovalRefreshed, "", req)
 	event.ApprovalID = approvalID
 	if err := b.recordRequiredAudit(ctx, event); err != nil {
+		b.rollbackReusableApproval(approvalID)
+		return nil, err
+	}
+	if err := b.requestActive(ctx, req); err != nil {
 		b.rollbackReusableApproval(approvalID)
 		return nil, err
 	}

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -39,6 +39,23 @@ func (m *mockApprover) ApproveExec(
 	return m.decision, m.err
 }
 
+type sleepingApprover struct {
+	delay    time.Duration
+	decision ApprovalDecision
+	calls    int
+}
+
+func (s *sleepingApprover) ApproveExec(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ request.ExecRequest,
+) (ApprovalDecision, error) {
+	s.calls++
+	time.Sleep(s.delay)
+	return s.decision, nil
+}
+
 type mockResolver struct {
 	mu     sync.Mutex
 	values map[string]string
@@ -99,6 +116,26 @@ func (r *cancelObservingResolver) Resolve(ctx context.Context, ref string, _ str
 	default:
 		return canarySecretValue, nil
 	}
+}
+
+type deadlineObservingResolver struct {
+	done chan struct{}
+}
+
+func (r *deadlineObservingResolver) Resolve(ctx context.Context, _ string, _ string) (string, error) {
+	<-ctx.Done()
+	close(r.done)
+	return "", ctx.Err()
+}
+
+type advancingResolver struct {
+	value   string
+	advance func()
+}
+
+func (r *advancingResolver) Resolve(_ context.Context, _ string, _ string) (string, error) {
+	r.advance()
+	return r.value, nil
 }
 
 type failingSecretCache struct {
@@ -433,6 +470,127 @@ func TestBrokerCancelsOutstandingFetchesAfterFirstFailure(t *testing.T) {
 	failure := events[len(events)-1]
 	if len(failure.SecretRefs) != 1 || failure.SecretRefs[0].Alias != "FAIL" || failure.SecretRefs[0].Ref != failRef {
 		t.Fatalf("fetch failure refs = %+v", failure.SecretRefs)
+	}
+}
+
+func TestBrokerRequestDeadlineCancelsSlowSecretFetch(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	now := time.Now()
+	req := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req.TTL = 50 * time.Millisecond
+	req.ExpiresAt = req.ReceivedAt.Add(req.TTL)
+	resolver := &deadlineObservingResolver{done: make(chan struct{})}
+	aud := &memoryAudit{}
+	broker, err := NewBroker(BrokerOptions{
+		Now:      time.Now,
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true}},
+		Resolver: resolver,
+		Audit:    aud,
+		Cache:    policy.NewSecretCache(),
+	})
+	if err != nil {
+		t.Fatalf("NewBroker returned error: %v", err)
+	}
+
+	_, err = broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if !errors.Is(err, ErrRequestExpired) {
+		t.Fatalf("expected request expiry while resolving, got %v", err)
+	}
+	receiveBrokerSignal(t, resolver.done, "resolver did not observe request deadline")
+	if containsAuditEvent(aud.Events(), audit.EventCommandStarting) {
+		t.Fatal("command_starting was audited after request deadline expired during fetch")
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); !errors.Is(err, ErrUnknownRequest) {
+		t.Fatalf("request should not become active after fetch deadline expiry, got %v", err)
+	}
+}
+
+func TestBrokerRejectsApprovalThatReturnsAfterRequestExpiry(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	now := time.Now()
+	req := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req.TTL = 25 * time.Millisecond
+	req.ExpiresAt = req.ReceivedAt.Add(req.TTL)
+	approver := &sleepingApprover{
+		delay:    50 * time.Millisecond,
+		decision: ApprovalDecision{Approved: true, Reusable: true},
+	}
+	resolver := &mockResolver{values: map[string]string{ref: "value"}}
+	aud := &memoryAudit{}
+	broker, err := NewBroker(BrokerOptions{
+		Now:      time.Now,
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    aud,
+	})
+	if err != nil {
+		t.Fatalf("NewBroker returned error: %v", err)
+	}
+
+	_, err = broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if !errors.Is(err, ErrRequestExpired) {
+		t.Fatalf("expected request expiry after slow approval, got %v", err)
+	}
+	if approver.calls != 1 {
+		t.Fatalf("approver calls = %d, want 1", approver.calls)
+	}
+	if calls := resolver.Calls(); len(calls) != 0 {
+		t.Fatalf("resolver was called after approval crossed deadline: %v", calls)
+	}
+	if containsAuditEvent(aud.Events(), audit.EventApprovalGranted) {
+		t.Fatal("approval_granted was audited after approval crossed deadline")
+	}
+}
+
+func TestBrokerStopsBeforePayloadWhenRequestExpiresAfterResolution(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	now := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
+	req := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	var nowMu sync.Mutex
+	nowFn := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return now
+	}
+	resolver := &advancingResolver{
+		value: "value",
+		advance: func() {
+			nowMu.Lock()
+			now = req.ExpiresAt
+			nowMu.Unlock()
+		},
+	}
+	cache := newFailingSecretCache(nil, 0)
+	aud := &memoryAudit{}
+	broker, err := NewBroker(BrokerOptions{
+		Now:      nowFn,
+		Cache:    cache,
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true}},
+		Resolver: resolver,
+		Audit:    aud,
+	})
+	if err != nil {
+		t.Fatalf("NewBroker returned error: %v", err)
+	}
+
+	_, err = broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if !errors.Is(err, ErrRequestExpired) {
+		t.Fatalf("expected request expiry after resolution, got %v", err)
+	}
+	if cache.puts != 0 {
+		t.Fatalf("cache writes after request expiry = %d, want 0", cache.puts)
+	}
+	if containsAuditEvent(aud.Events(), audit.EventCommandStarting) {
+		t.Fatal("command_starting was audited after request expired post-resolution")
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); !errors.Is(err, ErrUnknownRequest) {
+		t.Fatalf("request should not become active after post-resolution expiry, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #62.

## Summary
- bind each exec request to a broker-side timeout derived from ExpiresAt
- recheck request expiry after approval, after secret resolution/refresh, and immediately before returning a payload
- roll back reusable cache mutations if expiry is detected before delivery
- add regressions for slow approval, slow resolver cancellation, and expiry after resolution but before payload delivery

## Verification
- mise exec -- go test ./internal/daemon -run 'TestBrokerRequestDeadlineCancelsSlowSecretFetch|TestBrokerRejectsApprovalThatReturnsAfterRequestExpiry|TestBrokerStopsBeforePayloadWhenRequestExpiresAfterResolution'\n- mise exec -- go test -race ./internal/daemon -run 'TestBrokerRequestDeadlineCancelsSlowSecretFetch|TestBrokerRejectsApprovalThatReturnsAfterRequestExpiry|TestBrokerStopsBeforePayloadWhenRequestExpiresAfterResolution'\n- mise exec -- go test ./...\n- mise run lint\n- mise run build\n