### PR TITLE
ASR-008: Reject session_socket delivery in daemon

### DIFF
--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -569,6 +569,32 @@ func TestServerRejectsMalformedExecRequestBeforeApproval(t *testing.T) {
 	}
 }
 
+func TestServerRejectsSessionSocketDeliveryBeforeApproval(t *testing.T) {
+	t.Parallel()
+
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true}}
+	resolver := &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}}
+	client, cleanup := startTestServer(t, BrokerOptions{
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    &memoryAudit{},
+	})
+	defer cleanup()
+
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
+	req.DeliveryMode = request.DeliverySessionSocket
+	req.MaxReads = 1
+	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); !IsProtocolError(err, "bad_request") {
+		t.Fatalf("expected bad_request protocol error, got %v", err)
+	}
+	if approver.calls != 0 {
+		t.Fatalf("approver calls = %d, want 0", approver.calls)
+	}
+	if calls := resolver.Calls(); len(calls) != 0 {
+		t.Fatalf("resolver calls = %v, want none", calls)
+	}
+}
+
 func TestServerRejectsUntrustedExecPeerBeforeSecretPayload(t *testing.T) {
 	t.Parallel()
 

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -101,6 +101,9 @@ func (r ExecRequest) ValidateForDaemon() error {
 	if reason != r.Reason {
 		return fmt.Errorf("%w: reason must be pre-normalized", ErrInvalidReason)
 	}
+	if r.DeliveryMode == DeliverySessionSocket {
+		return fmt.Errorf("%w: daemon does not implement %q delivery", ErrInvalidDeliveryMode, r.DeliveryMode)
+	}
 	if err := validateDelivery(r.DeliveryMode, r.MaxReads); err != nil {
 		return err
 	}

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -206,6 +206,10 @@ func TestExecRequestValidateForDaemonRejectsFabricatedMetadata(t *testing.T) {
 		{name: "relative cwd", mutate: func(r *ExecRequest) { r.CWD = "project" }, want: ErrInvalidRequest},
 		{name: "relative resolved executable", mutate: func(r *ExecRequest) { r.ResolvedExecutable = "tool" }, want: ErrInvalidRequest},
 		{name: "missing command", mutate: func(r *ExecRequest) { r.Command = nil }, want: ErrInvalidCommand},
+		{name: "session socket delivery", mutate: func(r *ExecRequest) {
+			r.DeliveryMode = DeliverySessionSocket
+			r.MaxReads = 1
+		}, want: ErrInvalidDeliveryMode},
 		{name: "tampered ref metadata", mutate: func(r *ExecRequest) { r.Secrets[0].Ref.Field = "other" }, want: ErrInvalidReference},
 		{name: "duplicate alias", mutate: func(r *ExecRequest) {
 			r.Secrets = append(r.Secrets, r.Secrets[0])


### PR DESCRIPTION
Closes #63.

## Summary
- make daemon-visible request validation reject session_socket delivery until the daemon implements that mode end to end
- preserve client-side request modeling for future session delivery, but fail closed at the daemon boundary
- add protocol coverage proving session_socket is rejected before approval or secret fetch

## Verification
- mise exec -- go test ./internal/request ./internal/daemon -run 'TestExecRequestValidateForDaemonRejectsFabricatedMetadata|TestServerRejectsSessionSocketDeliveryBeforeApproval'\n- mise exec -- go test ./...\n- mise run lint\n- mise run build\n