### PR TITLE
ASR-010: Publish both macOS release architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,17 @@ jobs:
         run: mise run test:smoke
 
   draft-release-artifacts:
-    name: Draft Release Artifacts
+    name: Build Release Artifact (${{ matrix.arch }})
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: macos-latest
-    permissions:
-      contents: write
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-latest
+          - arch: x86_64
+            runner: macos-15-intel
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -106,22 +112,19 @@ jobs:
           AGENT_SECRET_NOTARY_KEY_ID: ${{ secrets.AGENT_SECRET_NOTARY_KEY_ID }}
         run: scripts/build-release.sh "$GITHUB_REF_NAME"
 
-      - name: Create or update draft release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Verify release artifact architecture
         run: |
-          artifact="dist/Agent-Secret-${GITHUB_REF_NAME}-macos-$(uname -m).dmg"
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" "$artifact" dist/checksums.txt --clobber
-          else
-            gh release create "$GITHUB_REF_NAME" \
-              "$artifact" \
-              dist/checksums.txt \
-              --draft \
-              --verify-tag \
-              --title "$GITHUB_REF_NAME" \
-              --notes "macOS artifacts built from $GITHUB_SHA."
-          fi
+          test "$(uname -m)" = "${{ matrix.arch }}"
+          test -f "dist/Agent-Secret-${GITHUB_REF_NAME}-macos-${{ matrix.arch }}.dmg"
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.arch }}
+          if-no-files-found: error
+          path: |
+            dist/Agent-Secret-${{ github.ref_name }}-macos-${{ matrix.arch }}.dmg
+            dist/checksums.txt
 
       - name: Delete temporary signing keychain
         if: ${{ always() }}
@@ -130,4 +133,48 @@ jobs:
         run: |
           if [ -f "$AGENT_SECRET_CODESIGN_KEYCHAIN_PATH" ]; then
             security delete-keychain "$AGENT_SECRET_CODESIGN_KEYCHAIN_PATH"
+          fi
+
+  publish-draft-release:
+    name: Publish Draft Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: draft-release-artifacts
+    permissions:
+      contents: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/release-artifacts
+          pattern: release-*
+
+      - name: Assemble release assets
+        run: |
+          mkdir -p dist
+          cp "dist/release-artifacts/release-arm64/Agent-Secret-${GITHUB_REF_NAME}-macos-arm64.dmg" dist/
+          cp "dist/release-artifacts/release-x86_64/Agent-Secret-${GITHUB_REF_NAME}-macos-x86_64.dmg" dist/
+          cat \
+            dist/release-artifacts/release-arm64/checksums.txt \
+            dist/release-artifacts/release-x86_64/checksums.txt \
+            >dist/checksums.txt
+
+      - name: Create or update draft release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          artifacts=(
+            "dist/Agent-Secret-${GITHUB_REF_NAME}-macos-arm64.dmg"
+            "dist/Agent-Secret-${GITHUB_REF_NAME}-macos-x86_64.dmg"
+            "dist/checksums.txt"
+          )
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "${artifacts[@]}" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              "${artifacts[@]}" \
+              --draft \
+              --verify-tag \
+              --title "$GITHUB_REF_NAME" \
+              --notes "macOS arm64 and x86_64 artifacts built from $GITHUB_SHA."
           fi

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -65,6 +65,7 @@ release target. Do not publish a release whose changelog section is empty.
 
    ```text
    Agent-Secret-vX.Y.Z-macos-arm64.dmg
+   Agent-Secret-vX.Y.Z-macos-x86_64.dmg
    checksums.txt
    ```
 


### PR DESCRIPTION
Closes #65.

## Summary
- build release artifacts with a matrix for arm64 and x86_64 macOS runners
- upload per-arch workflow artifacts, then publish one draft release containing both DMGs plus a combined checksums.txt
- keep the installer architecture policy matched by documented release assets
- update the release process docs to list both expected DMGs

## Verification
- mise exec -- actionlint .github/workflows/ci.yml
- npx --yes markdownlint-cli docs/release-process.md
- mise run lint
- mise run build

Reference checked while selecting runner labels: GitHub Actions hosted runner docs list macOS Intel labels including macos-15-intel and arm64 labels including macos-latest/macos-14/macos-15.
