### PR TITLE
ASR-017: Fix protocol timeouts for approvals and exec

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -148,8 +148,10 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 	reader := bufio.NewReader(conn)
 	encoder := json.NewEncoder(conn)
 	activeRequestID := ""
+	commandStarted := false
+	nextReadTimeout := s.readTimeout
 	for {
-		env, err := s.readEnvelope(conn, reader)
+		env, err := s.readEnvelope(conn, reader, nextReadTimeout)
 		if err != nil {
 			if activeRequestID != "" {
 				s.broker.ClientDisconnected(ctx, activeRequestID)
@@ -164,6 +166,11 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 		if err := validateEnvelope(env); err != nil {
 			_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_envelope", err)
 			continue
+		}
+
+		nextReadTimeout = s.readTimeout
+		if commandStarted {
+			nextReadTimeout = 0
 		}
 
 		switch env.Type {
@@ -198,7 +205,9 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
 				continue
 			}
-			_ = writeOK(encoder, payload.RequestID, payload.Nonce, payload)
+			if err := writeOK(encoder, payload.RequestID, payload.Nonce, payload); err == nil {
+				nextReadTimeout = s.approvalDecisionReadTimeout(payload.ExpiresAt)
+			}
 		case TypeApprovalDecision:
 			if s.approvals == nil {
 				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "approval_unavailable", ErrApprovalUnavailable)
@@ -226,12 +235,19 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 			}
 			if requestID := s.handleRequestExec(ctx, conn, encoder, env); requestID != "" {
 				activeRequestID = requestID
+				commandStarted = false
+				nextReadTimeout = s.readTimeout
 			}
 		case TypeCommandStarted:
-			s.handleCommandStarted(ctx, conn, encoder, env)
+			if s.handleCommandStarted(ctx, conn, encoder, env) {
+				commandStarted = true
+				nextReadTimeout = 0
+			}
 		case TypeCommandCompleted:
 			if s.handleCommandCompleted(ctx, conn, encoder, env) {
 				activeRequestID = ""
+				commandStarted = false
+				nextReadTimeout = s.readTimeout
 			}
 		default:
 			_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_type", fmt.Errorf("%w: %s", ErrProtocolType, env.Type))
@@ -278,21 +294,22 @@ func (s *Server) handleCommandStarted(
 	conn *net.UnixConn,
 	encoder *json.Encoder,
 	env Envelope,
-) {
+) bool {
 	if err := s.validateTrustedClientPeer(conn); err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
-		return
+		return false
 	}
 	payload, err := DecodePayload[CommandStartedPayload](env)
 	if err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_command_started", err)
-		return
+		return false
 	}
 	if err := s.broker.ReportStarted(ctx, env.RequestID, env.Nonce, payload.ChildPID); err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
-		return
+		return false
 	}
 	_ = writeOK(encoder, env.RequestID, env.Nonce, nil)
+	return true
 }
 
 func (s *Server) handleCommandCompleted(
@@ -328,14 +345,25 @@ func (s *Server) peerInfo(conn *net.UnixConn) (peercred.Info, error) {
 	return peercred.Inspect(conn)
 }
 
-func (s *Server) readEnvelope(conn *net.UnixConn, reader *bufio.Reader) (Envelope, error) {
-	if s.readTimeout > 0 {
-		if err := conn.SetReadDeadline(time.Now().Add(s.readTimeout)); err != nil {
+func (s *Server) readEnvelope(conn *net.UnixConn, reader *bufio.Reader, timeout time.Duration) (Envelope, error) {
+	if timeout > 0 {
+		if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
 			return Envelope{}, fmt.Errorf("set daemon read deadline: %w", err)
 		}
 		defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
 	}
 	return readEnvelopeFrame(reader, s.maxFrameBytes)
+}
+
+func (s *Server) approvalDecisionReadTimeout(expiresAt time.Time) time.Duration {
+	if s.readTimeout <= 0 {
+		return 0
+	}
+	remaining := time.Until(expiresAt)
+	if remaining <= 0 {
+		return s.readTimeout
+	}
+	return remaining + s.readTimeout
 }
 
 func daemonStopAuditEvent(peer peercred.Info, err error) audit.Event {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -77,6 +77,51 @@ func TestServerExecProtocolLifecycle(t *testing.T) {
 	}
 }
 
+func TestServerAllowsCommandCompletionAfterProtocolReadTimeout(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{ref: "value"}},
+		Audit:    aud,
+	})
+	path, stop := startRawServerWithOptions(t, ServerOptions{
+		Broker:        broker,
+		Validator:     allowPeerValidator{},
+		ExecValidator: NewTrustedExecutableValidator(CurrentExecutableTrustedClientPaths()),
+		ReadTimeout:   20 * time.Millisecond,
+	})
+	defer stop()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	client := NewClient(conn)
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", testExecRequest(t, []request.SecretSpec{
+		{Alias: "TOKEN", Ref: ref},
+	})); err != nil {
+		t.Fatalf("RequestExec returned error: %v", err)
+	}
+	if err := client.ReportStarted(context.Background(), "req_1", "nonce_1", 4321); err != nil {
+		t.Fatalf("ReportStarted returned error: %v", err)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	if err := client.ReportCompleted(context.Background(), "req_1", "nonce_1", 0, ""); err != nil {
+		t.Fatalf("ReportCompleted returned error after protocol read timeout: %v", err)
+	}
+	got := auditEventTypes(aud.Events())
+	if len(got) == 0 || got[len(got)-1] != audit.EventCommandCompleted {
+		t.Fatalf("audit events = %v; last event should be %s", got, audit.EventCommandCompleted)
+	}
+}
+
 func TestServerRejectsBadProtocolVersionAndNonceMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -509,6 +554,80 @@ func TestServerApprovalProtocolOverSingleSocket(t *testing.T) {
 		Decision:  "approve_once",
 	}); err != nil {
 		t.Fatalf("SubmitApprovalDecision returned error: %v", err)
+	}
+
+	select {
+	case payload := <-execDone:
+		if payload.Env["TOKEN"] != "value" {
+			t.Fatalf("exec payload = %+v", payload)
+		}
+	case err := <-execErr:
+		t.Fatalf("RequestExec returned error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for exec response")
+	}
+}
+
+func TestServerAllowsApprovalDecisionAfterProtocolReadTimeout(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	peer := peerInfoForTest(t, os.Getpid(), exe)
+	ref := "op://Example/Item/token"
+	launcher := &recordingLauncher{expected: ExpectedApprover{PID: peer.PID, ExecutablePath: peer.ExecutablePath}}
+	approver := newSocketApproverForTest(t, launcher, time.Now)
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: approver,
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+		Audit:    &memoryAudit{},
+	})
+	path, stop := startRawServerWithOptions(t, ServerOptions{
+		Broker:        broker,
+		Approvals:     approver,
+		Validator:     staticPeerValidator{info: peer},
+		ExecValidator: NewTrustedExecutableValidator(CurrentExecutableTrustedClientPaths()),
+		ReadTimeout:   20 * time.Millisecond,
+	})
+	defer stop()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial exec client returned error: %v", err)
+	}
+	client := NewClient(conn)
+	defer func() { _ = client.Close() }()
+
+	execDone := make(chan ExecResponsePayload, 1)
+	execErr := make(chan error, 1)
+	go func() {
+		payload, err := client.RequestExec(context.Background(), "req_1", "nonce_1", approvalTestRequest(t, time.Now().Add(time.Minute)))
+		if err != nil {
+			execErr <- err
+			return
+		}
+		execDone <- payload
+	}()
+	waitForPendingOrExecError(t, approver, execErr)
+
+	appConn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial app client returned error: %v", err)
+	}
+	appClient := NewClient(appConn)
+	defer func() { _ = appClient.Close() }()
+	pending, err := appClient.FetchPendingApproval(context.Background())
+	if err != nil {
+		t.Fatalf("FetchPendingApproval returned error: %v", err)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	if err := appClient.SubmitApprovalDecision(context.Background(), ApprovalDecisionPayload{
+		RequestID: pending.RequestID,
+		Nonce:     pending.Nonce,
+		Decision:  "approve_once",
+	}); err != nil {
+		t.Fatalf("SubmitApprovalDecision returned error after protocol read timeout: %v", err)
 	}
 
 	select {


### PR DESCRIPTION
## Summary
- make daemon socket read deadlines phase-aware instead of applying the short protocol timeout to every frame
- allow approval decision sockets to stay open through the pending request TTL plus a short protocol grace window
- remove the protocol read deadline after a trusted command.started until command.completed arrives
- add regressions for delayed approval decisions and long-running exec completion over a single socket

## Verification
- mise exec -- go test ./internal/daemon
- mise run lint
- mise run build
- mise run test:smoke

Closes #88