### PR TITLE
ASR-021: Bind installer to Agent Secret identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,12 @@ AGENT_SECRET_SKILLS_DIR="$HOME/.agents/skills"
 ```
 
 The unattended installer verifies the DMG checksum, DMG code signature,
-Gatekeeper assessment, notarization ticket, and the mounted app bundle before
-copying anything into place. For local unsigned test artifacts only, set
-`AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`. For signed but intentionally
-unstapled local artifacts, set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`.
+Developer ID Team ID, Gatekeeper assessment, notarization ticket, mounted app
+bundle ID, daemon helper bundle ID, and bundled CLI signature before copying
+anything into place. Maintainer releases are expected to use Team ID
+`B6L7QLWTZW`. For local unsigned test artifacts only, set
+`AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`. For signed but intentionally unstapled
+local artifacts, set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`.
 
 Unattended uninstall:
 

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -93,8 +93,9 @@ The installer should:
 1. Detect `arm64` or `x86_64`.
 2. Resolve the latest release unless `AGENT_SECRET_VERSION` is set.
 3. Download the matching release artifact.
-4. Verify the checksum, DMG signature, Gatekeeper assessment, notarization
-   ticket, and mounted app bundle identity.
+4. Verify the checksum, DMG signature, Developer ID Team ID, Gatekeeper
+   assessment, notarization ticket, mounted app bundle ID, daemon helper bundle
+   ID, and bundled CLI signature.
 5. Stop the old per-user daemon if it is running.
 6. Copy `Agent Secret.app` to `/Applications` by default.
 7. Create or refresh the CLI symlink in `~/.local/bin`.
@@ -113,6 +114,8 @@ For local smoke tests, `AGENT_SECRET_DMG` and
 `AGENT_SECRET_CHECKSUMS_FILE` can point at a locally built artifact. Unsigned
 local artifacts must also set `AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`; signed
 but unstapled local artifacts can set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`.
+Maintainer release installs expect Team ID `B6L7QLWTZW` and bundle identifiers
+`com.kovyrin.agent-secret` and `com.kovyrin.agent-secret.daemon`.
 
 ### Upgrade
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -74,6 +74,8 @@ release target. Do not publish a release whose changelog section is empty.
    ```bash
    shasum -a 256 -c checksums.txt
    codesign --verify --strict --verbose=2 "$artifact"
+   codesign -dv --verbose=4 "$artifact" 2>&1 |
+     grep '^TeamIdentifier=B6L7QLWTZW$'
    xcrun stapler validate "$artifact"
    spctl --assess --type open \
      --context context:primary-signature \
@@ -86,11 +88,23 @@ release target. Do not publish a release whose changelog section is empty.
    ```bash
    hdiutil attach -readonly -nobrowse \
      -mountpoint "$mount_dir" "$artifact"
+   app="$mount_dir/Agent Secret.app"
+   daemon="$app/Contents/Library/Helpers/AgentSecretDaemon.app"
    codesign --verify --deep --strict \
-     --verbose=2 "$mount_dir/Agent Secret.app"
-   xcrun stapler validate "$mount_dir/Agent Secret.app"
+     --verbose=2 "$app"
+   codesign -dv --verbose=4 "$app" 2>&1 |
+     grep '^TeamIdentifier=B6L7QLWTZW$'
+   /usr/libexec/PlistBuddy \
+     -c 'Print :CFBundleIdentifier' \
+     "$app/Contents/Info.plist" |
+     grep '^com.kovyrin.agent-secret$'
+   /usr/libexec/PlistBuddy \
+     -c 'Print :CFBundleIdentifier' \
+     "$daemon/Contents/Info.plist" |
+     grep '^com.kovyrin.agent-secret.daemon$'
+   xcrun stapler validate "$app"
    spctl --assess --type execute \
-     --verbose "$mount_dir/Agent Secret.app"
+     --verbose "$app"
    hdiutil detach "$mount_dir"
    ```
 

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,9 @@ local_checksums="${AGENT_SECRET_CHECKSUMS_FILE:-}"
 no_stop_daemon="${AGENT_SECRET_NO_STOP_DAEMON:-0}"
 allow_unsigned_install="${AGENT_SECRET_ALLOW_UNSIGNED_INSTALL:-0}"
 require_notarization="${AGENT_SECRET_REQUIRE_NOTARIZATION:-1}"
+expected_team_id="${AGENT_SECRET_EXPECTED_TEAM_ID:-B6L7QLWTZW}"
+expected_app_bundle_id="${AGENT_SECRET_EXPECTED_APP_BUNDLE_ID:-com.kovyrin.agent-secret}"
+expected_daemon_bundle_id="${AGENT_SECRET_EXPECTED_DAEMON_BUNDLE_ID:-com.kovyrin.agent-secret.daemon}"
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-install.XXXXXX")"
 mount_dir="$tmp_dir/mount"
@@ -95,6 +98,7 @@ verify_dmg_identity() {
 
   codesign --verify --strict --verbose=2 "$dmg" ||
     die "DMG code signature verification failed"
+  verify_team_id "$dmg" "DMG"
   spctl --assess --type open --context context:primary-signature --verbose "$dmg" ||
     die "DMG Gatekeeper assessment failed"
   if [ "$require_notarization" = "1" ]; then
@@ -103,8 +107,54 @@ verify_dmg_identity() {
   fi
 }
 
+codesign_team_id() {
+  path="$1"
+  details="$(codesign -dv --verbose=4 "$path" 2>&1)" ||
+    die "could not read code signature details for $path"
+  printf '%s\n' "$details" |
+    awk -F= '$1 == "TeamIdentifier" { print $2; found = 1; exit } END { if (!found) exit 1 }' ||
+    die "code signature for $path does not include a TeamIdentifier"
+}
+
+verify_team_id() {
+  path="$1"
+  label="$2"
+  team_id="$(codesign_team_id "$path")"
+  if [ "$team_id" != "$expected_team_id" ]; then
+    die "$label signed by unexpected Team ID: $team_id"
+  fi
+}
+
+plist_value() {
+  plist="$1"
+  key="$2"
+  /usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2>/dev/null ||
+    die "could not read $key from $plist"
+}
+
+verify_bundle_identifier() {
+  bundle="$1"
+  expected="$2"
+  label="$3"
+  plist="$bundle/Contents/Info.plist"
+
+  [ -f "$plist" ] || die "$label is missing Contents/Info.plist"
+  got="$(plist_value "$plist" CFBundleIdentifier)"
+  if [ "$got" != "$expected" ]; then
+    die "$label has unexpected bundle identifier: $got"
+  fi
+}
+
 verify_app_identity() {
   app="$1"
+  daemon_app="$app/Contents/Library/Helpers/AgentSecretDaemon.app"
+  cli="$app/Contents/Resources/bin/agent-secret"
+
+  require_command /usr/libexec/PlistBuddy
+  verify_bundle_identifier "$app" "$expected_app_bundle_id" "Agent Secret.app"
+  [ -d "$daemon_app" ] || die "Agent Secret.app is missing the daemon helper app"
+  verify_bundle_identifier "$daemon_app" "$expected_daemon_bundle_id" "AgentSecretDaemon.app"
+  [ -x "$cli" ] || die "Agent Secret.app is missing the bundled agent-secret CLI"
 
   if [ "$allow_unsigned_install" = "1" ]; then
     return
@@ -112,6 +162,9 @@ verify_app_identity() {
 
   codesign --verify --deep --strict --verbose=2 "$app" ||
     die "app code signature verification failed"
+  verify_team_id "$app" "Agent Secret.app"
+  verify_team_id "$daemon_app" "AgentSecretDaemon.app"
+  verify_team_id "$cli" "bundled agent-secret CLI"
   spctl --assess --type execute --verbose "$app" ||
     die "app Gatekeeper assessment failed"
   if [ "$require_notarization" = "1" ]; then

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -27,6 +27,35 @@ for arg in "$@"; do
   printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
 done
 printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+
+team_id_for_path() {
+  case "$1" in
+    *.dmg)
+      printf '%s\n' "${AGENT_SECRET_INSTALL_TEST_DMG_TEAM_ID:-${AGENT_SECRET_INSTALL_TEST_CODESIGN_TEAM_ID:-B6L7QLWTZW}}"
+      ;;
+    *AgentSecretDaemon.app)
+      printf '%s\n' "${AGENT_SECRET_INSTALL_TEST_DAEMON_TEAM_ID:-${AGENT_SECRET_INSTALL_TEST_CODESIGN_TEAM_ID:-B6L7QLWTZW}}"
+      ;;
+    */Contents/Resources/bin/agent-secret)
+      printf '%s\n' "${AGENT_SECRET_INSTALL_TEST_CLI_TEAM_ID:-${AGENT_SECRET_INSTALL_TEST_CODESIGN_TEAM_ID:-B6L7QLWTZW}}"
+      ;;
+    *)
+      printf '%s\n' "${AGENT_SECRET_INSTALL_TEST_APP_TEAM_ID:-${AGENT_SECRET_INSTALL_TEST_CODESIGN_TEAM_ID:-B6L7QLWTZW}}"
+      ;;
+  esac
+}
+
+for arg in "$@"; do
+  if [ "$arg" = "-dv" ]; then
+    last=""
+    for value in "$@"; do
+      last="$value"
+    done
+    printf 'TeamIdentifier=%s\n' "$(team_id_for_path "$last")" >&2
+    break
+  fi
+done
+
 exit "${AGENT_SECRET_INSTALL_TEST_CODESIGN_STATUS:-0}"
 SCRIPT
 
@@ -52,6 +81,7 @@ SCRIPT
 
   cat >"$fake_bin/ditto" <<'SCRIPT'
 #!/bin/sh
+printf 'ditto %s %s\n' "$1" "$2" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
 cp -R "$1" "$2"
 SCRIPT
 
@@ -72,7 +102,30 @@ if [ "$1" = "attach" ]; then
     exit 64
   fi
   cli="$mount_dir/Agent Secret.app/Contents/Resources/bin/agent-secret"
+  daemon_app="$mount_dir/Agent Secret.app/Contents/Library/Helpers/AgentSecretDaemon.app"
   mkdir -p "$(dirname "$cli")"
+  mkdir -p "$daemon_app/Contents/MacOS"
+  cat >"$mount_dir/Agent Secret.app/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>${AGENT_SECRET_INSTALL_TEST_APP_BUNDLE_ID:-com.kovyrin.agent-secret}</string>
+</dict>
+</plist>
+PLIST
+  cat >"$daemon_app/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>${AGENT_SECRET_INSTALL_TEST_DAEMON_BUNDLE_ID:-com.kovyrin.agent-secret.daemon}</string>
+</dict>
+</plist>
+PLIST
+  touch "$daemon_app/Contents/MacOS/Agent Secret"
   cat >"$cli" <<'APP'
 #!/bin/sh
 case "$1" in
@@ -177,9 +230,11 @@ test_identity_checks_run() {
   log="$tmp_dir/signed/tools.log"
 
   assert_log_contains "$log" "codesign --verify --strict --verbose=2"
+  assert_log_contains "$log" "codesign -dv --verbose=4"
   assert_log_contains "$log" "spctl --assess --type open --context context:primary-signature --verbose"
   assert_log_contains "$log" "xcrun stapler validate"
   assert_log_contains "$log" "codesign --verify --deep --strict --verbose=2"
+  assert_log_contains "$log" "codesign -dv --verbose=4"
   assert_log_contains "$log" "spctl --assess --type execute --verbose"
 }
 
@@ -190,6 +245,33 @@ test_identity_failure_stops_install() {
   assert_log_contains "$tmp_dir/unsigned-fail/tools.log" "codesign --verify --strict --verbose=2"
 }
 
+test_wrong_team_id_stops_install() {
+  if run_installer wrong-team AGENT_SECRET_INSTALL_TEST_CODESIGN_TEAM_ID=BADTEAM123; then
+    fail "installer succeeded with the wrong Developer ID Team ID"
+  fi
+  assert_log_contains "$tmp_dir/wrong-team/tools.log" "codesign -dv --verbose=4"
+}
+
+test_wrong_app_bundle_id_stops_install() {
+  if run_installer wrong-app-bundle \
+    AGENT_SECRET_INSTALL_TEST_APP_BUNDLE_ID=com.example.not-agent-secret; then
+    fail "installer succeeded with the wrong app bundle identifier"
+  fi
+  if grep -F "ditto " "$tmp_dir/wrong-app-bundle/tools.log" >/dev/null; then
+    fail "installer copied an app with the wrong bundle identifier"
+  fi
+}
+
+test_wrong_daemon_bundle_id_stops_install() {
+  if run_installer wrong-daemon-bundle \
+    AGENT_SECRET_INSTALL_TEST_DAEMON_BUNDLE_ID=com.example.not-agent-secret.daemon; then
+    fail "installer succeeded with the wrong daemon bundle identifier"
+  fi
+  if grep -F "ditto " "$tmp_dir/wrong-daemon-bundle/tools.log" >/dev/null; then
+    fail "installer copied an app with the wrong daemon bundle identifier"
+  fi
+}
+
 test_unsigned_override_skips_identity_checks() {
   run_installer unsigned-allowed \
     AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1 \
@@ -198,7 +280,7 @@ test_unsigned_override_skips_identity_checks() {
     AGENT_SECRET_INSTALL_TEST_XCRUN_STATUS=23
 
   log="$tmp_dir/unsigned-allowed/tools.log"
-  if [ -s "$log" ]; then
+  if grep -E '^(codesign|spctl|xcrun) ' "$log" >/dev/null; then
     echo "---- tool log ----" >&2
     cat "$log" >&2
     fail "unsigned override should not call identity verification tools"
@@ -207,6 +289,9 @@ test_unsigned_override_skips_identity_checks() {
 
 test_identity_checks_run
 test_identity_failure_stops_install
+test_wrong_team_id_stops_install
+test_wrong_app_bundle_id_stops_install
+test_wrong_daemon_bundle_id_stops_install
 test_unsigned_override_skips_identity_checks
 
 echo "test-install: ok"


### PR DESCRIPTION
## Summary

- require the installer to verify the expected Developer ID Team ID on the DMG, app bundle, daemon helper, and bundled CLI
- verify mounted app and daemon bundle identifiers before copying anything into place
- extend installer smoke tests with wrong Team ID and wrong bundle ID rejection cases
- update install and release docs to describe the stricter identity boundary

Closes #96

## Verification

- `AGENT_SECRET_IN_MISE=1 scripts/test-install.sh`
- `mise run lint:shell`
- `mise run test:smoke`
- `npx --yes markdownlint-cli README.md docs/macos-distribution-plan.md docs/release-process.md`
- `mise run lint`
- `mise run build`