### PR TITLE
ASR-023: Authenticate daemon startup readiness

### DIFF
--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -37,8 +37,10 @@ func NewManager(socketPath string) (Manager, error) {
 }
 
 func (m Manager) EnsureRunning(ctx context.Context) error {
-	if _, err := m.Status(ctx); err == nil {
+	if err := m.statusBeforeStart(ctx); err == nil {
 		return nil
+	} else if !errors.Is(err, ErrDaemonUnavailable) {
+		return err
 	}
 	if err := m.Start(ctx); err != nil {
 		return err
@@ -47,8 +49,10 @@ func (m Manager) EnsureRunning(ctx context.Context) error {
 }
 
 func (m Manager) Start(ctx context.Context) error {
-	if _, err := m.Status(ctx); err == nil {
+	if err := m.statusBeforeStart(ctx); err == nil {
 		return nil
+	} else if !errors.Is(err, ErrDaemonUnavailable) {
+		return err
 	}
 	if m.DaemonPath == "" {
 		return errors.New("daemon path is required")
@@ -56,7 +60,9 @@ func (m Manager) Start(ctx context.Context) error {
 	if err := prepareSocketDirectory(m.SocketPath); err != nil {
 		return err
 	}
-	_ = cleanupStaleSocket(m.SocketPath)
+	if err := cleanupStaleSocket(m.SocketPath); err != nil {
+		return err
+	}
 
 	cmd := daemonStartCommand(ctx, m.DaemonPath, m.daemonArgs())
 	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
@@ -81,7 +87,7 @@ func (m Manager) Start(ctx context.Context) error {
 	}
 	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	if err := WaitUntilReady(readyCtx, m.SocketPath, 25*time.Millisecond); err != nil {
+	if err := m.waitUntilReady(readyCtx, 25*time.Millisecond); err != nil {
 		return fmt.Errorf("wait for agent-secretd readiness: %w", err)
 	}
 	return nil
@@ -119,6 +125,34 @@ func (m Manager) Stop(ctx context.Context) error {
 
 func (m Manager) Connect(ctx context.Context) (*Client, error) {
 	return ConnectWithPeerValidator(ctx, m.SocketPath, NewTrustedDaemonValidator(m.trustedDaemonPaths()))
+}
+
+func (m Manager) statusBeforeStart(ctx context.Context) error {
+	_, err := m.Status(ctx)
+	return err
+}
+
+func (m Manager) waitUntilReady(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		interval = 25 * time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		err := m.statusBeforeStart(ctx)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrDaemonUnavailable) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%w: authenticated status timeout", ErrDaemonUnavailable)
+		case <-ticker.C:
+		}
+	}
 }
 
 func (m Manager) trustedDaemonPaths() []string {

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,6 +164,46 @@ func TestManagerRejectsPermissiveCustomSocketParentWithoutChmod(t *testing.T) {
 	}
 	if got := statMode(t, dir); got != 0o755 {
 		t.Fatalf("manager changed custom socket dir mode to %s", got)
+	}
+}
+
+func TestManagerStartRejectsUntrustedLiveSocket(t *testing.T) {
+	t.Parallel()
+
+	path, stop := startFakeExecDaemon(t)
+	defer stop()
+	manager := Manager{
+		SocketPath:     path,
+		DaemonPath:     writeExecutableAt(t, t.TempDir(), "agent-secretd"),
+		StartupTimeout: time.Millisecond,
+	}
+
+	err := manager.Start(context.Background())
+	if !errors.Is(err, ErrUntrustedDaemon) {
+		t.Fatalf("Start error = %v, want %v", err, ErrUntrustedDaemon)
+	}
+}
+
+func TestManagerStartPropagatesStaleSocketCleanupError(t *testing.T) {
+	t.Parallel()
+
+	dir := shortTempDir(t, "agent-secret-manager-")
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // G302: manager socket test needs a private custom directory.
+		t.Fatalf("chmod custom dir: %v", err)
+	}
+	path := filepath.Join(dir, "agent-secretd.sock")
+	if err := os.WriteFile(path, []byte("not a socket"), 0o600); err != nil {
+		t.Fatalf("write fake socket path: %v", err)
+	}
+	manager := Manager{
+		SocketPath:     path,
+		DaemonPath:     os.Args[0],
+		StartupTimeout: time.Millisecond,
+	}
+
+	err := manager.Start(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "refusing to remove non-socket path") {
+		t.Fatalf("Start error = %v, want stale socket cleanup failure", err)
 	}
 }
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -110,27 +110,6 @@ func Dial(ctx context.Context, path string) (*net.UnixConn, error) {
 	return unixConn, nil
 }
 
-func WaitUntilReady(ctx context.Context, path string, interval time.Duration) error {
-	if interval <= 0 {
-		interval = 25 * time.Millisecond
-	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		conn, err := Dial(ctx, path)
-		if err == nil {
-			_ = conn.Close()
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("%w: socket readiness timeout", ErrDaemonUnavailable)
-		case <-ticker.C:
-		}
-	}
-}
-
 func cleanupStaleSocket(path string) error {
 	//nolint:gosec // G703: lstat checks whether the configured socket path is a stale Unix socket before removal.
 	info, err := os.Lstat(path)

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -1,12 +1,10 @@
 package daemon
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 func TestDefaultSocketPathIgnoresEnvironmentOverrides(t *testing.T) {
@@ -99,18 +97,6 @@ func TestListenUnixRejectsNonSocketPath(t *testing.T) {
 	_, err := ListenUnix(path)
 	if err == nil {
 		t.Fatal("expected non-socket path rejection")
-	}
-}
-
-func TestWaitUntilReadyHonorsDefaultIntervalAndTimeout(t *testing.T) {
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
-	defer cancel()
-
-	err := WaitUntilReady(ctx, filepath.Join(t.TempDir(), "missing.sock"), 0)
-	if !errors.Is(err, ErrDaemonUnavailable) {
-		t.Fatalf("expected daemon unavailable timeout, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- require an authenticated daemon.status response before treating an existing socket as ready
- fail daemon startup on untrusted live sockets instead of removing or racing them
- propagate stale socket cleanup errors so non-socket paths cannot be silently ignored

Closes #98

## Verification
- mise exec -- go test ./internal/daemon
- mise run lint
- mise run test:smoke
- mise run build