### PR TITLE
ASR-018: Authenticate daemon peers before client protocol

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -31,10 +31,9 @@ func TestAppExecRunsChildWithApprovedEnvAndPassthrough(t *testing.T) {
 		Audit:    &appAudit{},
 	})
 	defer cleanup()
-	socketPath := client.SocketPath
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	app := NewApp(daemon.Manager{SocketPath: socketPath}, &stdout, &stderr)
+	app := NewApp(appTestManager(client), &stdout, &stderr)
 	t.Setenv("AGENT_SECRET_APP_EXEC_HELPER", "1")
 
 	code := app.Run(context.Background(), []string{
@@ -76,7 +75,7 @@ func TestAppExecRunsChildWithEnvFileSecretsAndPlainEnv(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	app := NewApp(daemon.Manager{SocketPath: client.SocketPath}, &stdout, &stderr)
+	app := NewApp(appTestManager(client), &stdout, &stderr)
 	t.Setenv("AGENT_SECRET_APP_EXEC_HELPER", "1")
 	t.Setenv("AGENT_SECRET_APP_EXPECT_PLAIN", "from-file")
 	t.Setenv("TOKEN", "parent-token")
@@ -111,7 +110,7 @@ func TestAppExecStopsBeforeSpawnOnApprovalDenial(t *testing.T) {
 	defer cleanup()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	app := NewApp(daemon.Manager{SocketPath: client.SocketPath}, &stdout, &stderr)
+	app := NewApp(appTestManager(client), &stdout, &stderr)
 	t.Setenv("AGENT_SECRET_APP_EXEC_HELPER", "1")
 
 	code := app.Run(context.Background(), []string{
@@ -139,7 +138,7 @@ func TestAppDaemonStatusAndDoctor(t *testing.T) {
 	defer cleanup()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	app := NewApp(daemon.Manager{SocketPath: client.SocketPath}, &stdout, &stderr)
+	app := NewApp(appTestManager(client), &stdout, &stderr)
 	app.DoctorApproverCheck = func(context.Context) error { return nil }
 	app.DoctorOnePasswordCheck = func(context.Context) error { return nil }
 
@@ -172,7 +171,7 @@ func TestAppDoctorReportsFailureWithoutSecretValues(t *testing.T) {
 	defer cleanup()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	app := NewApp(daemon.Manager{SocketPath: client.SocketPath}, &stdout, &stderr)
+	app := NewApp(appTestManager(client), &stdout, &stderr)
 	app.DoctorApproverCheck = func(context.Context) error { return nil }
 	app.DoctorOnePasswordCheck = func(context.Context) error {
 		return errors.New("desktop integration unavailable")
@@ -199,7 +198,7 @@ func TestAppDaemonStartAndStopCommands(t *testing.T) {
 	defer cleanup()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	app := NewApp(daemon.Manager{SocketPath: client.SocketPath}, &stdout, &stderr)
+	app := NewApp(appTestManager(client), &stdout, &stderr)
 
 	if code := app.Run(context.Background(), []string{"daemon", "start"}); code != 0 {
 		t.Fatalf("daemon start exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
@@ -328,7 +327,7 @@ func TestAppExecReportsRandomIDFailureBeforeRequest(t *testing.T) {
 	entropyErr := errors.New("entropy unavailable")
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	app := NewApp(daemon.Manager{SocketPath: client.SocketPath}, &stdout, &stderr)
+	app := NewApp(appTestManager(client), &stdout, &stderr)
 	app.RandomReader = failingRandomReader{err: entropyErr}
 	t.Setenv("AGENT_SECRET_APP_EXEC_HELPER", "1")
 
@@ -401,6 +400,10 @@ func runAppExecHelper() {
 
 type appTestClient struct {
 	SocketPath string
+}
+
+func appTestManager(client appTestClient) daemon.Manager {
+	return daemon.Manager{SocketPath: client.SocketPath, DaemonPath: os.Args[0]}
 }
 
 type appApprover struct {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
 
@@ -27,11 +28,30 @@ type Client struct {
 }
 
 func Connect(ctx context.Context, path string) (*Client, error) {
+	return ConnectWithPeerValidator(ctx, path, NewTrustedDaemonValidator(DefaultTrustedDaemonPaths()))
+}
+
+func ConnectWithPeerValidator(ctx context.Context, path string, validator DaemonPeerValidator) (*Client, error) {
 	conn, err := Dial(ctx, path)
 	if err != nil {
 		return nil, err
 	}
+	if err := validateDaemonPeer(conn, validator); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
 	return NewClient(conn), nil
+}
+
+func validateDaemonPeer(conn *net.UnixConn, validator DaemonPeerValidator) error {
+	if validator == nil {
+		return nil
+	}
+	info, err := peercred.Inspect(conn)
+	if err != nil {
+		return fmt.Errorf("%w: inspect daemon peer: %w", ErrUntrustedDaemon, err)
+	}
+	return validator.ValidateDaemonPeer(info)
 }
 
 func NewClient(conn *net.UnixConn) *Client {

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovyrin/agent-secret/internal/request"
+)
+
+func TestConnectAcceptsTrustedDaemonPeer(t *testing.T) {
+	t.Parallel()
+
+	path, stop := startRawServerWithOptions(t, ServerOptions{
+		Broker: newTestBroker(t, BrokerOptions{
+			Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
+			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
+			Audit:    &memoryAudit{},
+		}),
+		Validator: allowPeerValidator{},
+	})
+	defer stop()
+
+	client, err := ConnectWithPeerValidator(
+		context.Background(),
+		path,
+		NewTrustedDaemonValidator([]string{currentExecutable(t)}),
+	)
+	if err != nil {
+		t.Fatalf("ConnectWithPeerValidator returned error: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+	if _, err := client.Status(context.Background()); err != nil {
+		t.Fatalf("Status returned error: %v", err)
+	}
+}
+
+func TestConnectRejectsUntrustedDaemonBeforeExecPayload(t *testing.T) {
+	t.Parallel()
+
+	path, stop := startFakeExecDaemon(t)
+	defer stop()
+	trustedDaemon := writeExecutableAt(t, t.TempDir(), "agent-secretd")
+
+	client, err := ConnectWithPeerValidator(
+		context.Background(),
+		path,
+		NewTrustedDaemonValidator([]string{trustedDaemon}),
+	)
+	if err == nil {
+		defer func() { _ = client.Close() }()
+		payload, requestErr := client.RequestExec(
+			context.Background(),
+			"req_1",
+			"nonce_1",
+			testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}}),
+		)
+		if requestErr == nil {
+			t.Fatalf("accepted exec payload from untrusted daemon: %+v", payload.Env)
+		}
+		t.Fatalf("ConnectWithPeerValidator accepted untrusted daemon; request error = %v", requestErr)
+	}
+	if !errors.Is(err, ErrUntrustedDaemon) {
+		t.Fatalf("ConnectWithPeerValidator error = %v, want %v", err, ErrUntrustedDaemon)
+	}
+}
+
+func TestManagerStatusRejectsUntrustedDaemonPeer(t *testing.T) {
+	t.Parallel()
+
+	path, stop := startFakeExecDaemon(t)
+	defer stop()
+	manager := Manager{
+		SocketPath: path,
+		DaemonPath: writeExecutableAt(t, t.TempDir(), "agent-secretd"),
+	}
+
+	_, err := manager.Status(context.Background())
+	if !errors.Is(err, ErrUntrustedDaemon) {
+		t.Fatalf("Status error = %v, want %v", err, ErrUntrustedDaemon)
+	}
+}
+
+func TestTrustedDaemonPathsForAppUseBundleExecutable(t *testing.T) {
+	t.Parallel()
+
+	appPath := filepath.Join(t.TempDir(), "AgentSecretDaemon.app")
+	executablePath := filepath.Join(appPath, "Contents", "MacOS", "Agent Secret")
+	if err := os.MkdirAll(filepath.Dir(executablePath), 0o750); err != nil {
+		t.Fatalf("mkdir bundle executable dir: %v", err)
+	}
+	if err := os.WriteFile(executablePath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: daemon path tests need executable fixtures.
+		t.Fatalf("write executable: %v", err)
+	}
+	info := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>Agent Secret</string>
+</dict>
+</plist>
+`
+	if err := os.WriteFile(filepath.Join(appPath, "Contents", "Info.plist"), []byte(info), 0o600); err != nil {
+		t.Fatalf("write Info.plist: %v", err)
+	}
+
+	got := trustedDaemonPathsForPath(appPath)
+	if len(got) != 1 || got[0] != executablePath {
+		t.Fatalf("trusted daemon paths = %v, want [%s]", got, executablePath)
+	}
+}
+
+func startFakeExecDaemon(t *testing.T) (string, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "agent-secret-fake-daemon-")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	path := filepath.Join(dir, "d.sock")
+	listener, err := ListenUnix(path)
+	if err != nil {
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		serveFakeExecPayload(conn)
+	}()
+	return path, func() {
+		_ = listener.Close()
+		<-done
+		_ = os.RemoveAll(dir)
+	}
+}
+
+func serveFakeExecPayload(conn *net.UnixConn) {
+	decoder := json.NewDecoder(conn)
+	encoder := json.NewEncoder(conn)
+	var env Envelope
+	if err := decoder.Decode(&env); err != nil {
+		return
+	}
+	resp, err := NewEnvelope(TypeOK, env.RequestID, env.Nonce, ExecResponsePayload{
+		Env:           map[string]string{"TOKEN": "attacker-controlled"},
+		SecretAliases: []string{"TOKEN"},
+	})
+	if err != nil {
+		return
+	}
+	if err := encoder.Encode(resp); err != nil {
+		return
+	}
+}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -88,7 +88,7 @@ func (m Manager) Start(ctx context.Context) error {
 }
 
 func (m Manager) Status(ctx context.Context) (StatusPayload, error) {
-	client, err := Connect(ctx, m.SocketPath)
+	client, err := m.Connect(ctx)
 	if err != nil {
 		return StatusPayload{}, err
 	}
@@ -97,7 +97,7 @@ func (m Manager) Status(ctx context.Context) (StatusPayload, error) {
 }
 
 func (m Manager) Stop(ctx context.Context) error {
-	client, err := Connect(ctx, m.SocketPath)
+	client, err := m.Connect(ctx)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,19 @@ func (m Manager) Stop(ctx context.Context) error {
 }
 
 func (m Manager) Connect(ctx context.Context) (*Client, error) {
-	return Connect(ctx, m.SocketPath)
+	return ConnectWithPeerValidator(ctx, m.SocketPath, NewTrustedDaemonValidator(m.trustedDaemonPaths()))
+}
+
+func (m Manager) trustedDaemonPaths() []string {
+	daemonPath := m.DaemonPath
+	if daemonPath == "" {
+		var err error
+		daemonPath, err = defaultDaemonPath()
+		if err != nil {
+			return nil
+		}
+	}
+	return trustedDaemonPathsForPath(daemonPath)
 }
 
 func (m Manager) stopped(ctx context.Context) bool {

--- a/internal/daemon/trusted_client.go
+++ b/internal/daemon/trusted_client.go
@@ -18,8 +18,13 @@ type ExecPeerValidator interface {
 }
 
 type TrustedExecutableValidator struct {
+	set trustedExecutableSet
+}
+
+type trustedExecutableSet struct {
 	entries        []trustedExecutable
 	expectedTeamID string
+	err            error
 }
 
 type trustedExecutable struct {
@@ -33,6 +38,12 @@ func NewTrustedExecutableValidator(paths []string) TrustedExecutableValidator {
 }
 
 func newTrustedExecutableValidator(paths []string, expectedTeamID string) TrustedExecutableValidator {
+	return TrustedExecutableValidator{
+		set: newTrustedExecutableSet(paths, expectedTeamID, ErrUntrustedClient),
+	}
+}
+
+func newTrustedExecutableSet(paths []string, expectedTeamID string, err error) trustedExecutableSet {
 	seen := make(map[string]struct{}, len(paths))
 	entries := make([]trustedExecutable, 0, len(paths))
 	for _, path := range paths {
@@ -58,9 +69,10 @@ func newTrustedExecutableValidator(paths []string, expectedTeamID string) Truste
 		}
 		entries = append(entries, entry)
 	}
-	return TrustedExecutableValidator{
+	return trustedExecutableSet{
 		entries:        entries,
 		expectedTeamID: strings.TrimSpace(expectedTeamID),
+		err:            err,
 	}
 }
 
@@ -142,46 +154,56 @@ func containingAppBundlePath(path string) (string, bool) {
 }
 
 func (v TrustedExecutableValidator) ValidateExecPeer(info peercred.Info) error {
+	return v.set.validatePeer(info)
+}
+
+func (v trustedExecutableSet) validatePeer(info peercred.Info) error {
+	if v.err == nil {
+		v.err = ErrUntrustedClient
+	}
 	if info.ExecutablePath == "" {
-		return fmt.Errorf("%w: peer executable path is unavailable", ErrUntrustedClient)
+		return fmt.Errorf("%w: peer executable path is unavailable", v.err)
 	}
 	if len(v.entries) == 0 {
-		return fmt.Errorf("%w: no trusted client executables configured", ErrUntrustedClient)
+		return fmt.Errorf("%w: no trusted executables configured", v.err)
 	}
 	got := comparablePath(info.ExecutablePath)
 	for _, entry := range v.entries {
 		if entry.path != got {
 			continue
 		}
-		if err := entry.validate(got, v.expectedTeamID); err != nil {
+		if err := entry.validate(got, v.expectedTeamID, v.err); err != nil {
 			return err
 		}
 		return nil
 	}
-	return fmt.Errorf("%w: executable %q is not trusted", ErrUntrustedClient, got)
+	return fmt.Errorf("%w: executable %q is not trusted", v.err, got)
 }
 
-func (e trustedExecutable) validate(path string, expectedTeamID string) error {
+func (e trustedExecutable) validate(path string, expectedTeamID string, errKind error) error {
+	if errKind == nil {
+		errKind = ErrUntrustedClient
+	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("%w: stat trusted executable %q: %w", ErrUntrustedClient, path, err)
+		return fmt.Errorf("%w: stat trusted executable %q: %w", errKind, path, err)
 	}
 	if !os.SameFile(info, e.fileInfo) {
-		return fmt.Errorf("%w: executable %q changed since daemon startup", ErrUntrustedClient, path)
+		return fmt.Errorf("%w: executable %q changed since trust snapshot", errKind, path)
 	}
 	if e.bundlePath != "" {
 		currentBundlePath, ok := trustedClientBundlePath(path)
 		if !ok || currentBundlePath != e.bundlePath {
-			return fmt.Errorf("%w: executable %q is outside expected app bundle %q", ErrUntrustedClient, path, e.bundlePath)
+			return fmt.Errorf("%w: executable %q is outside expected app bundle %q", errKind, path, e.bundlePath)
 		}
 	}
 	if expectedTeamID != "" && runtime.GOOS == "darwin" {
 		teamID, err := verifyCodeSignature(path)
 		if err != nil {
-			return fmt.Errorf("%w: verify code signature: %w", ErrUntrustedClient, err)
+			return fmt.Errorf("%w: verify code signature: %w", errKind, err)
 		}
 		if teamID != expectedTeamID {
-			return fmt.Errorf("%w: team id %q != %q", ErrUntrustedClient, teamID, expectedTeamID)
+			return fmt.Errorf("%w: team id %q != %q", errKind, teamID, expectedTeamID)
 		}
 	}
 	return nil

--- a/internal/daemon/trusted_daemon.go
+++ b/internal/daemon/trusted_daemon.go
@@ -1,0 +1,65 @@
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"github.com/kovyrin/agent-secret/internal/peercred"
+)
+
+var ErrUntrustedDaemon = errors.New("untrusted daemon peer")
+
+type DaemonPeerValidator interface {
+	ValidateDaemonPeer(info peercred.Info) error
+}
+
+type TrustedDaemonValidator struct {
+	set trustedExecutableSet
+}
+
+func NewTrustedDaemonValidator(paths []string) TrustedDaemonValidator {
+	return newTrustedDaemonValidator(paths, defaultExpectedTeamID())
+}
+
+func newTrustedDaemonValidator(paths []string, expectedTeamID string) TrustedDaemonValidator {
+	return TrustedDaemonValidator{
+		set: newTrustedExecutableSet(paths, expectedTeamID, ErrUntrustedDaemon),
+	}
+}
+
+func DefaultTrustedDaemonPaths() []string {
+	path, err := defaultDaemonPath()
+	if err != nil {
+		return nil
+	}
+	return trustedDaemonPathsForPath(path)
+}
+
+func trustedDaemonPathsForPath(path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	if filepath.Ext(path) != ".app" {
+		return []string{path}
+	}
+	executable, err := bundleExecutablePath(path)
+	if err != nil {
+		return nil
+	}
+	return []string{executable}
+}
+
+func bundleExecutablePath(bundlePath string) (string, error) {
+	infoPath := filepath.Join(bundlePath, "Contents", "Info.plist")
+	executableName, err := plistString(infoPath, "CFBundleExecutable")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(bundlePath, "Contents", "MacOS", executableName), nil
+}
+
+func (v TrustedDaemonValidator) ValidateDaemonPeer(info peercred.Info) error {
+	return v.set.validatePeer(info)
+}


### PR DESCRIPTION
## Summary
- validate Unix peer credentials immediately after client dial and before accepting any daemon response
- bind Manager connections to the configured/default daemon executable, including bundled helper app executable resolution
- share trusted executable validation between trusted clients and trusted daemon peers with distinct error categories
- add regressions for trusted daemon acceptance, untrusted fake daemon rejection before exec payload delivery, Manager status rejection, and bundled daemon app path resolution

## Verification
- mise exec -- go test ./internal/daemon ./internal/cli
- mise exec -- go test ./...
- mise run lint
- mise run build
- mise run test:smoke

Closes #89