### PR TITLE
ASR-011 escape unicode command controls

### DIFF
--- a/approver/Sources/AgentSecretApprover/CommandArgumentViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/CommandArgumentViewModel.swift
@@ -10,7 +10,8 @@ struct CommandArgumentViewModel: Equatable {
         static let escape: UInt32 = 27
         static let horizontalTab: UInt32 = 9
         static let lineFeed: UInt32 = 10
-        static let printableHighStart: UInt32 = 128
+        static let maxByteEscapeScalar: UInt32 = 0xFF
+        static let maxFourDigitEscapeScalar: UInt32 = 0xFFFF
         static let printablePrefixEnd: UInt32 = 38
         static let printablePrefixStart: UInt32 = 32
         static let printableSuffixEnd: UInt32 = 126
@@ -40,7 +41,7 @@ struct CommandArgumentViewModel: Equatable {
         if value.isEmpty {
             return "''"
         }
-        if value.unicodeScalars.contains(where: { scalar in Self.isASCIIControlCharacter(scalar) }) {
+        if value.unicodeScalars.contains(where: requiresANSICEscaping) {
             return "$'\(ansiCEscaped(value))'"
         }
         return "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
@@ -77,7 +78,7 @@ struct CommandArgumentViewModel: Equatable {
                 if Self.isPrintableLiteral(scalar) {
                     return String(scalar)
                 }
-                return String(format: "\\x%02X", scalar.value)
+                return Self.unicodeEscape(scalar)
             }
         }
         return escaped.joined()
@@ -90,18 +91,46 @@ struct CommandArgumentViewModel: Equatable {
         let shellMetacharacters = CharacterSet(charactersIn: "|&;<>()$`\\\"'*!?[]{}")
         return value.rangeOfCharacter(from: .whitespacesAndNewlines) != nil ||
             value.rangeOfCharacter(from: .controlCharacters) != nil ||
+            value.unicodeScalars.contains(where: Self.requiresANSICEscaping) ||
             value.rangeOfCharacter(from: shellMetacharacters) != nil
+    }
+
+    private static func requiresANSICEscaping(_ scalar: Unicode.Scalar) -> Bool {
+        isASCIIControlCharacter(scalar) || isUnsafeUnicodeCategory(scalar)
     }
 
     private static func isASCIIControlCharacter(_ scalar: Unicode.Scalar) -> Bool {
         scalar.value < ScalarCode.printablePrefixStart || scalar.value == ScalarCode.controlDelete
     }
 
+    private static func isUnsafeUnicodeCategory(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.properties.generalCategory {
+        case .control, .format, .lineSeparator, .paragraphSeparator, .privateUse, .surrogate, .unassigned:
+            true
+
+        default:
+            false
+        }
+    }
+
     private static func isPrintableLiteral(_ scalar: Unicode.Scalar) -> Bool {
         let value = scalar.value
+        if isUnsafeUnicodeCategory(scalar) {
+            return false
+        }
         return (ScalarCode.printablePrefixStart ... ScalarCode.printablePrefixEnd).contains(value) ||
             (ScalarCode.printableWithoutBackslashStart ... ScalarCode.printableWithoutBackslashEnd).contains(value) ||
             (ScalarCode.printableSuffixStart ... ScalarCode.printableSuffixEnd).contains(value) ||
-            value >= ScalarCode.printableHighStart
+            value >= ScalarCode.controlDelete + 1
+    }
+
+    private static func unicodeEscape(_ scalar: Unicode.Scalar) -> String {
+        if scalar.value <= ScalarCode.maxByteEscapeScalar {
+            return String(format: "\\x%02X", scalar.value)
+        }
+        if scalar.value <= ScalarCode.maxFourDigitEscapeScalar {
+            return String(format: "\\u%04X", scalar.value)
+        }
+        return String(format: "\\U%08X", scalar.value)
     }
 }

--- a/approver/Tests/AgentSecretApproverTests/ApprovalCommandRenderingTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalCommandRenderingTests.swift
@@ -53,6 +53,35 @@ final class ApprovalCommandRenderingTests: XCTestCase {
         XCTAssertFalse(viewModel.command.contains("\u{001F}"))
     }
 
+    func testCommandDisplayEscapesUnicodeSpoofingControls() throws {
+        let unassigned = try XCTUnwrap(Unicode.Scalar(0x0378))
+        let argv = [
+            "/bin/echo",
+            "safe\u{202E}txt",
+            "join\u{200D}er",
+            "line\u{2028}sep",
+            "para\u{2029}sep",
+            "private\u{E000}use",
+            "unassigned\(unassigned)scalar"
+        ]
+        let viewModel = Self.viewModel(command: argv)
+
+        XCTAssertEqual(
+            viewModel.command,
+            "'/bin/echo' $'safe\\u202Etxt' $'join\\u200Der' $'line\\u2028sep' " +
+                "$'para\\u2029sep' $'private\\uE000use' $'unassigned\\u0378scalar'"
+        )
+        XCTAssertTrue(viewModel.commandNeedsInspector)
+        XCTAssertTrue(viewModel.commandInspectionText.contains("argv[1]: $'safe\\u202Etxt'"))
+        XCTAssertTrue(viewModel.commandInspectionText.contains("argv[2]: $'join\\u200Der'"))
+        XCTAssertFalse(viewModel.command.contains("\u{202E}"))
+        XCTAssertFalse(viewModel.command.contains("\u{200D}"))
+        XCTAssertFalse(viewModel.command.contains("\u{2028}"))
+        XCTAssertFalse(viewModel.command.contains("\u{2029}"))
+        XCTAssertFalse(viewModel.command.contains("\u{E000}"))
+        XCTAssertFalse(viewModel.command.unicodeScalars.contains(unassigned))
+    }
+
     func testStructuredCommandInspectorPreservesArgvBoundaries() {
         let viewModel = Self.viewModel(command: [
             "/usr/bin/env",


### PR DESCRIPTION
Closes #66.

## Summary
- treat Unicode control, format, line/paragraph separator, private-use, surrogate, and unassigned scalars as display-unsafe
- render unsafe non-ASCII scalars with ANSI-C `\u`/`\U` escapes instead of literal prompt text
- mark unsafe Unicode arguments as inspector-worthy so reviewers get argv boundary context
- add regression coverage for bidi controls, zero-width joiner, U+2028/U+2029, private-use, and unassigned scalars

## Verification
- `cd approver && swift test --filter ApprovalCommandRenderingTests`
- `cd approver && swift test`
- `mise run lint:swift`
- `mise run lint`
- `mise run build`
