### PR TITLE
ASR-019: Bind approvals to executable identity

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -127,6 +127,7 @@ func (a App) runExec(ctx context.Context, command Command) int {
 	}
 	result, err := execwrap.Run(ctx, execwrap.Spec{
 		Path:          command.ExecRequest.ResolvedExecutable,
+		PathIdentity:  command.ExecRequest.ExecutableIdentity,
 		Args:          command.ExecRequest.Command[1:],
 		Dir:           command.ExecRequest.CWD,
 		BaseEnv:       command.ExecRequest.Env,

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
@@ -595,6 +596,7 @@ func approvalTestRequest(t *testing.T, expiresAt time.Time) request.ExecRequest 
 		Reason:             "Run Terraform plan",
 		Command:            []string{"terraform", "plan"},
 		ResolvedExecutable: "/opt/homebrew/bin/terraform",
+		ExecutableIdentity: fileidentity.Identity{Device: 1, Inode: 1, Mode: 0o755},
 		CWD:                "/tmp/project",
 		Secrets:            []request.Secret{{Alias: "TOKEN", Ref: ref, Account: "Work"}},
 		ReceivedAt:         expiresAt.Add(-request.DefaultExecTTL),

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kovyrin/agent-secret/internal/audit"
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
 	"github.com/kovyrin/agent-secret/internal/policy"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
@@ -1116,6 +1117,7 @@ func testExecRequestAt(t *testing.T, now time.Time, secrets []request.SecretSpec
 		Reason:             "Run Terraform plan",
 		Command:            []string{"terraform", "plan"},
 		ResolvedExecutable: "/opt/homebrew/bin/terraform",
+		ExecutableIdentity: fileidentity.Identity{Device: 1, Inode: 1, Mode: 0o755},
 		CWD:                "/tmp/project",
 		Secrets:            reqSecrets,
 		TTL:                request.DefaultExecTTL,

--- a/internal/execwrap/execwrap.go
+++ b/internal/execwrap/execwrap.go
@@ -11,9 +11,12 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
 )
 
 var ErrEnvironmentConflict = errors.New("approved alias already exists in parent environment")
+var ErrExecutableChanged = errors.New("approved executable changed before spawn")
 
 const terminateGracePeriod = 2 * time.Second
 
@@ -33,6 +36,7 @@ type AuditEvent struct {
 
 type Spec struct {
 	Path          string
+	PathIdentity  fileidentity.Identity
 	Args          []string
 	Dir           string
 	BaseEnv       []string
@@ -53,6 +57,9 @@ type Result struct {
 func Run(ctx context.Context, spec Spec, interrupts <-chan os.Signal) (Result, error) {
 	if spec.Path == "" {
 		return Result{}, errors.New("command path is required")
+	}
+	if err := fileidentity.Verify(spec.Path, spec.PathIdentity); err != nil {
+		return Result{}, fmt.Errorf("%w: %w", ErrExecutableChanged, err)
 	}
 
 	baseEnv := spec.BaseEnv

--- a/internal/execwrap/execwrap_test.go
+++ b/internal/execwrap/execwrap_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -15,6 +16,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
 )
 
 const (
@@ -82,13 +85,16 @@ func TestRunInjectsEnvOnlyIntoChildAndRecordsMetadata(t *testing.T) {
 	var stdout bytes.Buffer
 	audit := &memoryAudit{}
 	result, err := Run(context.Background(), Spec{
-		Path:          os.Args[0],
-		Args:          []string{"-test.run=TestExecHelperProcess", "--", "check-env"},
-		Env:           helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
-		SecretAliases: []string{"AGENT_SECRET_CANARY"},
-		OverrideEnv:   true,
-		Stdout:        &stdout,
-		Audit:         audit,
+		Path:         os.Args[0],
+		PathIdentity: currentExecutableIdentity(t),
+		Args:         []string{"-test.run=TestExecHelperProcess", "--", "check-env"},
+		Env:          helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
+		SecretAliases: []string{
+			"AGENT_SECRET_CANARY",
+		},
+		OverrideEnv: true,
+		Stdout:      &stdout,
+		Audit:       audit,
 	}, nil)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -118,6 +124,7 @@ func TestRunPreservesMultilineSecretEnvValue(t *testing.T) {
 	var stdout bytes.Buffer
 	result, err := Run(context.Background(), Spec{
 		Path:          os.Args[0],
+		PathIdentity:  currentExecutableIdentity(t),
 		Args:          []string{"-test.run=TestExecHelperProcess", "--", "check-multiline-env"},
 		Env:           helperEnv("AGENT_SECRET_MULTILINE", syntheticMultilineText),
 		SecretAliases: []string{"AGENT_SECRET_MULTILINE"},
@@ -140,11 +147,12 @@ func TestRunForwardsStdinToChild(t *testing.T) {
 
 	var stdout bytes.Buffer
 	result, err := Run(context.Background(), Spec{
-		Path:   os.Args[0],
-		Args:   []string{"-test.run=TestExecHelperProcess", "--", "echo-stdin"},
-		Env:    helperEnv(),
-		Stdin:  strings.NewReader("script-from-stdin\n"),
-		Stdout: &stdout,
+		Path:         os.Args[0],
+		PathIdentity: currentExecutableIdentity(t),
+		Args:         []string{"-test.run=TestExecHelperProcess", "--", "echo-stdin"},
+		Env:          helperEnv(),
+		Stdin:        strings.NewReader("script-from-stdin\n"),
+		Stdout:       &stdout,
 	}, nil)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -161,9 +169,10 @@ func TestRunPreservesExitCode(t *testing.T) {
 	t.Parallel()
 
 	result, err := Run(context.Background(), Spec{
-		Path: os.Args[0],
-		Args: []string{"-test.run=TestExecHelperProcess", "--", "exit-42"},
-		Env:  helperEnv(),
+		Path:         os.Args[0],
+		PathIdentity: currentExecutableIdentity(t),
+		Args:         []string{"-test.run=TestExecHelperProcess", "--", "exit-42"},
+		Env:          helperEnv(),
 	}, nil)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -182,14 +191,59 @@ func TestRunRejectsMissingCommandPath(t *testing.T) {
 	}
 }
 
+func TestRunRejectsMissingExecutableIdentity(t *testing.T) {
+	t.Parallel()
+
+	_, err := Run(context.Background(), Spec{
+		Path: os.Args[0],
+		Args: []string{"-test.run=TestExecHelperProcess", "--", "check-env"},
+		Env:  helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
+	}, nil)
+	if !errors.Is(err, ErrExecutableChanged) {
+		t.Fatalf("Run error = %v, want %v", err, ErrExecutableChanged)
+	}
+}
+
+func TestRunRejectsExecutableReplacementBeforeSpawn(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool")
+	writeExecwrapExecutable(t, path, "echo original\n")
+	identity, err := fileidentity.Capture(path)
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	replacement := filepath.Join(dir, "replacement")
+	writeExecwrapExecutable(t, replacement, "echo attacker\n")
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatalf("replace executable: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	_, err = Run(context.Background(), Spec{
+		Path:         path,
+		PathIdentity: identity,
+		Env:          helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
+		Stdout:       &stdout,
+	}, nil)
+	if !errors.Is(err, ErrExecutableChanged) {
+		t.Fatalf("Run error = %v, want %v", err, ErrExecutableChanged)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("replacement executable appears to have run: stdout=%q", stdout.String())
+	}
+}
+
 func TestRunStopsBeforeSpawnWhenStartingAuditFails(t *testing.T) {
 	t.Parallel()
 
 	_, err := Run(context.Background(), Spec{
-		Path:  os.Args[0],
-		Args:  []string{"-test.run=TestExecHelperProcess", "--", "check-env"},
-		Env:   helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
-		Audit: failingAudit{failType: "command_starting"},
+		Path:         os.Args[0],
+		PathIdentity: currentExecutableIdentity(t),
+		Args:         []string{"-test.run=TestExecHelperProcess", "--", "check-env"},
+		Env:          helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
+		Audit:        failingAudit{failType: "command_starting"},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected command_starting audit failure")
@@ -200,10 +254,11 @@ func TestRunTerminatesChildWhenStartedAuditFails(t *testing.T) {
 	t.Parallel()
 
 	_, err := Run(context.Background(), Spec{
-		Path:  os.Args[0],
-		Args:  []string{"-test.run=TestExecHelperProcess", "--", "sleep-long"},
-		Env:   helperEnv(),
-		Audit: failingAudit{failType: "command_started"},
+		Path:         os.Args[0],
+		PathIdentity: currentExecutableIdentity(t),
+		Args:         []string{"-test.run=TestExecHelperProcess", "--", "sleep-long"},
+		Env:          helperEnv(),
+		Audit:        failingAudit{failType: "command_started"},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected command_started audit failure")
@@ -222,10 +277,11 @@ func TestRunForwardsInterruptToChild(t *testing.T) {
 	}()
 
 	result, err := Run(context.Background(), Spec{
-		Path:   os.Args[0],
-		Args:   []string{"-test.run=TestExecHelperProcess", "--", "wait-signal"},
-		Env:    helperEnv(),
-		Stdout: &stdout,
+		Path:         os.Args[0],
+		PathIdentity: currentExecutableIdentity(t),
+		Args:         []string{"-test.run=TestExecHelperProcess", "--", "wait-signal"},
+		Env:          helperEnv(),
+		Stdout:       &stdout,
 	}, interrupts)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -249,9 +305,10 @@ func TestRunTerminatesChildOnContextCancel(t *testing.T) {
 
 	started := time.Now()
 	result, err := Run(ctx, Spec{
-		Path: os.Args[0],
-		Args: []string{"-test.run=TestExecHelperProcess", "--", "sleep-long"},
-		Env:  helperEnv(),
+		Path:         os.Args[0],
+		PathIdentity: currentExecutableIdentity(t),
+		Args:         []string{"-test.run=TestExecHelperProcess", "--", "sleep-long"},
+		Env:          helperEnv(),
 	}, nil)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -359,4 +416,20 @@ func helperEnv(pairs ...string) map[string]string {
 		env[pairs[i]] = pairs[i+1]
 	}
 	return env
+}
+
+func currentExecutableIdentity(t *testing.T) fileidentity.Identity {
+	t.Helper()
+	identity, err := fileidentity.Capture(os.Args[0])
+	if err != nil {
+		t.Fatalf("capture current executable identity: %v", err)
+	}
+	return identity
+}
+
+func writeExecwrapExecutable(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil { //nolint:gosec // G306: exec wrapper identity tests need executable fixtures.
+		t.Fatalf("write executable: %v", err)
+	}
 }

--- a/internal/fileidentity/identity.go
+++ b/internal/fileidentity/identity.go
@@ -1,0 +1,55 @@
+package fileidentity
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+var (
+	ErrMismatch = errors.New("file identity mismatch")
+	ErrMissing  = errors.New("file identity missing")
+)
+
+type Identity struct {
+	Device             uint64
+	Inode              uint64
+	Mode               uint32
+	Size               int64
+	ModTimeUnixNano    int64
+	ChangeTimeUnixNano int64
+}
+
+func (i Identity) IsZero() bool {
+	return i == Identity{}
+}
+
+func Capture(path string) (Identity, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Identity{}, fmt.Errorf("stat executable identity %q: %w", path, err)
+	}
+	identity := Identity{
+		Mode:            uint32(info.Mode().Perm()),
+		Size:            info.Size(),
+		ModTimeUnixNano: info.ModTime().UnixNano(),
+	}
+	if err := addPlatformIdentity(&identity, info); err != nil {
+		return Identity{}, err
+	}
+	return identity, nil
+}
+
+func Verify(path string, expected Identity) error {
+	if expected.IsZero() {
+		return ErrMissing
+	}
+	actual, err := Capture(path)
+	if err != nil {
+		return err
+	}
+	if actual != expected {
+		return fmt.Errorf("%w: executable %q changed after approval", ErrMismatch, path)
+	}
+	return nil
+}

--- a/internal/fileidentity/identity_darwin.go
+++ b/internal/fileidentity/identity_darwin.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package fileidentity
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func addPlatformIdentity(identity *Identity, info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("%w: executable stat metadata unavailable", ErrMissing)
+	}
+	if stat.Dev < 0 {
+		return fmt.Errorf("%w: executable device id is negative", ErrMissing)
+	}
+	identity.Device = uint64(stat.Dev)
+	identity.Inode = stat.Ino
+	identity.ChangeTimeUnixNano = stat.Ctimespec.Sec*1_000_000_000 + stat.Ctimespec.Nsec
+	return nil
+}

--- a/internal/fileidentity/identity_other.go
+++ b/internal/fileidentity/identity_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package fileidentity
+
+import "os"
+
+func addPlatformIdentity(_ *Identity, _ os.FileInfo) error {
+	return nil
+}

--- a/internal/fileidentity/identity_test.go
+++ b/internal/fileidentity/identity_test.go
@@ -1,0 +1,77 @@
+package fileidentity
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVerifyDetectsExecutableReplacement(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecutable(t, path, "echo original\n")
+	identity, err := Capture(path)
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	replacement := filepath.Join(t.TempDir(), "replacement")
+	writeExecutable(t, replacement, "echo replacement\n")
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatalf("replace executable: %v", err)
+	}
+
+	err = Verify(path, identity)
+	if !errors.Is(err, ErrMismatch) {
+		t.Fatalf("Verify error = %v, want %v", err, ErrMismatch)
+	}
+}
+
+func TestVerifyAcceptsUnchangedExecutable(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecutable(t, path, "exit 0\n")
+	identity, err := Capture(path)
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	if identity.IsZero() {
+		t.Fatal("Capture returned zero identity")
+	}
+
+	if err := Verify(path, identity); err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+}
+
+func TestVerifyRejectsMissingIdentity(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecutable(t, path, "exit 0\n")
+	err := Verify(path, Identity{})
+	if !errors.Is(err, ErrMissing) {
+		t.Fatalf("Verify error = %v, want %v", err, ErrMissing)
+	}
+}
+
+func TestCaptureReportsStatFailure(t *testing.T) {
+	t.Parallel()
+
+	_, err := Capture(filepath.Join(t.TempDir(), "missing-tool"))
+	if err == nil {
+		t.Fatal("expected missing executable error")
+	}
+}
+
+func writeExecutable(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir executable dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil { //nolint:gosec // G306: file identity tests need executable fixtures.
+		t.Fatalf("write executable: %v", err)
+	}
+}

--- a/internal/fileidentity/identity_unix.go
+++ b/internal/fileidentity/identity_unix.go
@@ -1,0 +1,19 @@
+//go:build unix && !darwin
+
+package fileidentity
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func addPlatformIdentity(identity *Identity, info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("%w: executable stat metadata unavailable", ErrMissing)
+	}
+	identity.Device = uint64(stat.Dev)
+	identity.Inode = stat.Ino
+	return nil
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
 	"github.com/kovyrin/agent-secret/internal/request"
 	"github.com/kovyrin/agent-secret/internal/secretmem"
 )
@@ -58,6 +59,7 @@ type ReuseKey struct {
 	Reason             string
 	Command            []string
 	ResolvedExecutable string
+	ExecutableIdentity fileidentity.Identity
 	CWD                string
 	Secrets            []SecretGrant
 	DeliveryMode       request.DeliveryMode
@@ -335,6 +337,7 @@ func NewReuseKey(req request.ExecRequest) ReuseKey {
 		Reason:             req.Reason,
 		Command:            slices.Clone(req.Command),
 		ResolvedExecutable: req.ResolvedExecutable,
+		ExecutableIdentity: req.ExecutableIdentity,
 		CWD:                req.CWD,
 		Secrets:            secrets,
 		DeliveryMode:       req.DeliveryMode,
@@ -348,6 +351,7 @@ func (k ReuseKey) Equal(other ReuseKey) bool {
 	return k.Reason == other.Reason &&
 		slices.Equal(k.Command, other.Command) &&
 		k.ResolvedExecutable == other.ResolvedExecutable &&
+		k.ExecutableIdentity == other.ExecutableIdentity &&
 		k.CWD == other.CWD &&
 		slices.Equal(k.Secrets, other.Secrets) &&
 		k.DeliveryMode == other.DeliveryMode &&

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
 
@@ -76,6 +77,7 @@ func TestReusableApprovalMissesOnPolicyChanges(t *testing.T) {
 		{name: "reason", mutate: func(r *request.ExecRequest) { r.Reason = "different" }},
 		{name: "command shape", mutate: func(r *request.ExecRequest) { r.Command = append(r.Command, "-refresh=false") }},
 		{name: "resolved executable", mutate: func(r *request.ExecRequest) { r.ResolvedExecutable = "/different/tool" }},
+		{name: "executable identity", mutate: func(r *request.ExecRequest) { r.ExecutableIdentity.Inode++ }},
 		{name: "cwd", mutate: func(r *request.ExecRequest) { r.CWD = "/tmp/other" }},
 		{name: "ref", mutate: func(r *request.ExecRequest) { r.Secrets[0].Ref.Raw = "op://Example Vault/Other/token" }},
 		{name: "account", mutate: func(r *request.ExecRequest) { r.Secrets[0].Account = "Fixture" }},
@@ -541,6 +543,7 @@ func testRequest(t *testing.T, now time.Time) request.ExecRequest {
 		Reason:             "Run Terraform plan",
 		Command:            []string{"terraform", "plan"},
 		ResolvedExecutable: "/opt/homebrew/bin/terraform",
+		ExecutableIdentity: fileidentity.Identity{Device: 1, Inode: 1, Mode: 0o755},
 		CWD:                "/tmp/project",
 		Secrets:            []request.Secret{{Alias: "TOKEN", Ref: ref}},
 		TTL:                2 * time.Minute,

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
 )
 
 const (
@@ -76,6 +78,7 @@ type ExecRequest struct {
 	Reason             string
 	Command            []string
 	ResolvedExecutable string
+	ExecutableIdentity fileidentity.Identity
 	CWD                string
 	Env                []string `json:"-"`
 	Secrets            []Secret
@@ -121,6 +124,9 @@ func (r ExecRequest) ValidateForDaemon() error {
 	}
 	if err := validateDaemonPath("resolved executable", r.ResolvedExecutable, true); err != nil {
 		return err
+	}
+	if r.ExecutableIdentity.IsZero() {
+		return fmt.Errorf("%w: executable identity is required", ErrInvalidRequest)
 	}
 	if len(r.Command) == 0 || r.Command[0] == "" {
 		return fmt.Errorf("%w: argv is required", ErrInvalidCommand)
@@ -176,6 +182,10 @@ func NewExec(opts ExecOptions) (ExecRequest, error) {
 	if err != nil {
 		return ExecRequest{}, err
 	}
+	executableIdentity, err := fileidentity.Capture(resolved)
+	if err != nil {
+		return ExecRequest{}, fmt.Errorf("%w: capture executable identity: %w", ErrInvalidCommand, err)
+	}
 
 	secrets, err := parseSecrets(opts.Secrets)
 	if err != nil {
@@ -191,6 +201,7 @@ func NewExec(opts ExecOptions) (ExecRequest, error) {
 		Reason:             reason,
 		Command:            command,
 		ResolvedExecutable: resolved,
+		ExecutableIdentity: executableIdentity,
 		CWD:                cwd,
 		Env:                env,
 		Secrets:            secrets,

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
 )
 
 func TestNewExecValidatesAndNormalizesRequest(t *testing.T) {
@@ -46,6 +48,9 @@ func TestNewExecValidatesAndNormalizesRequest(t *testing.T) {
 	}
 	if req.ResolvedExecutable != bin {
 		t.Fatalf("resolved executable = %q, want %q", req.ResolvedExecutable, bin)
+	}
+	if req.ExecutableIdentity.IsZero() {
+		t.Fatal("executable identity was not captured")
 	}
 	if len(req.Secrets) != 2 || req.Secrets[0].Ref.Raw != req.Secrets[1].Ref.Raw {
 		t.Fatalf("duplicate refs with different aliases should be preserved: %+v", req.Secrets)
@@ -205,6 +210,7 @@ func TestExecRequestValidateForDaemonRejectsFabricatedMetadata(t *testing.T) {
 		{name: "expiration mismatch", mutate: func(r *ExecRequest) { r.ExpiresAt = r.ExpiresAt.Add(time.Second) }, want: ErrInvalidTTL},
 		{name: "relative cwd", mutate: func(r *ExecRequest) { r.CWD = "project" }, want: ErrInvalidRequest},
 		{name: "relative resolved executable", mutate: func(r *ExecRequest) { r.ResolvedExecutable = "tool" }, want: ErrInvalidRequest},
+		{name: "missing executable identity", mutate: func(r *ExecRequest) { r.ExecutableIdentity = fileidentity.Identity{} }, want: ErrInvalidRequest},
 		{name: "missing command", mutate: func(r *ExecRequest) { r.Command = nil }, want: ErrInvalidCommand},
 		{name: "session socket delivery", mutate: func(r *ExecRequest) {
 			r.DeliveryMode = DeliverySessionSocket


### PR DESCRIPTION
## Summary
- capture executable file identity when building an exec request and require that identity in daemon request validation
- include executable identity in reusable approval cache keys so path-equivalent replacements miss the cache
- verify the captured identity in execwrap immediately before cmd.Start and refuse to spawn if the executable was replaced
- add file identity and execwrap regression tests that replace a temporary executable before spawn and confirm no child runs with secret env

## Verification
- mise exec -- go test ./internal/fileidentity ./internal/request ./internal/execwrap ./internal/cli ./internal/daemon
- mise exec -- go test ./...
- mise run lint
- mise run build
- mise run test:smoke

Closes #90