### PR TITLE
ASR-009: Normalize bundle short versions from release tags

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -77,6 +77,7 @@ run = "scripts/check-go-coverage.sh"
 description = "Run non-secret smoke tests"
 run = """
 AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh
 cd approver && swift run agent-secret-approver-smoke
 """
 

--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -64,6 +64,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+version="$(agent_secret_normalize_short_version "$version")"
+
 require_command() {
   local name="$1"
 

--- a/scripts/bundle-metadata.sh
+++ b/scripts/bundle-metadata.sh
@@ -12,3 +12,9 @@ AGENT_SECRET_MIN_MACOS_VERSION="14.0"
 AGENT_SECRET_INFO_DICTIONARY_VERSION="6.0"
 AGENT_SECRET_DEFAULT_VERSION="0.1.0"
 AGENT_SECRET_DEFAULT_BUNDLE_VERSION="1"
+
+agent_secret_normalize_short_version() {
+  local release_version="$1"
+
+  printf '%s\n' "${release_version#v}"
+}

--- a/scripts/check-bundle-metadata.sh
+++ b/scripts/check-bundle-metadata.sh
@@ -30,6 +30,7 @@ app_bundle="$1"
 short_version="${2:-${AGENT_SECRET_VERSION:-$AGENT_SECRET_DEFAULT_VERSION}}"
 bundle_version="${3:-${AGENT_SECRET_BUNDLE_VERSION:-$AGENT_SECRET_DEFAULT_BUNDLE_VERSION}}"
 daemon_bundle="$app_bundle/Contents/Library/Helpers/AgentSecretDaemon.app"
+short_version="$(agent_secret_normalize_short_version "$short_version")"
 
 require_command() {
   local name="$1"

--- a/scripts/test-release-version.sh
+++ b/scripts/test-release-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd -- "$script_dir/.." && pwd)"
+# shellcheck source=scripts/bundle-metadata.sh
+# shellcheck disable=SC1091
+source "$project_root/scripts/bundle-metadata.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-release-version-test.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "test-release-version: $*" >&2
+  exit 1
+}
+
+tag_version="v0.3.1"
+short_version="$(agent_secret_normalize_short_version "$tag_version")"
+bundle_version="${AGENT_SECRET_BUNDLE_VERSION:-$AGENT_SECRET_DEFAULT_BUNDLE_VERSION}"
+
+"$project_root/scripts/build-app-bundle.sh" --version "$tag_version" --output "$tmp_dir"
+"$project_root/scripts/check-bundle-metadata.sh" \
+  "$tmp_dir/$AGENT_SECRET_APP_NAME.app" \
+  "$short_version" \
+  "$bundle_version"
+
+app_short_version="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$tmp_dir/$AGENT_SECRET_APP_NAME.app/Contents/Info.plist")"
+if [[ "$app_short_version" == v* ]]; then
+  fail "app bundle short version kept tag prefix: $app_short_version"
+fi
+
+echo "test-release-version: ok"


### PR DESCRIPTION
Closes #64.

## Summary
- normalize leading-v release versions before writing CFBundleShortVersionString
- make bundle metadata checks normalize the expected short version as well
- add a release-version smoke test that builds from v0.3.1 and verifies the plist contains 0.3.1
- wire the release-version smoke into test:smoke

## Verification
- mise exec -- env AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh
- mise run test:smoke
- mise run lint:shell
- mise run lint:toml
- mise run lint
- mise run build
