### PR TITLE
ASR-013 target gosec permission suppressions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,10 +52,6 @@ linters:
   settings:
     gosec:
       excludes:
-        # Private directories need executable bits; test scripts need executable bits.
-        - G301
-        - G302
-        - G306
         # Queue promotion is detached from request cancellation by design.
         - G118
     revive:

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -177,7 +177,7 @@ func openPath(path string, now func() time.Time) (*Writer, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, fmt.Errorf("create audit directory: %w", err)
 	}
-	if err := os.Chmod(filepath.Dir(path), 0o700); err != nil {
+	if err := os.Chmod(filepath.Dir(path), 0o700); err != nil { //nolint:gosec // G302: audit directories need owner execute/search while denying group and other access.
 		return nil, fmt.Errorf("secure audit directory: %w", err)
 	}
 	if err := rejectInsecureFile(path); err != nil {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -93,7 +93,7 @@ func TestOpenDefaultRejectsPermissiveExistingAuditFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
 		t.Fatalf("write audit file: %v", err)
 	}
-	if err := os.Chmod(path, 0o644); err != nil {
+	if err := os.Chmod(path, 0o644); err != nil { //nolint:gosec // G302: this test intentionally creates an insecure audit log to prove rejection.
 		t.Fatalf("chmod audit file: %v", err)
 	}
 
@@ -284,7 +284,7 @@ func writeExecutable(t *testing.T, dir string, name string) {
 	t.Helper()
 
 	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: audit tests need a runnable fixture executable in command metadata.
 		t.Fatalf("write executable: %v", err)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -49,7 +49,7 @@ func TestParseExecBuildsValidatedRequest(t *testing.T) {
 func TestParseExecBuildsRequestFromProfile(t *testing.T) {
 	root := t.TempDir()
 	infraDir := filepath.Join(root, "infra")
-	if err := os.MkdirAll(infraDir, 0o755); err != nil {
+	if err := os.MkdirAll(infraDir, 0o750); err != nil {
 		t.Fatalf("create infra dir: %v", err)
 	}
 	writeExecutable(t, infraDir, "terraform")
@@ -103,7 +103,7 @@ profiles:
 func TestParseExecFiltersProfileSecretsWithOnly(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "ansible-playbook")
@@ -152,7 +152,7 @@ profiles:
 func TestParseExecBuildsRequestFromEnvFiles(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -212,7 +212,7 @@ NEXT=op://Example/Next/token
 func TestParseExecEnvFileDoesNotLoadDefaultProfile(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -246,7 +246,7 @@ profiles:
 func TestParseExecFiltersEnvFileSecretsWithOnly(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -288,7 +288,7 @@ PLAIN=kept
 func TestParseExecCombinesProfileEnvFileSecretAndOnlyPredictably(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -345,7 +345,7 @@ PLAIN=kept
 func TestParseExecAccountAppliesToExplicitAndEnvFileSecrets(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -382,7 +382,7 @@ func TestParseExecAccountAppliesToExplicitAndEnvFileSecrets(t *testing.T) {
 func TestParseExecAccountPrecedenceInCombinedSources(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -436,7 +436,7 @@ profiles:
 func TestParseExecAccountAppliesToProfileSecretsWithoutConfigAccount(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -472,7 +472,7 @@ profiles:
 func TestParseExecEnvFileSecretsInheritProfileAccount(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -517,7 +517,7 @@ profiles:
 func TestParseExecRejectsInvalidOnlyAlias(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -560,7 +560,7 @@ profiles:
 func TestParseExecBuildsRequestFromDefaultProfile(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "terraform")
@@ -607,7 +607,7 @@ func TestParseExecBuildsDefaultProfileFromExplicitConfigPath(t *testing.T) {
 	root := t.TempDir()
 	configPath := filepath.Join(root, "custom-agent-secret.yml")
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "terraform")
@@ -646,7 +646,7 @@ profiles:
 func TestParseExecExplicitSecretsDoNotLoadDefaultProfile(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "tool")
@@ -687,7 +687,7 @@ profiles:
 func TestParseExecMergesProfileAndExplicitSecretsWithOverrides(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		t.Fatalf("create bin dir: %v", err)
 	}
 	writeExecutable(t, binDir, "ansible-playbook")
@@ -927,7 +927,7 @@ func writeExecutable(t *testing.T, dir string, name string) {
 	t.Helper()
 
 	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: CLI parser tests need runnable fixture commands on PATH.
 		t.Fatalf("write executable: %v", err)
 	}
 }
@@ -941,7 +941,7 @@ func writeProfileConfig(t *testing.T, dir string, contents string) {
 func writeConfigFile(t *testing.T, path string, contents string) {
 	t.Helper()
 
-	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 		t.Fatalf("write config file: %v", err)
 	}
 }

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -304,13 +304,13 @@ func TestProcessApproverLauncherPrefersUnifiedAppExecutable(t *testing.T) {
 	appPath := filepath.Join(t.TempDir(), "Agent Secret.app")
 	unifiedExecutable := filepath.Join(appPath, "Contents", "MacOS", "Agent Secret")
 	legacyExecutable := filepath.Join(appPath, "Contents", "MacOS", "agent-secret-approver")
-	if err := os.MkdirAll(filepath.Dir(unifiedExecutable), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(unifiedExecutable), 0o750); err != nil {
 		t.Fatalf("create app macos dir: %v", err)
 	}
-	if err := os.WriteFile(legacyExecutable, []byte("test"), 0o755); err != nil {
+	if err := os.WriteFile(legacyExecutable, []byte("test"), 0o755); err != nil { //nolint:gosec // G306: approver tests need runnable app executable fixtures.
 		t.Fatalf("write legacy executable: %v", err)
 	}
-	if err := os.WriteFile(unifiedExecutable, []byte("test"), 0o755); err != nil {
+	if err := os.WriteFile(unifiedExecutable, []byte("test"), 0o755); err != nil { //nolint:gosec // G306: approver tests need runnable app executable fixtures.
 		t.Fatalf("write unified executable: %v", err)
 	}
 
@@ -353,10 +353,10 @@ func TestDefaultApproverPathUsesInstalledUnifiedApp(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	want := filepath.Join(home, "Applications", "Agent Secret.app", "Contents", "MacOS", "Agent Secret")
-	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(want), 0o750); err != nil {
 		t.Fatalf("create app macos dir: %v", err)
 	}
-	if err := os.WriteFile(want, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(want, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: default approver path tests need runnable app executable fixtures.
 		t.Fatalf("write app executable: %v", err)
 	}
 
@@ -374,10 +374,10 @@ func TestDefaultApproverPathIgnoresEnvironmentOverride(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("AGENT_SECRET_APPROVER_PATH", filepath.Join(t.TempDir(), "PoisonApprover.app"))
 	want := filepath.Join(home, "Applications", "Agent Secret.app", "Contents", "MacOS", "Agent Secret")
-	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(want), 0o750); err != nil {
 		t.Fatalf("create app macos dir: %v", err)
 	}
-	if err := os.WriteFile(want, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(want, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: default approver path tests need runnable app executable fixtures.
 		t.Fatalf("write app executable: %v", err)
 	}
 
@@ -394,7 +394,7 @@ func TestProcessApproverLauncherLaunchesBinary(t *testing.T) {
 	t.Parallel()
 
 	helper := filepath.Join(t.TempDir(), "approver-helper")
-	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: launcher tests need runnable helper executables.
 		t.Fatalf("write helper: %v", err)
 	}
 
@@ -421,7 +421,7 @@ func TestProcessApproverLauncherHealthCheck(t *testing.T) {
 	t.Parallel()
 
 	helper := filepath.Join(t.TempDir(), "approver-helper")
-	if err := os.WriteFile(helper, []byte("#!/bin/sh\nif [ \"$1\" = \"--health-check\" ]; then echo 'agent-secret-approver: ok'; exit 0; fi\nexit 64\n"), 0o755); err != nil {
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nif [ \"$1\" = \"--health-check\" ]; then echo 'agent-secret-approver: ok'; exit 0; fi\nexit 64\n"), 0o755); err != nil { //nolint:gosec // G306: launcher tests need runnable helper executables.
 		t.Fatalf("write helper: %v", err)
 	}
 
@@ -438,7 +438,7 @@ func TestProcessApproverLauncherHealthCheckRejectsUnexpectedOutput(t *testing.T)
 	t.Parallel()
 
 	helper := filepath.Join(t.TempDir(), "approver-helper")
-	if err := os.WriteFile(helper, []byte("#!/bin/sh\necho nope\n"), 0o755); err != nil {
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\necho nope\n"), 0o755); err != nil { //nolint:gosec // G306: launcher tests need runnable helper executables.
 		t.Fatalf("write helper: %v", err)
 	}
 
@@ -455,7 +455,7 @@ func TestProcessApproverLauncherRejectsBareBinaryByDefault(t *testing.T) {
 	t.Parallel()
 
 	helper := filepath.Join(t.TempDir(), "agent-secret-approver")
-	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: launcher tests need runnable helper executables.
 		t.Fatalf("write helper: %v", err)
 	}
 
@@ -561,11 +561,11 @@ func writeApproverBundle(t *testing.T, dir string, bundleID string, executableNa
 	t.Helper()
 	bundlePath := filepath.Join(dir, "AgentSecretApprover.app")
 	macOSPath := filepath.Join(bundlePath, "Contents", "MacOS")
-	if err := os.MkdirAll(macOSPath, 0o755); err != nil {
+	if err := os.MkdirAll(macOSPath, 0o750); err != nil {
 		t.Fatalf("mkdir bundle: %v", err)
 	}
 	executablePath := filepath.Join(macOSPath, executableName)
-	if err := os.WriteFile(executablePath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(executablePath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: bundle identity tests need runnable app executable fixtures.
 		t.Fatalf("write executable: %v", err)
 	}
 	info := `<?xml version="1.0" encoding="UTF-8"?>
@@ -579,7 +579,7 @@ func writeApproverBundle(t *testing.T, dir string, bundleID string, executableNa
 </dict>
 </plist>
 `
-	if err := os.WriteFile(filepath.Join(bundlePath, "Contents", "Info.plist"), []byte(info), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(bundlePath, "Contents", "Info.plist"), []byte(info), 0o600); err != nil {
 		t.Fatalf("write Info.plist: %v", err)
 	}
 	return executablePath

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -148,7 +148,7 @@ func TestManagerRejectsPermissiveCustomSocketParentWithoutChmod(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	if err := os.Chmod(dir, 0o755); err != nil {
+	if err := os.Chmod(dir, 0o755); err != nil { //nolint:gosec // G302: this test intentionally creates a permissive custom socket directory.
 		t.Fatalf("chmod custom dir: %v", err)
 	}
 	manager := Manager{
@@ -178,7 +178,7 @@ func TestDaemonAppPathAndStartCommand(t *testing.T) {
 		"Helpers",
 		"AgentSecretDaemon.app",
 	)
-	if err := os.MkdirAll(daemonAppPath, 0o755); err != nil {
+	if err := os.MkdirAll(daemonAppPath, 0o750); err != nil {
 		t.Fatalf("mkdir daemon app: %v", err)
 	}
 	t.Setenv("AGENT_SECRET_DAEMON_APP_PATH", "/tmp/PoisonDaemon.app")
@@ -233,13 +233,13 @@ func TestDaemonAppPathForBundledExecutable(t *testing.T) {
 	appPath := filepath.Join(root, "Agent Secret.app")
 	cliPath := filepath.Join(appPath, "Contents", "Resources", "bin", "agent-secret")
 	daemonAppPath := filepath.Join(appPath, "Contents", "Library", "Helpers", "AgentSecretDaemon.app")
-	if err := os.MkdirAll(filepath.Dir(cliPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(cliPath), 0o750); err != nil {
 		t.Fatalf("create cli dir: %v", err)
 	}
-	if err := os.MkdirAll(daemonAppPath, 0o755); err != nil {
+	if err := os.MkdirAll(daemonAppPath, 0o750); err != nil {
 		t.Fatalf("create daemon app: %v", err)
 	}
-	if err := os.WriteFile(cliPath, []byte("test"), 0o755); err != nil {
+	if err := os.WriteFile(cliPath, []byte("test"), 0o755); err != nil { //nolint:gosec // G306: bundled daemon path tests need a runnable CLI fixture.
 		t.Fatalf("write cli: %v", err)
 	}
 
@@ -249,7 +249,7 @@ func TestDaemonAppPathForBundledExecutable(t *testing.T) {
 	}
 
 	symlinkPath := filepath.Join(root, "bin", "agent-secret")
-	if err := os.MkdirAll(filepath.Dir(symlinkPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(symlinkPath), 0o750); err != nil {
 		t.Fatalf("create symlink dir: %v", err)
 	}
 	if err := os.Symlink(cliPath, symlinkPath); err != nil {

--- a/internal/daemon/protocol_test.go
+++ b/internal/daemon/protocol_test.go
@@ -218,7 +218,7 @@ func startStallingDaemonClient(t *testing.T) (*Client, <-chan Envelope, func()) 
 	if err != nil {
 		t.Fatalf("MkdirTemp returned error: %v", err)
 	}
-	if err := os.Chmod(dir, 0o700); err != nil {
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // G302: socket tests need an owner-searchable private listener directory.
 		_ = os.RemoveAll(dir)
 		t.Fatalf("secure socket test directory: %v", err)
 	}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -950,7 +950,7 @@ func testSocketPath(t *testing.T) string {
 func writeExecutableAt(t *testing.T, dir string, name string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: daemon tests need runnable fixture executables.
 		t.Fatalf("write executable: %v", err)
 	}
 	return path

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -52,7 +52,7 @@ func TestListenUnixAcceptsPrivateCustomSocketParent(t *testing.T) {
 	t.Parallel()
 
 	dir := shortTempDir(t, "agent-secret-socket-")
-	if err := os.Chmod(dir, 0o700); err != nil {
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // G302: custom socket directories must be owner-searchable and private.
 		t.Fatalf("chmod custom dir: %v", err)
 	}
 	path := filepath.Join(dir, "agent-secretd.sock")
@@ -71,7 +71,7 @@ func TestListenUnixRejectsPermissiveCustomSocketParentWithoutChmod(t *testing.T)
 	t.Parallel()
 
 	dir := shortTempDir(t, "agent-secret-socket-")
-	if err := os.Chmod(dir, 0o755); err != nil {
+	if err := os.Chmod(dir, 0o755); err != nil { //nolint:gosec // G302: this test intentionally creates a permissive custom socket directory.
 		t.Fatalf("chmod custom dir: %v", err)
 	}
 	path := filepath.Join(dir, "agent-secretd.sock")

--- a/internal/daemon/trusted_client_test.go
+++ b/internal/daemon/trusted_client_test.go
@@ -52,7 +52,7 @@ func TestTrustedExecutableValidatorRejectsExecutableReplacedAfterStartup(t *test
 	if err := os.Remove(trusted); err != nil {
 		t.Fatalf("remove trusted executable: %v", err)
 	}
-	if err := os.WriteFile(trusted, []byte("#!/bin/sh\nexit 64\n"), 0o755); err != nil {
+	if err := os.WriteFile(trusted, []byte("#!/bin/sh\nexit 64\n"), 0o755); err != nil { //nolint:gosec // G306: trusted-client tests need a runnable replacement executable.
 		t.Fatalf("replace trusted executable: %v", err)
 	}
 

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -76,7 +76,7 @@ func InstallCLI(options CLIOptions) (CLIResult, error) {
 		return CLIResult{}, err
 	}
 
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o755); err != nil { //nolint:gosec // G301: user command directories must be searchable for PATH execution.
 		return CLIResult{}, fmt.Errorf("create bin dir %s: %w", binDir, err)
 	}
 	linkPath := filepath.Join(binDir, CommandName)
@@ -111,7 +111,7 @@ func InstallSkill(options SkillOptions) (SkillResult, error) {
 		return SkillResult{}, err
 	}
 
-	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil { //nolint:gosec // G301: agent skill directories are non-secret content intended for tool discovery.
 		return SkillResult{}, fmt.Errorf("create skills dir %s: %w", skillsDir, err)
 	}
 	linkPath := filepath.Join(skillsDir, SkillName)

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -59,7 +59,7 @@ func TestInstallCLIRefusesExistingRegularFileWithoutForce(t *testing.T) {
 	binDir := t.TempDir()
 	executable := writeInstallTestExecutable(t, t.TempDir())
 	linkPath := filepath.Join(binDir, CommandName)
-	if err := os.WriteFile(linkPath, []byte("not a symlink"), 0o644); err != nil {
+	if err := os.WriteFile(linkPath, []byte("not a symlink"), 0o600); err != nil {
 		t.Fatalf("write existing file: %v", err)
 	}
 
@@ -75,7 +75,7 @@ func TestInstallCLIForceReplacesExistingRegularFile(t *testing.T) {
 	binDir := t.TempDir()
 	executable := writeInstallTestExecutable(t, t.TempDir())
 	linkPath := filepath.Join(binDir, CommandName)
-	if err := os.WriteFile(linkPath, []byte("not a symlink"), 0o644); err != nil {
+	if err := os.WriteFile(linkPath, []byte("not a symlink"), 0o600); err != nil {
 		t.Fatalf("write existing file: %v", err)
 	}
 
@@ -111,13 +111,14 @@ func TestInstallCLIUsesDefaultBinDirAndCurrentExecutable(t *testing.T) {
 	if target != result.TargetPath {
 		t.Fatalf("symlink target = %q, want result target %q", target, result.TargetPath)
 	}
+	assertInstallPathMode(t, filepath.Dir(result.LinkPath), 0o755)
 }
 
 func TestInstallCLIRejectsNonExecutableTarget(t *testing.T) {
 	t.Parallel()
 
 	target := filepath.Join(t.TempDir(), "agent-secret")
-	if err := os.WriteFile(target, []byte("not executable"), 0o644); err != nil {
+	if err := os.WriteFile(target, []byte("not executable"), 0o600); err != nil {
 		t.Fatalf("write target: %v", err)
 	}
 
@@ -186,7 +187,7 @@ func TestInstallCLIForceRefusesDirectoryAtLinkPath(t *testing.T) {
 	t.Parallel()
 
 	binDir := t.TempDir()
-	if err := os.Mkdir(filepath.Join(binDir, CommandName), 0o755); err != nil {
+	if err := os.Mkdir(filepath.Join(binDir, CommandName), 0o750); err != nil {
 		t.Fatalf("create existing directory: %v", err)
 	}
 
@@ -254,6 +255,7 @@ func TestInstallSkillUsesDefaultSkillsDir(t *testing.T) {
 	if result.LinkPath != wantLinkPath {
 		t.Fatalf("link path = %q, want %q", result.LinkPath, wantLinkPath)
 	}
+	assertInstallPathMode(t, filepath.Dir(result.LinkPath), 0o755)
 }
 
 func TestInstallSkillRefusesExistingRegularFileWithoutForce(t *testing.T) {
@@ -261,7 +263,7 @@ func TestInstallSkillRefusesExistingRegularFileWithoutForce(t *testing.T) {
 
 	skillsDir := t.TempDir()
 	linkPath := filepath.Join(skillsDir, SkillName)
-	if err := os.WriteFile(linkPath, []byte("not a symlink"), 0o644); err != nil {
+	if err := os.WriteFile(linkPath, []byte("not a symlink"), 0o600); err != nil {
 		t.Fatalf("write existing file: %v", err)
 	}
 
@@ -277,7 +279,7 @@ func TestInstallSkillForceReplacesExistingRegularFile(t *testing.T) {
 	skillsDir := t.TempDir()
 	source := writeInstallTestSkill(t, t.TempDir())
 	linkPath := filepath.Join(skillsDir, SkillName)
-	if err := os.WriteFile(linkPath, []byte("not a symlink"), 0o644); err != nil {
+	if err := os.WriteFile(linkPath, []byte("not a symlink"), 0o600); err != nil {
 		t.Fatalf("write existing file: %v", err)
 	}
 
@@ -329,7 +331,7 @@ func TestInstallSkillRejectsFileSource(t *testing.T) {
 	t.Parallel()
 
 	source := filepath.Join(t.TempDir(), "agent-secret")
-	if err := os.WriteFile(source, []byte("---\nname: agent-secret\n---\n"), 0o644); err != nil {
+	if err := os.WriteFile(source, []byte("---\nname: agent-secret\n---\n"), 0o600); err != nil {
 		t.Fatalf("write source file: %v", err)
 	}
 
@@ -343,7 +345,7 @@ func TestInstallSkillRejectsSkillFileDirectory(t *testing.T) {
 	t.Parallel()
 
 	source := filepath.Join(t.TempDir(), SkillName)
-	if err := os.MkdirAll(filepath.Join(source, "SKILL.md"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(source, "SKILL.md"), 0o750); err != nil {
 		t.Fatalf("create skill file directory: %v", err)
 	}
 
@@ -357,7 +359,7 @@ func TestInstallSkillRejectsDirectoryAtLinkPath(t *testing.T) {
 	t.Parallel()
 
 	skillsDir := t.TempDir()
-	if err := os.Mkdir(filepath.Join(skillsDir, SkillName), 0o755); err != nil {
+	if err := os.Mkdir(filepath.Join(skillsDir, SkillName), 0o750); err != nil {
 		t.Fatalf("create existing directory: %v", err)
 	}
 
@@ -375,7 +377,7 @@ func writeInstallTestExecutable(t *testing.T, dir string) string {
 	t.Helper()
 
 	path := filepath.Join(dir, "agent-secret")
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: installer tests need a runnable fixture executable.
 		t.Fatalf("write executable: %v", err)
 	}
 	return path
@@ -387,10 +389,10 @@ func writeInstallTestBundle(t *testing.T, dir string) string {
 	bundle := filepath.Join(dir, "Agent Secret.app")
 	executableDir := filepath.Join(bundle, "Contents", "Resources", "bin")
 	skillsDir := filepath.Join(bundle, "Contents", "Resources", "skills")
-	if err := os.MkdirAll(executableDir, 0o755); err != nil {
+	if err := os.MkdirAll(executableDir, 0o750); err != nil {
 		t.Fatalf("create executable dir: %v", err)
 	}
-	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+	if err := os.MkdirAll(skillsDir, 0o750); err != nil {
 		t.Fatalf("create skills dir: %v", err)
 	}
 	writeInstallTestExecutable(t, executableDir)
@@ -402,13 +404,25 @@ func writeInstallTestSkill(t *testing.T, dir string) string {
 	t.Helper()
 
 	path := filepath.Join(dir, SkillName)
-	if err := os.MkdirAll(path, 0o755); err != nil {
+	if err := os.MkdirAll(path, 0o750); err != nil {
 		t.Fatalf("create skill dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(path, "SKILL.md"), []byte("---\nname: agent-secret\n---\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(path, "SKILL.md"), []byte("---\nname: agent-secret\n---\n"), 0o600); err != nil {
 		t.Fatalf("write skill file: %v", err)
 	}
 	return path
+}
+
+func assertInstallPathMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %s, want %s", path, got, want)
+	}
 }
 
 func resolveInstallTestPath(t *testing.T, path string) string {

--- a/internal/profileconfig/profileconfig_test.go
+++ b/internal/profileconfig/profileconfig_test.go
@@ -11,7 +11,7 @@ import (
 func TestLoadFindsProfileInParentAndSortsSecrets(t *testing.T) {
 	root := t.TempDir()
 	child := filepath.Join(root, "infra", "terraform")
-	if err := os.MkdirAll(child, 0o755); err != nil {
+	if err := os.MkdirAll(child, 0o750); err != nil {
 		t.Fatalf("create child dir: %v", err)
 	}
 	writeConfig(t, filepath.Join(root, "agent-secret.yml"), `
@@ -420,7 +420,7 @@ profiles:
 func writeConfig(t *testing.T, path string, contents string) {
 	t.Helper()
 
-	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 }

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -299,7 +299,7 @@ func writeExecutable(t *testing.T, dir string) string {
 	t.Helper()
 
 	path := filepath.Join(dir, "tool")
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: request validation tests need a runnable fixture executable.
 		t.Fatalf("write executable: %v", err)
 	}
 


### PR DESCRIPTION
Closes #68.

## Summary
- remove the global gosec suppressions for `G301`, `G302`, and `G306`
- keep only line-local `nolint:gosec` comments where executable/searchable modes are intentional and justified
- tighten test fixture file and directory modes where permissive access is not needed
- add installer mode assertions for the default CLI and skill install directories

## Verification
- `mise run lint:go`
- `mise exec -- go test ./internal/install ./internal/audit ./internal/daemon`
- `mise exec -- go test ./internal/cli ./internal/profileconfig ./internal/request`
- `mise run lint`
- `mise run build`
