### PR TITLE
ASR-016 sanitize Swift daemon errors

### DIFF
--- a/approver/Sources/AgentSecretApprover/DaemonErrorDisplay.swift
+++ b/approver/Sources/AgentSecretApprover/DaemonErrorDisplay.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+enum DaemonErrorDisplay {
+    private enum Code {
+        static let unknown: String = "unknown"
+        static let maxLength: Int = 64
+    }
+
+    private static let allowedCodeScalars = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789_")
+    private static let messagesByCode: [String: String] = [
+        "approval_denied": "approval denied",
+        "approval_unavailable": "approval is unavailable",
+        "approver_identity_mismatch": "approver identity did not match policy",
+        "approver_peer_mismatch": "approver peer did not match request",
+        "audit_failed": "required audit write failed",
+        "bad_approval_decision": "daemon rejected malformed approval decision",
+        "bad_command_completed": "daemon rejected malformed command completion",
+        "bad_command_started": "daemon rejected malformed command start",
+        "bad_envelope": "daemon rejected malformed protocol envelope",
+        "bad_request": "daemon rejected malformed request",
+        "bad_type": "daemon rejected unsupported message type",
+        "frame_too_large": "daemon response frame was too large",
+        "invalid_nonce": "request nonce did not match",
+        "no_pending_approval": "no pending approval request",
+        "peer_rejected": "daemon rejected peer identity",
+        "request_active": "connection already has an active request",
+        "request_expired": "request expired",
+        "stale_approval": "stale approval response",
+        "untrusted_client": "daemon rejected untrusted client"
+    ]
+
+    static func sanitizedCode(_ rawCode: String?) -> String {
+        guard let rawCode else {
+            return Code.unknown
+        }
+        if rawCode.isEmpty || rawCode.count > Code.maxLength {
+            return Code.unknown
+        }
+        if !rawCode.unicodeScalars.allSatisfy({ scalar in allowedCodeScalars.contains(scalar) }) {
+            return Code.unknown
+        }
+        return rawCode
+    }
+
+    static func message(for rawCode: String?) -> String {
+        messagesByCode[sanitizedCode(rawCode)] ?? "daemon returned an error"
+    }
+}

--- a/approver/Sources/AgentSecretApprover/SocketDaemonClient.swift
+++ b/approver/Sources/AgentSecretApprover/SocketDaemonClient.swift
@@ -125,7 +125,8 @@ public final class SocketDaemonClient: ApprovalDaemonClient {
             from: data
         )
         let payload: DaemonErrorPayload? = response.payload
-        return .daemonError(payload?.code ?? "unknown", payload?.message ?? "unknown daemon error")
+        let code: String = DaemonErrorDisplay.sanitizedCode(payload?.code)
+        return .daemonError(code, DaemonErrorDisplay.message(for: code))
     }
 
     private func send(_ envelope: DaemonEnvelope<some Encodable>) throws {

--- a/approver/Sources/AgentSecretApprover/SocketDaemonClientError.swift
+++ b/approver/Sources/AgentSecretApprover/SocketDaemonClientError.swift
@@ -31,8 +31,8 @@ public enum SocketDaemonClientError: Error, CustomStringConvertible, Equatable {
         case let .connectFailed(errnoValue):
             "connect failed: errno \(errnoValue)"
 
-        case let .daemonError(code, message):
-            "daemon error \(code): \(message)"
+        case let .daemonError(code, _):
+            "daemon error \(DaemonErrorDisplay.sanitizedCode(code)): \(DaemonErrorDisplay.message(for: code))"
 
         case .disconnected:
             "daemon disconnected"

--- a/approver/Tests/AgentSecretApproverTests/SocketDaemonClientErrorSanitizationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/SocketDaemonClientErrorSanitizationTests.swift
@@ -1,0 +1,88 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class SocketDaemonClientErrorSanitizationTests: XCTestCase {
+    private final class MemoryLineTransport: LineTransport {
+        private var reads: [Data]
+
+        init(reads: [Data]) {
+            self.reads = reads
+        }
+
+        func readLine() throws -> Data {
+            guard !reads.isEmpty else {
+                throw SocketDaemonClientError.disconnected
+            }
+            return reads.removeFirst()
+        }
+
+        func writeLine(_: Data) {
+            /* Test responses do not inspect outbound requests. */
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+
+    private static let expectedProtocolVersion: Int = 1
+    private static let secretCanary: String = "synthetic-secret-value"
+
+    private static func errorResponse(code: String, message: String) throws -> Data {
+        let envelope = DaemonEnvelope(
+            nonce: nil,
+            payload: DaemonErrorPayload(code: code, message: message),
+            requestID: nil,
+            type: "error",
+            version: expectedProtocolVersion
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(envelope)
+    }
+
+    func testDaemonErrorDisplayRedactsDaemonSuppliedMessageText() throws {
+        let message = """
+        failed op://Example Vault/Deploy/token for alias SECRET_ALIAS_CANARY \
+        account prod-account-123 value synthetic-secret-value path /Users/alice/.ssh/id_rsa
+        """
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(reads: [Self.errorResponse(code: "bad_request", message: message)])
+        )
+
+        XCTAssertThrowsError(try client.fetchPendingRequest()) { error in
+            XCTAssertEqual(
+                error as? SocketDaemonClientError,
+                .daemonError("bad_request", "daemon rejected malformed request")
+            )
+            let displayed = String(describing: error)
+            XCTAssertEqual(displayed, "daemon error bad_request: daemon rejected malformed request")
+            XCTAssertFalse(displayed.contains("op://"))
+            XCTAssertFalse(displayed.contains("SECRET_ALIAS_CANARY"))
+            XCTAssertFalse(displayed.contains("prod-account-123"))
+            XCTAssertFalse(displayed.contains(Self.secretCanary))
+            XCTAssertFalse(displayed.contains("/Users/alice/.ssh/id_rsa"))
+        }
+    }
+
+    func testDaemonErrorDisplaySanitizesDaemonSuppliedCodeText() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [Self.errorResponse(code: "op://Example Vault/Item/token", message: Self.secretCanary)]
+            )
+        )
+
+        XCTAssertThrowsError(try client.fetchPendingRequest()) { error in
+            XCTAssertEqual(error as? SocketDaemonClientError, .daemonError("unknown", "daemon returned an error"))
+            let displayed = String(describing: error)
+            XCTAssertEqual(displayed, "daemon error unknown: daemon returned an error")
+            XCTAssertFalse(displayed.contains("op://"))
+            XCTAssertFalse(displayed.contains(Self.secretCanary))
+        }
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}

--- a/approver/Tests/AgentSecretApproverTests/SocketDaemonClientTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/SocketDaemonClientTests.swift
@@ -91,11 +91,18 @@ final class SocketDaemonClientTests: XCTestCase {
         )
     }
 
-    private static func errorResponse() -> Data {
-        Data(
-            """
-            {"payload":{"code":"stale_approval","message":"stale approval response"},"type":"error","version":1}
-            """.utf8
+    private static func errorResponse(
+        code: String = "stale_approval",
+        message: String = "stale approval response"
+    ) throws -> Data {
+        try encode(
+            DaemonEnvelope(
+                nonce: nil,
+                payload: DaemonErrorPayload(code: code, message: message),
+                requestID: nil,
+                type: "error",
+                version: expectedProtocolVersion
+            )
         )
     }
 
@@ -252,8 +259,8 @@ final class SocketDaemonClientTests: XCTestCase {
         XCTAssertFalse(written.contains(Self.secretCanary))
     }
 
-    func testReportsDaemonErrors() {
-        let client = SocketDaemonClient(transport: MemoryLineTransport(reads: [Self.errorResponse()]))
+    func testReportsDaemonErrors() throws {
+        let client = try SocketDaemonClient(transport: MemoryLineTransport(reads: [Self.errorResponse()]))
 
         XCTAssertThrowsError(try client.fetchPendingRequest()) { error in
             XCTAssertEqual(


### PR DESCRIPTION
Closes #71.

## Summary
- derive Swift daemon error display text from a local stable code-to-message table
- sanitize daemon error codes and ignore daemon-supplied message text before storing/displaying errors
- make `SocketDaemonClientError.description` sanitize direct daemon error values too
- add regressions proving secret-looking refs, aliases, accounts, values, paths, and malicious codes do not appear in displayed errors

## Verification
- `cd approver && swift test --filter SocketDaemonClientTests`
- `cd approver && swift test --filter SocketDaemonClientErrorSanitizationTests`
- `mise run lint:swift`
- `cd approver && swift test`
- `mise run lint`
- `mise run build`
