### PR TITLE
ASR-020: Gate tag releases on production signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,17 +90,23 @@ jobs:
       - name: Install project dependencies
         run: mise run setup
 
+      - name: Verify release signing configuration
+        env:
+          AGENT_SECRET_CODESIGN_CERT_P12_BASE64: ${{ secrets.AGENT_SECRET_CODESIGN_CERT_P12_BASE64 }}
+          AGENT_SECRET_CODESIGN_CERT_PASSWORD: ${{ secrets.AGENT_SECRET_CODESIGN_CERT_PASSWORD }}
+          AGENT_SECRET_CODESIGN_IDENTITY: ${{ secrets.AGENT_SECRET_CODESIGN_IDENTITY }}
+          AGENT_SECRET_NOTARIZE: ${{ secrets.AGENT_SECRET_NOTARIZE }}
+          AGENT_SECRET_NOTARY_ISSUER_ID: ${{ secrets.AGENT_SECRET_NOTARY_ISSUER_ID }}
+          AGENT_SECRET_NOTARY_KEY: ${{ secrets.AGENT_SECRET_NOTARY_KEY }}
+          AGENT_SECRET_NOTARY_KEY_ID: ${{ secrets.AGENT_SECRET_NOTARY_KEY_ID }}
+        run: scripts/check-release-signing-env.sh
+
       - name: Import Developer ID certificate
         env:
           AGENT_SECRET_CODESIGN_CERT_P12_BASE64: ${{ secrets.AGENT_SECRET_CODESIGN_CERT_P12_BASE64 }}
           AGENT_SECRET_CODESIGN_CERT_PASSWORD: ${{ secrets.AGENT_SECRET_CODESIGN_CERT_PASSWORD }}
           AGENT_SECRET_CODESIGN_KEYCHAIN_PATH: ${{ runner.temp }}/agent-secret-codesign.keychain-db
-        run: |
-          if [ -n "$AGENT_SECRET_CODESIGN_CERT_P12_BASE64" ]; then
-            scripts/import-codesign-certificate.sh
-          else
-            echo "No Developer ID certificate secret configured; skipping keychain import."
-          fi
+        run: scripts/import-codesign-certificate.sh
 
       - name: Build release artifacts
         env:
@@ -110,7 +116,7 @@ jobs:
           AGENT_SECRET_NOTARY_ISSUER_ID: ${{ secrets.AGENT_SECRET_NOTARY_ISSUER_ID }}
           AGENT_SECRET_NOTARY_KEY: ${{ secrets.AGENT_SECRET_NOTARY_KEY }}
           AGENT_SECRET_NOTARY_KEY_ID: ${{ secrets.AGENT_SECRET_NOTARY_KEY_ID }}
-        run: scripts/build-release.sh "$GITHUB_REF_NAME"
+        run: scripts/build-release.sh "$GITHUB_REF_NAME" --require-production-signing
 
       - name: Verify release artifact architecture
         run: |

--- a/mise.toml
+++ b/mise.toml
@@ -77,6 +77,7 @@ run = "scripts/check-go-coverage.sh"
 description = "Run non-secret smoke tests"
 run = """
 AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh
 cd approver && swift run agent-secret-approver-smoke
 """

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -9,14 +9,16 @@ Usage:
 Build a local macOS DMG release artifact and checksums.txt.
 
 Flags:
-  --output DIR   Output directory. Defaults to ./dist.
-  -h, --help     Show this help.
+  --output DIR                    Output directory. Defaults to ./dist.
+  --require-production-signing    Require Developer ID signing and notarization.
+  -h, --help                      Show this help.
 USAGE
 }
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 output_dir="$project_root/dist"
+require_production_signing=0
 codesign_identity="${AGENT_SECRET_CODESIGN_IDENTITY:-"-"}"
 notarize="${AGENT_SECRET_NOTARIZE:-0}"
 notary_key="${AGENT_SECRET_NOTARY_KEY:-}"
@@ -46,6 +48,10 @@ while [[ $# -gt 0 ]]; do
       output_dir="$2"
       shift 2
       ;;
+    --require-production-signing)
+      require_production_signing=1
+      shift
+      ;;
     -h | --help)
       usage
       exit 0
@@ -69,6 +75,38 @@ done
 if [[ "$version" == "" ]]; then
   echo "build-release: VERSION is required" >&2
   exit 2
+fi
+
+require_production_release_signing() {
+  local missing=0
+
+  if [[ "$codesign_identity" == "" || "$codesign_identity" == "-" ]]; then
+    echo "build-release: production release requires AGENT_SECRET_CODESIGN_IDENTITY" >&2
+    missing=1
+  fi
+  if [[ "$notarize" != "1" ]]; then
+    echo "build-release: production release requires AGENT_SECRET_NOTARIZE=1" >&2
+    missing=1
+  fi
+  if [[ "$notary_key" == "" ]]; then
+    echo "build-release: production release requires AGENT_SECRET_NOTARY_KEY" >&2
+    missing=1
+  fi
+  if [[ "$notary_key_id" == "" ]]; then
+    echo "build-release: production release requires AGENT_SECRET_NOTARY_KEY_ID" >&2
+    missing=1
+  fi
+  if [[ "$notary_issuer_id" == "" ]]; then
+    echo "build-release: production release requires AGENT_SECRET_NOTARY_ISSUER_ID" >&2
+    missing=1
+  fi
+  if [[ "$missing" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+if [[ "$require_production_signing" == "1" ]]; then
+  require_production_release_signing
 fi
 
 require_command() {

--- a/scripts/check-release-signing-env.sh
+++ b/scripts/check-release-signing-env.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=0
+
+require_env() {
+  local name="$1"
+
+  if [[ -z "${!name:-}" ]]; then
+    echo "release signing configuration: missing $name" >&2
+    missing=1
+  fi
+}
+
+require_env AGENT_SECRET_CODESIGN_CERT_P12_BASE64
+require_env AGENT_SECRET_CODESIGN_CERT_PASSWORD
+require_env AGENT_SECRET_CODESIGN_IDENTITY
+require_env AGENT_SECRET_NOTARIZE
+require_env AGENT_SECRET_NOTARY_KEY
+require_env AGENT_SECRET_NOTARY_KEY_ID
+require_env AGENT_SECRET_NOTARY_ISSUER_ID
+
+if [[ "$missing" -ne 0 ]]; then
+  exit 1
+fi
+
+if [[ "$AGENT_SECRET_NOTARIZE" != "1" ]]; then
+  echo "release signing configuration: AGENT_SECRET_NOTARIZE must be 1 for tag releases" >&2
+  exit 1
+fi

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd -- "$script_dir/.." && pwd)"
+check_script="$project_root/scripts/check-release-signing-env.sh"
+build_release="$project_root/scripts/build-release.sh"
+test_path="${PATH:-/usr/bin:/bin}"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-release-signing-test.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "test-release-signing-env: $*" >&2
+  exit 1
+}
+
+expect_failure() {
+  local want="$1"
+  shift
+
+  if "$@" >"$tmp_dir/stdout" 2>"$tmp_dir/stderr"; then
+    fail "expected failure containing $want"
+  fi
+  if ! grep -F "$want" "$tmp_dir/stderr" >/dev/null; then
+    fail "stderr did not contain $want: $(cat "$tmp_dir/stderr")"
+  fi
+}
+
+release_env=(
+  AGENT_SECRET_CODESIGN_CERT_P12_BASE64=dummy-p12
+  AGENT_SECRET_CODESIGN_CERT_PASSWORD=dummy-password
+  "AGENT_SECRET_CODESIGN_IDENTITY=Developer ID Application: Example (TEAMID)"
+  AGENT_SECRET_NOTARY_KEY=dummy-key
+  AGENT_SECRET_NOTARY_KEY_ID=dummy-key-id
+  AGENT_SECRET_NOTARY_ISSUER_ID=dummy-issuer-id
+)
+
+expect_failure "missing AGENT_SECRET_CODESIGN_CERT_P12_BASE64" \
+  env -i "PATH=$test_path" "$check_script"
+
+expect_failure "AGENT_SECRET_NOTARIZE must be 1" \
+  env -i "PATH=$test_path" "${release_env[@]}" AGENT_SECRET_NOTARIZE=0 "$check_script"
+
+env -i "PATH=$test_path" "${release_env[@]}" AGENT_SECRET_NOTARIZE=1 "$check_script"
+
+expect_failure "production release requires AGENT_SECRET_CODESIGN_IDENTITY" \
+  env -i "PATH=$test_path" AGENT_SECRET_IN_MISE=1 "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/out"
+
+echo "test-release-signing-env: ok"


### PR DESCRIPTION
## Summary
- add an explicit production signing gate to the release builder
- fail tag release jobs before artifact creation when Developer ID certificate/signing/notary inputs are missing or notarization is disabled
- make the tag workflow import the Developer ID cert unconditionally after preflight
- add a smoke test for missing release signing inputs and wire it into test:smoke

## Verification
- AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh
- mise run lint
- mise run build
- mise run test:smoke

Closes #91