### PR TITLE
ASR-015 lint root installer scripts

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -25,7 +25,7 @@ if [ ! -x node_modules/.bin/markdownlint ]; then
   npm ci --ignore-scripts --no-audit --no-fund
 fi
 
-shellcheck scripts/*.sh approver/scripts/*.sh
+shellcheck install.sh uninstall.sh scripts/*.sh approver/scripts/*.sh
 scripts/check-format.sh shell
 if [ -d .github/workflows ]; then
   workflow_files=()


### PR DESCRIPTION
Closes #70.

## Summary
- include `install.sh` and `uninstall.sh` in the default `scripts/lint.sh` shellcheck invocation
- keep the default `mise run lint` shell surface aligned with `mise run lint:shell`

## Verification
- `mise run lint:shell`
- `mise run lint`
- `mise run build`
