### PR TITLE
ASR-022: Reject mutable executables before secret exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ Current `exec` flags:
   environment variables.
 - `--force-refresh`: for reusable approvals, refetch approved refs before
   delivery.
+- `--allow-mutable-executable`: permit a command whose executable file or
+  parent directory is writable by the current user. Without this explicit
+  opt-in, `exec` rejects project-local and temp executables that can be swapped
+  after approval.
 
 The command to run must appear after `--` as argv. `agent-secret exec` has no
 `--json` mode and does not parse shell strings.

--- a/approver/Sources/AgentSecretApprover/ApprovalRequest.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequest.swift
@@ -7,6 +7,7 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
         case cwd
         case expiresAt
         case nonce
+        case allowMutableExecutable
         case overrideEnv
         case overriddenAliases
         case reason
@@ -37,6 +38,8 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
     public var secrets: [RequestedSecret]
     /// Whether approved values will replace existing environment variables.
     public var overrideEnv: Bool
+    /// Whether the caller explicitly allowed a mutable executable path.
+    public var allowMutableExecutable: Bool
     /// Existing environment aliases that will be replaced.
     public var overriddenAliases: [String]
     /// Maximum command launches covered by a reusable approval.
@@ -53,6 +56,7 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
         secrets: [RequestedSecret],
         resolvedExecutable: String? = nil,
         overrideEnv: Bool = false,
+        allowMutableExecutable: Bool = false,
         overriddenAliases: [String] = [],
         reusableUses: Int = Self.defaultReusableUses
     ) {
@@ -65,6 +69,7 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
         self.expiresAt = expiresAt
         self.secrets = secrets
         self.overrideEnv = overrideEnv
+        self.allowMutableExecutable = allowMutableExecutable
         self.overriddenAliases = overriddenAliases
         self.reusableUses = reusableUses
     }
@@ -81,6 +86,7 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
         expiresAt = try container.decode(Date.self, forKey: .expiresAt)
         secrets = try container.decode([RequestedSecret].self, forKey: .secrets)
         overrideEnv = try container.decodeIfPresent(Bool.self, forKey: .overrideEnv) ?? false
+        allowMutableExecutable = try container.decodeIfPresent(Bool.self, forKey: .allowMutableExecutable) ?? false
         overriddenAliases = try container.decodeIfPresent([String].self, forKey: .overriddenAliases) ?? []
         reusableUses = try container.decodeIfPresent(Int.self, forKey: .reusableUses) ?? Self.defaultReusableUses
     }

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
@@ -167,6 +167,9 @@ import Foundation
                     if let overrideWarning: String = viewModel.overrideWarning {
                         ApprovalPanelDetailLine(label: "Overrides", value: overrideWarning)
                     }
+                    if let mutableExecutableWarning: String = viewModel.mutableExecutableWarning {
+                        ApprovalPanelDetailLine(label: "Executable", value: mutableExecutableWarning)
+                    }
                     ApprovalPanelDetailLine(label: "Reusable approval", value: reusableDetail)
                 }
                 .padding(.top, Metric.detailTopPadding)

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
@@ -21,6 +21,7 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         let secretRows: [String]
         let timeRemaining: String
         let overrideWarning: String?
+        let mutableExecutableWarning: String?
     }
 
     private static let highScopeSecretThreshold: Int = 6
@@ -79,6 +80,8 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
     public let printsEnvironmentWarning: Bool
     /// Environment override warning when applicable.
     public let overrideWarning: String?
+    /// Mutable executable opt-in warning when applicable.
+    public let mutableExecutableWarning: String?
     /// Footer copy with correct singular/plural wording.
     public let footerMessage: String
     /// Full sanitized prompt body for AppKit alerts.
@@ -116,6 +119,7 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         allowReusableTitle = Self.reuseTitle(uses: reusableUseLimit, remaining: remainingText, expired: isExpired)
         printsEnvironmentWarning = Self.environmentWarning(for: request)
         overrideWarning = Self.overrideWarning(for: request)
+        mutableExecutableWarning = Self.mutableExecutableWarning(for: request)
         footerMessage = Self.footerMessage(secretCount: secretPresentation.count, expired: isExpired)
         renderedText = Self.renderedText(
             for: request,
@@ -129,7 +133,8 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
                 resolvedExecutable: resolvedExecutable,
                 secretRows: secretRows,
                 timeRemaining: timeRemaining,
-                overrideWarning: overrideWarning
+                overrideWarning: overrideWarning,
+                mutableExecutableWarning: mutableExecutableWarning
             )
         )
     }
@@ -202,6 +207,9 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         if let overrideWarning: String = viewModel.overrideWarning {
             lines.append(overrideWarning)
         }
+        if let mutableExecutableWarning: String = viewModel.mutableExecutableWarning {
+            lines.append(mutableExecutableWarning)
+        }
         return lines.joined(separator: "\n")
     }
 
@@ -210,6 +218,13 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
             return nil
         }
         return "Will replace existing variables: \(request.overriddenAliases.joined(separator: ", "))"
+    }
+
+    private static func mutableExecutableWarning(for request: ApprovalRequest) -> String? {
+        guard request.allowMutableExecutable else {
+            return nil
+        }
+        return "Mutable executable opt-in: command path may be replaceable before launch."
     }
 
     private static func commandArguments(_ command: [String]) -> [CommandArgumentViewModel] {

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
@@ -154,6 +154,7 @@ final class ApprovalControllerTests: XCTestCase {
     func testViewModelContainsApprovalContextWithoutSecretValuesOrDebugIdentifiers() {
         var request: ApprovalRequest = Self.sampleRequest
         request.overrideEnv = true
+        request.allowMutableExecutable = true
         request.overriddenAliases = ["EXAMPLE_TOKEN"]
         let viewModel = ApprovalRequestViewModel(
             request: request,
@@ -170,6 +171,7 @@ final class ApprovalControllerTests: XCTestCase {
         XCTAssertTrue(viewModel.renderedText.contains("Resolved binary: /opt/homebrew/bin/terraform"))
         XCTAssertTrue(viewModel.renderedText.contains("Time remaining: 2 minutes"))
         XCTAssertTrue(viewModel.renderedText.contains("Will replace existing variables: EXAMPLE_TOKEN"))
+        XCTAssertTrue(viewModel.renderedText.contains("Mutable executable opt-in"))
         XCTAssertEqual(viewModel.executable, "terraform")
         XCTAssertEqual(viewModel.promptQuestion, "Allow this command to use the following secret?")
         XCTAssertEqual(viewModel.accessSummary, "wants temporary access.")

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1002,7 +1002,8 @@ Status: Not started
 
 - Risk: public distribution needs stronger binary identity than private dogfood.
 - Mitigation: defer signing/notarization and installation-integrity guidance to
-  the release path; v1 does not police local execution paths.
+  the release path; `exec` rejects current-user-writable executable paths unless
+  the caller explicitly opts into mutable local executable launch.
 
 ### Epic 7 Tasks
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -47,29 +47,30 @@ type SecretRef struct {
 }
 
 type Event struct {
-	Timestamp          time.Time            `json:"timestamp"`
-	Type               EventType            `json:"type"`
-	RequestID          string               `json:"request_id,omitempty"`
-	ApprovalID         string               `json:"approval_id,omitempty"`
-	SessionID          string               `json:"session_id,omitempty"`
-	Reason             string               `json:"reason,omitempty"`
-	Command            []string             `json:"command,omitempty"`
-	ResolvedExecutable string               `json:"resolved_executable,omitempty"`
-	CWD                string               `json:"cwd,omitempty"`
-	DeliveryMode       request.DeliveryMode `json:"delivery_mode,omitempty"`
-	SecretRefs         []SecretRef          `json:"secret_refs,omitempty"`
-	ChildPID           *int                 `json:"child_pid,omitempty"`
-	ExitCode           *int                 `json:"exit_code,omitempty"`
-	Signal             string               `json:"signal,omitempty"`
-	ErrorCode          string               `json:"error_code,omitempty"`
-	RequesterPID       *int                 `json:"requester_pid,omitempty"`
-	RequesterUID       *int                 `json:"requester_uid,omitempty"`
-	RequesterPath      string               `json:"requester_path,omitempty"`
-	RemainingTTLMillis *int64               `json:"remaining_ttl_ms,omitempty"`
-	RemainingUses      *int                 `json:"remaining_uses,omitempty"`
-	ForceRefresh       bool                 `json:"force_refresh,omitempty"`
-	OverrideEnv        bool                 `json:"override_env,omitempty"`
-	OverriddenAliases  []string             `json:"overridden_aliases,omitempty"`
+	Timestamp              time.Time            `json:"timestamp"`
+	Type                   EventType            `json:"type"`
+	RequestID              string               `json:"request_id,omitempty"`
+	ApprovalID             string               `json:"approval_id,omitempty"`
+	SessionID              string               `json:"session_id,omitempty"`
+	Reason                 string               `json:"reason,omitempty"`
+	Command                []string             `json:"command,omitempty"`
+	ResolvedExecutable     string               `json:"resolved_executable,omitempty"`
+	CWD                    string               `json:"cwd,omitempty"`
+	DeliveryMode           request.DeliveryMode `json:"delivery_mode,omitempty"`
+	SecretRefs             []SecretRef          `json:"secret_refs,omitempty"`
+	ChildPID               *int                 `json:"child_pid,omitempty"`
+	ExitCode               *int                 `json:"exit_code,omitempty"`
+	Signal                 string               `json:"signal,omitempty"`
+	ErrorCode              string               `json:"error_code,omitempty"`
+	RequesterPID           *int                 `json:"requester_pid,omitempty"`
+	RequesterUID           *int                 `json:"requester_uid,omitempty"`
+	RequesterPath          string               `json:"requester_path,omitempty"`
+	RemainingTTLMillis     *int64               `json:"remaining_ttl_ms,omitempty"`
+	RemainingUses          *int                 `json:"remaining_uses,omitempty"`
+	ForceRefresh           bool                 `json:"force_refresh,omitempty"`
+	OverrideEnv            bool                 `json:"override_env,omitempty"`
+	OverriddenAliases      []string             `json:"overridden_aliases,omitempty"`
+	AllowMutableExecutable bool                 `json:"allow_mutable_executable,omitempty"`
 }
 
 type Writer struct {
@@ -96,17 +97,18 @@ func OpenDefault(now func() time.Time) (*Writer, error) {
 
 func FromExecRequest(eventType EventType, requestID string, req request.ExecRequest) Event {
 	return Event{
-		Type:               eventType,
-		RequestID:          requestID,
-		Reason:             req.Reason,
-		Command:            slices.Clone(req.Command),
-		ResolvedExecutable: req.ResolvedExecutable,
-		CWD:                req.CWD,
-		DeliveryMode:       req.DeliveryMode,
-		SecretRefs:         secretRefs(req.Secrets),
-		ForceRefresh:       req.ForceRefresh,
-		OverrideEnv:        req.OverrideEnv,
-		OverriddenAliases:  slices.Clone(req.OverriddenAliases),
+		Type:                   eventType,
+		RequestID:              requestID,
+		Reason:                 req.Reason,
+		Command:                slices.Clone(req.Command),
+		ResolvedExecutable:     req.ResolvedExecutable,
+		CWD:                    req.CWD,
+		DeliveryMode:           req.DeliveryMode,
+		SecretRefs:             secretRefs(req.Secrets),
+		ForceRefresh:           req.ForceRefresh,
+		OverrideEnv:            req.OverrideEnv,
+		OverriddenAliases:      slices.Clone(req.OverriddenAliases),
+		AllowMutableExecutable: req.AllowMutableExecutable,
 	}
 }
 

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -163,6 +163,7 @@ func TestFromExecRequestUsesValidatedTrimmedReason(t *testing.T) {
 		Secrets: []request.SecretSpec{
 			{Alias: "TOKEN", Ref: "op://Example Vault/Item/token"},
 		},
+		AllowMutableExecutable: true,
 	})
 	if err != nil {
 		t.Fatalf("NewExec returned error: %v", err)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -126,17 +126,18 @@ func (a App) runExec(ctx context.Context, command Command) int {
 		stderr:    a.Stderr,
 	}
 	result, err := execwrap.Run(ctx, execwrap.Spec{
-		Path:          command.ExecRequest.ResolvedExecutable,
-		PathIdentity:  command.ExecRequest.ExecutableIdentity,
-		Args:          command.ExecRequest.Command[1:],
-		Dir:           command.ExecRequest.CWD,
-		BaseEnv:       command.ExecRequest.Env,
-		Env:           payload.Env,
-		SecretAliases: payload.SecretAliases,
-		OverrideEnv:   command.ExecRequest.OverrideEnv,
-		Stdout:        a.Stdout,
-		Stderr:        a.Stderr,
-		Audit:         reporter,
+		Path:                   command.ExecRequest.ResolvedExecutable,
+		PathIdentity:           command.ExecRequest.ExecutableIdentity,
+		Args:                   command.ExecRequest.Command[1:],
+		Dir:                    command.ExecRequest.CWD,
+		BaseEnv:                command.ExecRequest.Env,
+		Env:                    payload.Env,
+		SecretAliases:          payload.SecretAliases,
+		OverrideEnv:            command.ExecRequest.OverrideEnv,
+		AllowMutableExecutable: command.ExecRequest.AllowMutableExecutable,
+		Stdout:                 a.Stdout,
+		Stderr:                 a.Stderr,
+		Audit:                  reporter,
 	}, interrupts)
 	if err != nil {
 		a.stderrf("agent-secret: %v\n", err)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -40,6 +40,7 @@ func TestAppExecRunsChildWithApprovedEnvAndPassthrough(t *testing.T) {
 		"exec",
 		"--reason", "Run helper",
 		"--secret", "TOKEN=" + ref,
+		"--allow-mutable-executable",
 		"--",
 		os.Args[0], "-test.run=TestAppExecRunsChildWithApprovedEnvAndPassthrough", "--", "child",
 	})
@@ -85,6 +86,7 @@ func TestAppExecRunsChildWithEnvFileSecretsAndPlainEnv(t *testing.T) {
 		"exec",
 		"--reason", "Run helper",
 		"--env-file", envFilePath,
+		"--allow-mutable-executable",
 		"--",
 		os.Args[0], "-test.run=TestAppExecRunsChildWithEnvFileSecretsAndPlainEnv", "--", "child",
 	})
@@ -117,6 +119,7 @@ func TestAppExecStopsBeforeSpawnOnApprovalDenial(t *testing.T) {
 		"exec",
 		"--reason", "Run helper",
 		"--secret", "TOKEN=op://Example/Item/token",
+		"--allow-mutable-executable",
 		"--",
 		os.Args[0], "-test.run=TestAppExecStopsBeforeSpawnOnApprovalDenial", "--", "child",
 	})
@@ -301,6 +304,7 @@ func TestAppExecReportsDaemonStartFailureBeforeSpawn(t *testing.T) {
 		"exec",
 		"--reason", "Run helper",
 		"--secret", "TOKEN=op://Example/Item/token",
+		"--allow-mutable-executable",
 		"--",
 		os.Args[0], "-test.run=TestAppExecReportsDaemonStartFailureBeforeSpawn", "--", "child",
 	})
@@ -335,6 +339,7 @@ func TestAppExecReportsRandomIDFailureBeforeRequest(t *testing.T) {
 		"exec",
 		"--reason", "Run helper",
 		"--secret", "TOKEN=" + ref,
+		"--allow-mutable-executable",
 		"--",
 		os.Args[0], "-test.run=TestAppExecReportsRandomIDFailureBeforeRequest", "--", "child",
 	})

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -136,6 +136,7 @@ Safety rules:
   - ALIAS must look like an environment variable name, for example API_TOKEN.
   - By default, the daemon uses the personal 1Password sign-in address my.1password.com. Set AGENT_SECRET_1PASSWORD_ACCOUNT only to override it.
   - The wrapped command must appear after -- as argv. agent-secret does not parse shell strings.
+  - Commands from current-user-writable files or directories are rejected unless --allow-mutable-executable is set.
   - exec has no --json mode and never prints secret values.
   - Text file/document refs such as op://Example/GitHub App/key.pem are injected as env values; binary attachments are not supported.
   - agent-secret skill-install links the bundled Agent Secret skill into ~/.agents/skills/agent-secret.
@@ -174,6 +175,8 @@ Flags:
   --ttl DURATION      Approval TTL. Defaults to profile ttl or 2m. Allowed range: 10s through 10m.
   --override-env      Allow approved aliases to replace existing child environment variables.
   --force-refresh     For matching reusable approvals, refetch approved refs before delivery.
+  --allow-mutable-executable
+                      Permit a project or temp executable that can be replaced by the current user.
   -h, --help          Show this help.
 
 Project profiles:
@@ -292,6 +295,7 @@ func (p Parser) parseExec(args []string) (Command, error) {
 	account := fs.String("account", "", "1Password account")
 	overrideEnv := fs.Bool("override-env", false, "override existing env aliases")
 	forceRefresh := fs.Bool("force-refresh", false, "refresh reusable approval values")
+	allowMutableExecutable := fs.Bool("allow-mutable-executable", false, "allow mutable executable path")
 	jsonOutput := fs.Bool("json", false, "unsupported")
 	reuse := fs.Bool("reuse", false, "unsupported")
 	fs.Var(&secrets, "secret", "secret mapping")
@@ -355,16 +359,17 @@ func (p Parser) parseExec(args []string) (Command, error) {
 	}
 
 	req, err := request.NewExec(request.ExecOptions{
-		Reason:       effectiveReason,
-		Command:      command,
-		CWD:          *cwd,
-		Env:          childEnv,
-		Secrets:      effectiveSecrets,
-		TTL:          effectiveTTL,
-		ReceivedAt:   p.now(),
-		DeliveryMode: request.DeliveryEnvExec,
-		OverrideEnv:  *overrideEnv,
-		ForceRefresh: *forceRefresh,
+		Reason:                 effectiveReason,
+		Command:                command,
+		CWD:                    *cwd,
+		Env:                    childEnv,
+		Secrets:                effectiveSecrets,
+		TTL:                    effectiveTTL,
+		ReceivedAt:             p.now(),
+		DeliveryMode:           request.DeliveryEnvExec,
+		OverrideEnv:            *overrideEnv,
+		ForceRefresh:           *forceRefresh,
+		AllowMutableExecutable: *allowMutableExecutable,
 	})
 	if err != nil {
 		return Command{}, fmt.Errorf("build exec request: %w", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -25,6 +25,7 @@ func TestParseExecBuildsValidatedRequest(t *testing.T) {
 		"--ttl", "90s",
 		"--secret", "TOKEN=op://Example Vault/Cloudflare/token",
 		"--force-refresh",
+		"--allow-mutable-executable",
 		"--",
 		"terraform", "plan",
 	})
@@ -35,7 +36,7 @@ func TestParseExecBuildsValidatedRequest(t *testing.T) {
 		t.Fatalf("kind = %s, want exec", command.Kind)
 	}
 	req := command.ExecRequest
-	if req.Reason != "Terraform plan" || req.TTL != 90*time.Second || !req.ForceRefresh {
+	if req.Reason != "Terraform plan" || req.TTL != 90*time.Second || !req.ForceRefresh || !req.AllowMutableExecutable {
 		t.Fatalf("unexpected request policy: %+v", req)
 	}
 	if req.Command[0] != "terraform" || req.ResolvedExecutable == "" {
@@ -75,6 +76,7 @@ profiles:
 	command, err := parser.Parse([]string{
 		"exec",
 		"--profile", "terraform-cloudflare",
+		"--allow-mutable-executable",
 		"--",
 		"terraform", "plan",
 	})
@@ -128,6 +130,7 @@ profiles:
 		"--profile", "ansible",
 		"--only", "B_TOKEN,A_TOKEN",
 		"--secret", "EXTRA_TOKEN=op://Example/Extra/token",
+		"--allow-mutable-executable",
 		"--",
 		"ansible-playbook", "site.yml",
 	})
@@ -179,6 +182,7 @@ NEXT=op://Example/Next/token
 		"--reason", "Env file command",
 		"--env-file", firstEnv,
 		"--env-file", secondEnv,
+		"--allow-mutable-executable",
 		"--",
 		"tool",
 	})
@@ -235,6 +239,7 @@ profiles:
 		"exec",
 		"--reason", "Plain env file",
 		"--env-file", envPath,
+		"--allow-mutable-executable",
 		"--",
 		"tool",
 	})
@@ -266,6 +271,7 @@ PLAIN=kept
 		"--reason", "Env file command",
 		"--env-file", envPath,
 		"--only", "BETA_TOKEN",
+		"--allow-mutable-executable",
 		"--",
 		"tool",
 	})
@@ -318,6 +324,7 @@ PLAIN=kept
 		"--env-file", envPath,
 		"--only", "PROFILE_KEEP,FILE_KEEP",
 		"--secret", "EXPLICIT_TOKEN=op://Example/Explicit/token",
+		"--allow-mutable-executable",
 		"--",
 		"tool",
 	})
@@ -361,6 +368,7 @@ func TestParseExecAccountAppliesToExplicitAndEnvFileSecrets(t *testing.T) {
 		"--account", "fixture.1password.com",
 		"--secret", "EXPLICIT_TOKEN=op://Example/Explicit/token",
 		"--env-file", envPath,
+		"--allow-mutable-executable",
 		"--",
 		"tool",
 	})
@@ -409,6 +417,7 @@ profiles:
 		"--account", "CLI Account",
 		"--env-file", envPath,
 		"--secret", "EXPLICIT_TOKEN=op://Example/Explicit/token",
+		"--allow-mutable-executable",
 		"--",
 		"tool",
 	})
@@ -456,6 +465,7 @@ profiles:
 		"exec",
 		"--profile", "deploy",
 		"--account", "fixture.1password.com",
+		"--allow-mutable-executable",
 		"--",
 		"tool",
 	})
@@ -496,6 +506,7 @@ profiles:
 		"--profile", "deploy",
 		"--account", "CLI Account",
 		"--env-file", envPath,
+		"--allow-mutable-executable",
 		"--",
 		"tool",
 	})
@@ -557,6 +568,24 @@ profiles:
 	}
 }
 
+func TestParseExecRejectsMutableExecutableWithoutOptIn(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "tool")
+	t.Setenv("PATH", dir)
+	parser := NewParser(func() time.Time { return time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC) })
+
+	_, err := parser.Parse([]string{
+		"exec",
+		"--reason", "reason",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--",
+		"tool",
+	})
+	if !errors.Is(err, request.ErrMutableExecutable) {
+		t.Fatalf("Parse error = %v, want %v", err, request.ErrMutableExecutable)
+	}
+}
+
 func TestParseExecBuildsRequestFromDefaultProfile(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
@@ -581,6 +610,7 @@ profiles:
 
 	command, err := parser.Parse([]string{
 		"exec",
+		"--allow-mutable-executable",
 		"--",
 		"terraform", "plan",
 	})
@@ -627,6 +657,7 @@ profiles:
 	command, err := parser.Parse([]string{
 		"exec",
 		"--config", configPath,
+		"--allow-mutable-executable",
 		"--",
 		"terraform", "plan",
 	})
@@ -668,6 +699,7 @@ profiles:
 		"exec",
 		"--reason", "Explicit only",
 		"--secret", "TOKEN=op://Example/Item/token",
+		"--allow-mutable-executable",
 		"--",
 		"tool",
 	})
@@ -711,6 +743,7 @@ profiles:
 		"--reason", "CLI reason",
 		"--ttl", "90s",
 		"--secret", "CADDY_TOKEN=op://Example/Caddy/token",
+		"--allow-mutable-executable",
 		"--",
 		"ansible-playbook", "site.yml",
 	})

--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -26,17 +26,18 @@ var (
 )
 
 type ApprovalRequestPayload struct {
-	RequestID          string                    `json:"requestID"`
-	Nonce              string                    `json:"nonce"`
-	Reason             string                    `json:"reason"`
-	Command            []string                  `json:"command"`
-	CWD                string                    `json:"cwd"`
-	ResolvedExecutable string                    `json:"resolvedExecutable,omitempty"`
-	ExpiresAt          time.Time                 `json:"expiresAt"`
-	Secrets            []ApprovalRequestedSecret `json:"secrets"`
-	OverrideEnv        bool                      `json:"overrideEnv"`
-	OverriddenAliases  []string                  `json:"overriddenAliases,omitempty"`
-	ReusableUses       int                       `json:"reusableUses"`
+	RequestID              string                    `json:"requestID"`
+	Nonce                  string                    `json:"nonce"`
+	Reason                 string                    `json:"reason"`
+	Command                []string                  `json:"command"`
+	CWD                    string                    `json:"cwd"`
+	ResolvedExecutable     string                    `json:"resolvedExecutable,omitempty"`
+	ExpiresAt              time.Time                 `json:"expiresAt"`
+	Secrets                []ApprovalRequestedSecret `json:"secrets"`
+	OverrideEnv            bool                      `json:"overrideEnv"`
+	OverriddenAliases      []string                  `json:"overriddenAliases,omitempty"`
+	AllowMutableExecutable bool                      `json:"allowMutableExecutable,omitempty"`
+	ReusableUses           int                       `json:"reusableUses"`
 }
 
 type ApprovalRequestedSecret struct {
@@ -322,17 +323,18 @@ func approvalPayload(requestID string, nonce string, req request.ExecRequest) Ap
 		})
 	}
 	return ApprovalRequestPayload{
-		RequestID:          requestID,
-		Nonce:              nonce,
-		Reason:             req.Reason,
-		Command:            slices.Clone(req.Command),
-		CWD:                req.CWD,
-		ResolvedExecutable: req.ResolvedExecutable,
-		ExpiresAt:          req.ExpiresAt,
-		Secrets:            secrets,
-		OverrideEnv:        req.OverrideEnv,
-		OverriddenAliases:  slices.Clone(req.OverriddenAliases),
-		ReusableUses:       3,
+		RequestID:              requestID,
+		Nonce:                  nonce,
+		Reason:                 req.Reason,
+		Command:                slices.Clone(req.Command),
+		CWD:                    req.CWD,
+		ResolvedExecutable:     req.ResolvedExecutable,
+		ExpiresAt:              req.ExpiresAt,
+		Secrets:                secrets,
+		OverrideEnv:            req.OverrideEnv,
+		OverriddenAliases:      slices.Clone(req.OverriddenAliases),
+		AllowMutableExecutable: req.AllowMutableExecutable,
+		ReusableUses:           3,
 	}
 }
 

--- a/internal/execwrap/execwrap.go
+++ b/internal/execwrap/execwrap.go
@@ -17,6 +17,7 @@ import (
 
 var ErrEnvironmentConflict = errors.New("approved alias already exists in parent environment")
 var ErrExecutableChanged = errors.New("approved executable changed before spawn")
+var ErrMutableExecutable = errors.New("mutable executable requires explicit opt-in")
 
 const terminateGracePeriod = 2 * time.Second
 
@@ -35,18 +36,19 @@ type AuditEvent struct {
 }
 
 type Spec struct {
-	Path          string
-	PathIdentity  fileidentity.Identity
-	Args          []string
-	Dir           string
-	BaseEnv       []string
-	Env           map[string]string
-	SecretAliases []string
-	OverrideEnv   bool
-	Stdin         io.Reader
-	Stdout        io.Writer
-	Stderr        io.Writer
-	Audit         AuditSink
+	Path                   string
+	PathIdentity           fileidentity.Identity
+	Args                   []string
+	Dir                    string
+	BaseEnv                []string
+	Env                    map[string]string
+	SecretAliases          []string
+	OverrideEnv            bool
+	AllowMutableExecutable bool
+	Stdin                  io.Reader
+	Stdout                 io.Writer
+	Stderr                 io.Writer
+	Audit                  AuditSink
 }
 
 type Result struct {
@@ -60,6 +62,11 @@ func Run(ctx context.Context, spec Spec, interrupts <-chan os.Signal) (Result, e
 	}
 	if err := fileidentity.Verify(spec.Path, spec.PathIdentity); err != nil {
 		return Result{}, fmt.Errorf("%w: %w", ErrExecutableChanged, err)
+	}
+	if !spec.AllowMutableExecutable {
+		if err := fileidentity.ValidateStableExecutable(spec.Path); err != nil {
+			return Result{}, fmt.Errorf("%w: %w", ErrMutableExecutable, err)
+		}
 	}
 
 	baseEnv := spec.BaseEnv

--- a/internal/execwrap/execwrap_test.go
+++ b/internal/execwrap/execwrap_test.go
@@ -85,10 +85,11 @@ func TestRunInjectsEnvOnlyIntoChildAndRecordsMetadata(t *testing.T) {
 	var stdout bytes.Buffer
 	audit := &memoryAudit{}
 	result, err := Run(context.Background(), Spec{
-		Path:         os.Args[0],
-		PathIdentity: currentExecutableIdentity(t),
-		Args:         []string{"-test.run=TestExecHelperProcess", "--", "check-env"},
-		Env:          helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
+		Path:                   os.Args[0],
+		PathIdentity:           currentExecutableIdentity(t),
+		AllowMutableExecutable: true,
+		Args:                   []string{"-test.run=TestExecHelperProcess", "--", "check-env"},
+		Env:                    helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
 		SecretAliases: []string{
 			"AGENT_SECRET_CANARY",
 		},
@@ -123,13 +124,14 @@ func TestRunPreservesMultilineSecretEnvValue(t *testing.T) {
 
 	var stdout bytes.Buffer
 	result, err := Run(context.Background(), Spec{
-		Path:          os.Args[0],
-		PathIdentity:  currentExecutableIdentity(t),
-		Args:          []string{"-test.run=TestExecHelperProcess", "--", "check-multiline-env"},
-		Env:           helperEnv("AGENT_SECRET_MULTILINE", syntheticMultilineText),
-		SecretAliases: []string{"AGENT_SECRET_MULTILINE"},
-		OverrideEnv:   true,
-		Stdout:        &stdout,
+		Path:                   os.Args[0],
+		PathIdentity:           currentExecutableIdentity(t),
+		AllowMutableExecutable: true,
+		Args:                   []string{"-test.run=TestExecHelperProcess", "--", "check-multiline-env"},
+		Env:                    helperEnv("AGENT_SECRET_MULTILINE", syntheticMultilineText),
+		SecretAliases:          []string{"AGENT_SECRET_MULTILINE"},
+		OverrideEnv:            true,
+		Stdout:                 &stdout,
 	}, nil)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -147,12 +149,13 @@ func TestRunForwardsStdinToChild(t *testing.T) {
 
 	var stdout bytes.Buffer
 	result, err := Run(context.Background(), Spec{
-		Path:         os.Args[0],
-		PathIdentity: currentExecutableIdentity(t),
-		Args:         []string{"-test.run=TestExecHelperProcess", "--", "echo-stdin"},
-		Env:          helperEnv(),
-		Stdin:        strings.NewReader("script-from-stdin\n"),
-		Stdout:       &stdout,
+		Path:                   os.Args[0],
+		PathIdentity:           currentExecutableIdentity(t),
+		AllowMutableExecutable: true,
+		Args:                   []string{"-test.run=TestExecHelperProcess", "--", "echo-stdin"},
+		Env:                    helperEnv(),
+		Stdin:                  strings.NewReader("script-from-stdin\n"),
+		Stdout:                 &stdout,
 	}, nil)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -169,10 +172,11 @@ func TestRunPreservesExitCode(t *testing.T) {
 	t.Parallel()
 
 	result, err := Run(context.Background(), Spec{
-		Path:         os.Args[0],
-		PathIdentity: currentExecutableIdentity(t),
-		Args:         []string{"-test.run=TestExecHelperProcess", "--", "exit-42"},
-		Env:          helperEnv(),
+		Path:                   os.Args[0],
+		PathIdentity:           currentExecutableIdentity(t),
+		AllowMutableExecutable: true,
+		Args:                   []string{"-test.run=TestExecHelperProcess", "--", "exit-42"},
+		Env:                    helperEnv(),
 	}, nil)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -235,15 +239,41 @@ func TestRunRejectsExecutableReplacementBeforeSpawn(t *testing.T) {
 	}
 }
 
+func TestRunRejectsMutableExecutableWithoutOptIn(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecwrapExecutable(t, path, "echo should-not-run\n")
+	identity, err := fileidentity.Capture(path)
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	_, err = Run(context.Background(), Spec{
+		Path:         path,
+		PathIdentity: identity,
+		Env:          helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
+		Stdout:       &stdout,
+	}, nil)
+	if !errors.Is(err, ErrMutableExecutable) {
+		t.Fatalf("Run error = %v, want %v", err, ErrMutableExecutable)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("mutable executable appears to have run: stdout=%q", stdout.String())
+	}
+}
+
 func TestRunStopsBeforeSpawnWhenStartingAuditFails(t *testing.T) {
 	t.Parallel()
 
 	_, err := Run(context.Background(), Spec{
-		Path:         os.Args[0],
-		PathIdentity: currentExecutableIdentity(t),
-		Args:         []string{"-test.run=TestExecHelperProcess", "--", "check-env"},
-		Env:          helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
-		Audit:        failingAudit{failType: "command_starting"},
+		Path:                   os.Args[0],
+		PathIdentity:           currentExecutableIdentity(t),
+		AllowMutableExecutable: true,
+		Args:                   []string{"-test.run=TestExecHelperProcess", "--", "check-env"},
+		Env:                    helperEnv("AGENT_SECRET_CANARY", syntheticSecret),
+		Audit:                  failingAudit{failType: "command_starting"},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected command_starting audit failure")
@@ -254,11 +284,12 @@ func TestRunTerminatesChildWhenStartedAuditFails(t *testing.T) {
 	t.Parallel()
 
 	_, err := Run(context.Background(), Spec{
-		Path:         os.Args[0],
-		PathIdentity: currentExecutableIdentity(t),
-		Args:         []string{"-test.run=TestExecHelperProcess", "--", "sleep-long"},
-		Env:          helperEnv(),
-		Audit:        failingAudit{failType: "command_started"},
+		Path:                   os.Args[0],
+		PathIdentity:           currentExecutableIdentity(t),
+		AllowMutableExecutable: true,
+		Args:                   []string{"-test.run=TestExecHelperProcess", "--", "sleep-long"},
+		Env:                    helperEnv(),
+		Audit:                  failingAudit{failType: "command_started"},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected command_started audit failure")
@@ -277,11 +308,12 @@ func TestRunForwardsInterruptToChild(t *testing.T) {
 	}()
 
 	result, err := Run(context.Background(), Spec{
-		Path:         os.Args[0],
-		PathIdentity: currentExecutableIdentity(t),
-		Args:         []string{"-test.run=TestExecHelperProcess", "--", "wait-signal"},
-		Env:          helperEnv(),
-		Stdout:       &stdout,
+		Path:                   os.Args[0],
+		PathIdentity:           currentExecutableIdentity(t),
+		AllowMutableExecutable: true,
+		Args:                   []string{"-test.run=TestExecHelperProcess", "--", "wait-signal"},
+		Env:                    helperEnv(),
+		Stdout:                 &stdout,
 	}, interrupts)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
@@ -305,10 +337,11 @@ func TestRunTerminatesChildOnContextCancel(t *testing.T) {
 
 	started := time.Now()
 	result, err := Run(ctx, Spec{
-		Path:         os.Args[0],
-		PathIdentity: currentExecutableIdentity(t),
-		Args:         []string{"-test.run=TestExecHelperProcess", "--", "sleep-long"},
-		Env:          helperEnv(),
+		Path:                   os.Args[0],
+		PathIdentity:           currentExecutableIdentity(t),
+		AllowMutableExecutable: true,
+		Args:                   []string{"-test.run=TestExecHelperProcess", "--", "sleep-long"},
+		Env:                    helperEnv(),
 	}, nil)
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)

--- a/internal/fileidentity/identity_test.go
+++ b/internal/fileidentity/identity_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -63,6 +64,44 @@ func TestCaptureReportsStatFailure(t *testing.T) {
 	_, err := Capture(filepath.Join(t.TempDir(), "missing-tool"))
 	if err == nil {
 		t.Fatal("expected missing executable error")
+	}
+}
+
+func TestValidateStableExecutableRejectsCurrentUserWritableFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecutable(t, path, "exit 0\n")
+
+	err := ValidateStableExecutable(path)
+	if !errors.Is(err, ErrMutable) {
+		t.Fatalf("ValidateStableExecutable error = %v, want %v", err, ErrMutable)
+	}
+}
+
+func TestValidateStableExecutableRejectsCurrentUserWritableParent(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecutable(t, path, "exit 0\n")
+	if err := os.Chmod(path, 0o555); err != nil { //nolint:gosec // G302: stability test needs executable permissions without owner write.
+		t.Fatalf("chmod executable: %v", err)
+	}
+
+	err := ValidateStableExecutable(path)
+	if !errors.Is(err, ErrMutable) {
+		t.Fatalf("ValidateStableExecutable error = %v, want %v", err, ErrMutable)
+	}
+}
+
+func TestValidateStableExecutableAcceptsSystemExecutable(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "darwin" {
+		t.Skip("system executable ownership expectation is macOS-specific")
+	}
+	if err := ValidateStableExecutable("/bin/sh"); err != nil {
+		t.Fatalf("ValidateStableExecutable returned error: %v", err)
 	}
 }
 

--- a/internal/fileidentity/stability_other.go
+++ b/internal/fileidentity/stability_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package fileidentity
+
+import "fmt"
+
+func ValidateStableExecutable(path string) error {
+	return fmt.Errorf("executable stability checks are unsupported on this platform: %s", path)
+}

--- a/internal/fileidentity/stability_unix.go
+++ b/internal/fileidentity/stability_unix.go
@@ -1,0 +1,78 @@
+//go:build unix
+
+package fileidentity
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"syscall"
+)
+
+var ErrMutable = errors.New("mutable executable identity")
+
+func ValidateStableExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat executable %q: %w", path, err)
+	}
+	if writableByCurrentUser(info, false) {
+		return fmt.Errorf("%w: executable %q is writable by the current user", ErrMutable, path)
+	}
+
+	for dir := filepath.Dir(path); ; dir = filepath.Dir(dir) {
+		info, err := os.Stat(dir)
+		if err != nil {
+			return fmt.Errorf("stat executable parent %q: %w", dir, err)
+		}
+		if writableByCurrentUser(info, true) {
+			return fmt.Errorf("%w: executable parent directory %q is writable by the current user", ErrMutable, dir)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil
+		}
+	}
+}
+
+func writableByCurrentUser(info os.FileInfo, requireSearch bool) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return true
+	}
+
+	mode := info.Mode().Perm()
+	uid := os.Getuid()
+	gids := currentGroups()
+
+	if int64(stat.Uid) == int64(uid) {
+		return modeAllowsWrite(mode, 0o200, 0o100, requireSearch)
+	}
+	if slices.ContainsFunc(gids, func(gid int) bool { return int64(stat.Gid) == int64(gid) }) {
+		return modeAllowsWrite(mode, 0o020, 0o010, requireSearch)
+	}
+	return modeAllowsWrite(mode, 0o002, 0o001, requireSearch)
+}
+
+func currentGroups() []int {
+	groups, err := os.Getgroups()
+	if err != nil {
+		return nil
+	}
+	out := make([]int, 0, len(groups))
+	for _, group := range groups {
+		if group >= 0 {
+			out = append(out, group)
+		}
+	}
+	return out
+}
+
+func modeAllowsWrite(mode os.FileMode, write os.FileMode, search os.FileMode, requireSearch bool) bool {
+	if mode&write == 0 {
+		return false
+	}
+	return !requireSearch || mode&search != 0
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -56,16 +56,17 @@ type ReusableApproval struct {
 }
 
 type ReuseKey struct {
-	Reason             string
-	Command            []string
-	ResolvedExecutable string
-	ExecutableIdentity fileidentity.Identity
-	CWD                string
-	Secrets            []SecretGrant
-	DeliveryMode       request.DeliveryMode
-	TTL                time.Duration
-	OverrideEnv        bool
-	OverriddenAliases  []string
+	Reason                 string
+	Command                []string
+	ResolvedExecutable     string
+	ExecutableIdentity     fileidentity.Identity
+	CWD                    string
+	Secrets                []SecretGrant
+	DeliveryMode           request.DeliveryMode
+	TTL                    time.Duration
+	OverrideEnv            bool
+	OverriddenAliases      []string
+	AllowMutableExecutable bool
 }
 
 type SecretGrant struct {
@@ -334,16 +335,17 @@ func NewReuseKey(req request.ExecRequest) ReuseKey {
 	slices.Sort(overridden)
 
 	return ReuseKey{
-		Reason:             req.Reason,
-		Command:            slices.Clone(req.Command),
-		ResolvedExecutable: req.ResolvedExecutable,
-		ExecutableIdentity: req.ExecutableIdentity,
-		CWD:                req.CWD,
-		Secrets:            secrets,
-		DeliveryMode:       req.DeliveryMode,
-		TTL:                req.TTL,
-		OverrideEnv:        req.OverrideEnv,
-		OverriddenAliases:  overridden,
+		Reason:                 req.Reason,
+		Command:                slices.Clone(req.Command),
+		ResolvedExecutable:     req.ResolvedExecutable,
+		ExecutableIdentity:     req.ExecutableIdentity,
+		CWD:                    req.CWD,
+		Secrets:                secrets,
+		DeliveryMode:           req.DeliveryMode,
+		TTL:                    req.TTL,
+		OverrideEnv:            req.OverrideEnv,
+		OverriddenAliases:      overridden,
+		AllowMutableExecutable: req.AllowMutableExecutable,
 	}
 }
 
@@ -357,6 +359,7 @@ func (k ReuseKey) Equal(other ReuseKey) bool {
 		k.DeliveryMode == other.DeliveryMode &&
 		k.TTL == other.TTL &&
 		k.OverrideEnv == other.OverrideEnv &&
+		k.AllowMutableExecutable == other.AllowMutableExecutable &&
 		slices.Equal(k.OverriddenAliases, other.OverriddenAliases)
 }
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -84,6 +84,7 @@ func TestReusableApprovalMissesOnPolicyChanges(t *testing.T) {
 		{name: "delivery mode", mutate: func(r *request.ExecRequest) { r.DeliveryMode = request.DeliverySessionSocket }},
 		{name: "override", mutate: func(r *request.ExecRequest) { r.OverrideEnv = true }},
 		{name: "overridden alias", mutate: func(r *request.ExecRequest) { r.OverriddenAliases = []string{"TOKEN"} }},
+		{name: "mutable executable opt-in", mutate: func(r *request.ExecRequest) { r.AllowMutableExecutable = true }},
 		{name: "ttl", mutate: func(r *request.ExecRequest) { r.TTL = 5 * time.Minute }},
 	}
 

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -25,6 +25,7 @@ var (
 	ErrInvalidCommand      = errors.New("invalid command")
 	ErrInvalidDeliveryMode = errors.New("invalid delivery mode")
 	ErrInvalidMaxReads     = errors.New("invalid max reads")
+	ErrMutableExecutable   = errors.New("mutable executable requires explicit opt-in")
 	ErrInvalidReason       = errors.New("invalid reason")
 	ErrInvalidReference    = errors.New("invalid 1Password secret reference")
 	ErrInvalidRequest      = errors.New("invalid exec request")
@@ -61,35 +62,37 @@ type Secret struct {
 }
 
 type ExecOptions struct {
-	Reason       string
-	Command      []string
-	CWD          string
-	Env          []string
-	Secrets      []SecretSpec
-	TTL          time.Duration
-	ReceivedAt   time.Time
-	DeliveryMode DeliveryMode
-	MaxReads     int
-	OverrideEnv  bool
-	ForceRefresh bool
+	Reason                 string
+	Command                []string
+	CWD                    string
+	Env                    []string
+	Secrets                []SecretSpec
+	TTL                    time.Duration
+	ReceivedAt             time.Time
+	DeliveryMode           DeliveryMode
+	MaxReads               int
+	OverrideEnv            bool
+	ForceRefresh           bool
+	AllowMutableExecutable bool
 }
 
 type ExecRequest struct {
-	Reason             string
-	Command            []string
-	ResolvedExecutable string
-	ExecutableIdentity fileidentity.Identity
-	CWD                string
-	Env                []string `json:"-"`
-	Secrets            []Secret
-	TTL                time.Duration
-	ReceivedAt         time.Time
-	ExpiresAt          time.Time
-	DeliveryMode       DeliveryMode
-	MaxReads           int
-	OverrideEnv        bool
-	OverriddenAliases  []string
-	ForceRefresh       bool
+	Reason                 string
+	Command                []string
+	ResolvedExecutable     string
+	ExecutableIdentity     fileidentity.Identity
+	CWD                    string
+	Env                    []string `json:"-"`
+	Secrets                []Secret
+	TTL                    time.Duration
+	ReceivedAt             time.Time
+	ExpiresAt              time.Time
+	DeliveryMode           DeliveryMode
+	MaxReads               int
+	OverrideEnv            bool
+	OverriddenAliases      []string
+	ForceRefresh           bool
+	AllowMutableExecutable bool
 }
 
 func (r ExecRequest) Expired(at time.Time) bool {
@@ -186,6 +189,11 @@ func NewExec(opts ExecOptions) (ExecRequest, error) {
 	if err != nil {
 		return ExecRequest{}, fmt.Errorf("%w: capture executable identity: %w", ErrInvalidCommand, err)
 	}
+	if !opts.AllowMutableExecutable {
+		if err := fileidentity.ValidateStableExecutable(resolved); err != nil {
+			return ExecRequest{}, fmt.Errorf("%w: %w", ErrMutableExecutable, err)
+		}
+	}
 
 	secrets, err := parseSecrets(opts.Secrets)
 	if err != nil {
@@ -198,21 +206,22 @@ func NewExec(opts ExecOptions) (ExecRequest, error) {
 	}
 
 	return ExecRequest{
-		Reason:             reason,
-		Command:            command,
-		ResolvedExecutable: resolved,
-		ExecutableIdentity: executableIdentity,
-		CWD:                cwd,
-		Env:                env,
-		Secrets:            secrets,
-		TTL:                ttl,
-		ReceivedAt:         receivedAt,
-		ExpiresAt:          receivedAt.Add(ttl),
-		DeliveryMode:       mode,
-		MaxReads:           opts.MaxReads,
-		OverrideEnv:        opts.OverrideEnv,
-		OverriddenAliases:  overriddenAliases,
-		ForceRefresh:       opts.ForceRefresh,
+		Reason:                 reason,
+		Command:                command,
+		ResolvedExecutable:     resolved,
+		ExecutableIdentity:     executableIdentity,
+		CWD:                    cwd,
+		Env:                    env,
+		Secrets:                secrets,
+		TTL:                    ttl,
+		ReceivedAt:             receivedAt,
+		ExpiresAt:              receivedAt.Add(ttl),
+		DeliveryMode:           mode,
+		MaxReads:               opts.MaxReads,
+		OverrideEnv:            opts.OverrideEnv,
+		OverriddenAliases:      overriddenAliases,
+		ForceRefresh:           opts.ForceRefresh,
+		AllowMutableExecutable: opts.AllowMutableExecutable,
 	}, nil
 }
 

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -29,6 +29,7 @@ func TestNewExecValidatesAndNormalizesRequest(t *testing.T) {
 			{Alias: "TOKEN", Ref: "op://Example Vault/Cloudflare/token", Account: " Fixture "},
 			{Alias: "TOKEN_COPY", Ref: "op://Example Vault/Cloudflare/token"},
 		},
+		AllowMutableExecutable: true,
 	})
 	if err != nil {
 		t.Fatalf("NewExec returned error: %v", err)
@@ -111,6 +112,35 @@ func TestNewExecRejectsInvalidInputs(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tt.want, err)
 			}
 		})
+	}
+}
+
+func TestNewExecRejectsMutableExecutableByDefault(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeExecutable(t, dir)
+
+	_, err := NewExec(mutate(baseOptions(dir, "reason"), func(o *ExecOptions) {
+		o.AllowMutableExecutable = false
+	}))
+	if !errors.Is(err, ErrMutableExecutable) {
+		t.Fatalf("NewExec error = %v, want %v", err, ErrMutableExecutable)
+	}
+}
+
+func TestNewExecAllowsMutableExecutableWithExplicitOptIn(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeExecutable(t, dir)
+
+	req, err := NewExec(baseOptions(dir, "reason"))
+	if err != nil {
+		t.Fatalf("NewExec returned error: %v", err)
+	}
+	if !req.AllowMutableExecutable {
+		t.Fatal("AllowMutableExecutable = false, want explicit opt-in recorded")
 	}
 }
 
@@ -285,6 +315,7 @@ func baseOptions(dir string, reason string) ExecOptions {
 		Secrets: []SecretSpec{
 			{Alias: "TOKEN", Ref: "op://Example Vault/Item/token"},
 		},
+		AllowMutableExecutable: true,
 	}
 }
 


### PR DESCRIPTION
## Summary

- add file identity stability checks for current-user-writable executables and parent directories
- reject mutable executable paths during request construction and immediately before child spawn unless explicitly opted in
- add `--allow-mutable-executable` to preserve an explicit local-development escape hatch and carry that context through audit, reuse keys, daemon approval payloads, and the native approval UI
- document the new exec contract

Closes #97

## Verification

- `mise exec -- go test ./internal/fileidentity ./internal/request ./internal/execwrap ./internal/cli`
- `cd approver && swift test`
- `mise run lint:go`
- `mise run lint:swift`
- `npx --yes markdownlint-cli README.md docs/implementation-plan.md`
- `mise run lint`
- `mise run test:smoke`
- `mise run build`