### PR TITLE
ASR-024: Authenticate native approver daemon socket peer

### DIFF
--- a/approver/Sources/AgentSecretApprover/DaemonPeerInfo.swift
+++ b/approver/Sources/AgentSecretApprover/DaemonPeerInfo.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+#if canImport(Darwin)
+    import Darwin
+
+    struct DaemonPeerInfo: Equatable {
+        let uid: uid_t
+        let gid: gid_t
+        let pid: pid_t
+        let executablePath: String
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/DaemonPeerInspector.swift
+++ b/approver/Sources/AgentSecretApprover/DaemonPeerInspector.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+#if canImport(Darwin)
+    import Darwin
+
+    enum DaemonPeerInspector {
+        // swiftlint:disable:next no_magic_numbers
+        private static let pidPathCapacity: Int = .init(MAXPATHLEN) * 4
+
+        static func inspect(socketFileDescriptor descriptor: Int32) throws -> DaemonPeerInfo {
+            var uid: uid_t = 0
+            var gid: gid_t = 0
+            guard getpeereid(descriptor, &uid, &gid) == 0 else {
+                throw SocketDaemonClientError.untrustedDaemon("getpeereid failed with errno \(errno)")
+            }
+
+            var cred = xucred()
+            var credLength = socklen_t(MemoryLayout<xucred>.size)
+            guard getsockopt(descriptor, 0, LOCAL_PEERCRED, &cred, &credLength) == 0 else {
+                throw SocketDaemonClientError.untrustedDaemon("LOCAL_PEERCRED failed with errno \(errno)")
+            }
+            guard cred.cr_version == XUCRED_VERSION, cred.cr_ngroups > 0 else {
+                throw SocketDaemonClientError.untrustedDaemon("LOCAL_PEERCRED returned incomplete metadata")
+            }
+            guard cred.cr_uid == uid, cred.cr_groups.0 == gid else {
+                throw SocketDaemonClientError.untrustedDaemon("peer credential sources disagree")
+            }
+
+            var pid: pid_t = 0
+            var pidLength = socklen_t(MemoryLayout<pid_t>.size)
+            guard getsockopt(descriptor, 0, LOCAL_PEERPID, &pid, &pidLength) == 0 else {
+                throw SocketDaemonClientError.untrustedDaemon("LOCAL_PEERPID failed with errno \(errno)")
+            }
+
+            var pathBuffer = [CChar](repeating: 0, count: Self.pidPathCapacity)
+            guard proc_pidpath(pid, &pathBuffer, UInt32(pathBuffer.count)) > 0 else {
+                throw SocketDaemonClientError.untrustedDaemon("proc_pidpath failed with errno \(errno)")
+            }
+
+            let pathBytes: [UInt8] = pathBuffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+            guard let executablePath = String(bytes: pathBytes, encoding: .utf8) else {
+                throw SocketDaemonClientError.untrustedDaemon("proc_pidpath returned invalid utf8")
+            }
+
+            return DaemonPeerInfo(
+                uid: uid,
+                gid: gid,
+                pid: pid,
+                executablePath: executablePath
+            )
+        }
+
+        static func validate(
+            socketFileDescriptor descriptor: Int32,
+            using peerValidator: DaemonPeerValidator?
+        ) throws {
+            guard let peerValidator else {
+                return
+            }
+            let info = try inspect(socketFileDescriptor: descriptor)
+            try peerValidator.validateDaemonPeer(info)
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/DaemonPeerValidator.swift
+++ b/approver/Sources/AgentSecretApprover/DaemonPeerValidator.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+#if canImport(Darwin)
+    protocol DaemonPeerValidator {
+        func validateDaemonPeer(_ info: DaemonPeerInfo) throws
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/SocketDaemonClientError.swift
+++ b/approver/Sources/AgentSecretApprover/SocketDaemonClientError.swift
@@ -20,6 +20,8 @@ public enum SocketDaemonClientError: Error, CustomStringConvertible, Equatable {
     case readTimedOut
     /// Unix sockets are unavailable on this platform.
     case socketUnavailable
+    /// The connected socket peer is not the trusted Agent Secret daemon.
+    case untrustedDaemon(String)
     /// The socket write syscall failed.
     case writeFailed(Int32)
     /// The daemon did not accept the request before the write timeout.
@@ -54,6 +56,9 @@ public enum SocketDaemonClientError: Error, CustomStringConvertible, Equatable {
 
         case .socketUnavailable:
             "unix sockets are unavailable on this platform"
+
+        case let .untrustedDaemon(message):
+            "untrusted daemon peer: \(message)"
 
         case let .writeFailed(errnoValue):
             "write failed: errno \(errnoValue)"

--- a/approver/Sources/AgentSecretApprover/TrustedDaemonPeerValidator.swift
+++ b/approver/Sources/AgentSecretApprover/TrustedDaemonPeerValidator.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+#if canImport(Darwin)
+    import Darwin
+    import Security
+
+    struct TrustedDaemonPeerValidator: DaemonPeerValidator {
+        private struct TrustedExecutable {
+            let path: String
+            let fileIdentity: FileIdentity
+
+            func validateCurrentFile() throws {
+                let current = try FileIdentity(path: path)
+                guard current == fileIdentity else {
+                    throw SocketDaemonClientError.untrustedDaemon(
+                        "daemon executable changed since trust snapshot"
+                    )
+                }
+            }
+        }
+
+        private struct FileIdentity: Equatable {
+            let device: UInt64
+            let inode: UInt64
+
+            init(path: String) throws {
+                var statBuffer = stat()
+                guard stat(path, &statBuffer) == 0 else {
+                    throw SocketDaemonClientError.untrustedDaemon(
+                        "stat trusted daemon executable failed with errno \(errno)"
+                    )
+                }
+                guard (statBuffer.st_mode & S_IFMT) == S_IFREG else {
+                    throw SocketDaemonClientError.untrustedDaemon(
+                        "trusted daemon path is not a regular file"
+                    )
+                }
+                guard (statBuffer.st_mode & S_IXUSR) != 0 else {
+                    throw SocketDaemonClientError.untrustedDaemon(
+                        "trusted daemon path is not executable"
+                    )
+                }
+                device = UInt64(statBuffer.st_dev)
+                inode = UInt64(statBuffer.st_ino)
+            }
+        }
+
+        private static let daemonHelperPathComponents: [String] = [
+            "Contents",
+            "Library",
+            "Helpers",
+            "AgentSecretDaemon.app",
+            "Contents",
+            "MacOS",
+            "Agent Secret"
+        ]
+        private static let expectedTeamIDKey: String = "AgentSecretExpectedTeamID"
+
+        private let expectedTeamID: String
+        private let trustedExecutables: [TrustedExecutable]
+
+        init(expectedExecutablePaths: [String], expectedTeamID: String = Self.configuredExpectedTeamID()) {
+            self.expectedTeamID = expectedTeamID.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            var seen = Set<String>()
+            trustedExecutables = expectedExecutablePaths.compactMap { path in
+                let normalized = Self.comparablePath(path)
+                guard !normalized.isEmpty, seen.insert(normalized).inserted else {
+                    return nil
+                }
+                guard let identity = try? FileIdentity(path: normalized) else {
+                    return nil
+                }
+                return TrustedExecutable(path: normalized, fileIdentity: identity)
+            }
+        }
+
+        static func defaultForCurrentProcess() -> Self {
+            Self(expectedExecutablePaths: defaultTrustedDaemonPaths())
+        }
+
+        static func defaultTrustedDaemonPaths(
+            mainBundle: Bundle = .main,
+            arguments: [String] = CommandLine.arguments
+        ) -> [String] {
+            var candidates: [String] = []
+            let executablePath = mainBundle.executableURL?.path ?? arguments.first ?? ""
+            if let appBundlePath = containingAppBundlePath(executablePath) {
+                candidates.append(daemonHelperPath(inAppBundle: appBundlePath))
+            }
+            if !executablePath.isEmpty {
+                candidates.append(
+                    URL(fileURLWithPath: executablePath)
+                        .deletingLastPathComponent()
+                        .appendingPathComponent("agent-secretd")
+                        .path
+                )
+            }
+            return uniqueComparablePaths(candidates)
+        }
+
+        private static func daemonHelperPath(inAppBundle appBundlePath: String) -> String {
+            var url = URL(fileURLWithPath: appBundlePath)
+            for component in daemonHelperPathComponents {
+                url.appendPathComponent(component)
+            }
+            return url.path
+        }
+
+        private static func containingAppBundlePath(_ path: String) -> String? {
+            var url = URL(fileURLWithPath: path).deletingLastPathComponent()
+            while url.path != "/" {
+                if url.pathExtension == "app" {
+                    return url.path
+                }
+                url.deleteLastPathComponent()
+            }
+            return nil
+        }
+
+        private static func uniqueComparablePaths(_ paths: [String]) -> [String] {
+            var seen = Set<String>()
+            var output: [String] = []
+            for path in paths {
+                let normalized = comparablePath(path)
+                if !normalized.isEmpty, seen.insert(normalized).inserted {
+                    output.append(normalized)
+                }
+            }
+            return output
+        }
+
+        private static func comparablePath(_ path: String) -> String {
+            guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return ""
+            }
+            return URL(fileURLWithPath: path)
+                .standardizedFileURL
+                .resolvingSymlinksInPath()
+                .path
+        }
+
+        private static func configuredExpectedTeamID() -> String {
+            guard let value = Bundle.main.object(forInfoDictionaryKey: expectedTeamIDKey) as? String else {
+                return ""
+            }
+            return value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        private static func codeSignatureTeamID(for path: String) throws -> String {
+            var staticCode: SecStaticCode?
+            let createStatus = SecStaticCodeCreateWithPath(
+                URL(fileURLWithPath: path) as CFURL,
+                SecCSFlags(),
+                &staticCode
+            )
+            guard createStatus == errSecSuccess, let code = staticCode else {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "load daemon code signature failed with status \(createStatus)"
+                )
+            }
+
+            let checkStatus = SecStaticCodeCheckValidity(
+                code,
+                SecCSFlags(rawValue: kSecCSStrictValidate),
+                nil
+            )
+            guard checkStatus == errSecSuccess else {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "daemon code signature validation failed with status \(checkStatus)"
+                )
+            }
+
+            var information: CFDictionary?
+            let copyStatus = SecCodeCopySigningInformation(
+                code,
+                SecCSFlags(rawValue: kSecCSSigningInformation),
+                &information
+            )
+            guard copyStatus == errSecSuccess, let dictionary = information as? [String: Any] else {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "read daemon code signature failed with status \(copyStatus)"
+                )
+            }
+            guard let teamID = dictionary[kSecCodeInfoTeamIdentifier as String] as? String else {
+                throw SocketDaemonClientError.untrustedDaemon("daemon code signature has no Team ID")
+            }
+            guard !teamID.isEmpty else {
+                throw SocketDaemonClientError.untrustedDaemon("daemon code signature has no Team ID")
+            }
+            return teamID
+        }
+
+        func validateDaemonPeer(_ info: DaemonPeerInfo) throws {
+            let got = Self.comparablePath(info.executablePath)
+            guard !got.isEmpty else {
+                throw SocketDaemonClientError.untrustedDaemon("daemon executable path is unavailable")
+            }
+            guard !trustedExecutables.isEmpty else {
+                throw SocketDaemonClientError.untrustedDaemon("no trusted daemon executables configured")
+            }
+            guard let trusted = trustedExecutables.first(where: { $0.path == got }) else {
+                throw SocketDaemonClientError.untrustedDaemon("daemon executable is not trusted")
+            }
+
+            try trusted.validateCurrentFile()
+            if !expectedTeamID.isEmpty {
+                let teamID = try Self.codeSignatureTeamID(for: trusted.path)
+                guard teamID == expectedTeamID else {
+                    throw SocketDaemonClientError.untrustedDaemon("daemon Team ID does not match")
+                }
+            }
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/UnixSocketLineTransport.swift
+++ b/approver/Sources/AgentSecretApprover/UnixSocketLineTransport.swift
@@ -23,7 +23,8 @@ final class UnixSocketLineTransport: LineTransport {
         try self.init(
             path: path,
             maxFrameBytes: Self.defaultMaxFrameBytes,
-            ioTimeout: Self.defaultIOTimeout
+            ioTimeout: Self.defaultIOTimeout,
+            peerValidator: TrustedDaemonPeerValidator.defaultForCurrentProcess()
         )
     }
 
@@ -31,13 +32,18 @@ final class UnixSocketLineTransport: LineTransport {
         init(
             socketFileDescriptor descriptor: Int32,
             maxFrameBytes: Int = defaultMaxFrameBytes,
-            ioTimeout: TimeInterval = defaultIOTimeout
+            ioTimeout: TimeInterval = defaultIOTimeout,
+            peerValidator: DaemonPeerValidator? = nil
         ) throws {
             try Self.validate(maxFrameBytes: maxFrameBytes)
             do {
                 try Self.configureTimeouts(
                     for: descriptor,
                     ioTimeout: ioTimeout
+                )
+                try DaemonPeerInspector.validate(
+                    socketFileDescriptor: descriptor,
+                    using: peerValidator
                 )
             } catch {
                 close(descriptor)
@@ -48,10 +54,11 @@ final class UnixSocketLineTransport: LineTransport {
         }
     #endif
 
-    private init(
+    init(
         path: String,
         maxFrameBytes: Int,
-        ioTimeout: TimeInterval
+        ioTimeout: TimeInterval,
+        peerValidator: DaemonPeerValidator?
     ) throws {
         #if canImport(Darwin)
             try Self.validate(maxFrameBytes: maxFrameBytes)
@@ -88,6 +95,10 @@ final class UnixSocketLineTransport: LineTransport {
                     for: descriptor,
                     ioTimeout: ioTimeout
                 )
+                try DaemonPeerInspector.validate(
+                    socketFileDescriptor: descriptor,
+                    using: peerValidator
+                )
             } catch {
                 close(descriptor)
                 throw error
@@ -98,6 +109,7 @@ final class UnixSocketLineTransport: LineTransport {
             _ = path
             _ = maxFrameBytes
             _ = ioTimeout
+            _ = peerValidator
             throw SocketDaemonClientError.socketUnavailable
         #endif
     }
@@ -164,6 +176,7 @@ final class UnixSocketLineTransport: LineTransport {
         private static func isTimeout(_ errnoValue: Int32) -> Bool {
             errnoValue == EAGAIN || errnoValue == EWOULDBLOCK
         }
+
     #endif
 
     func readLine() throws -> Data {

--- a/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTests.swift
@@ -1,0 +1,151 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+#if canImport(Darwin)
+    import Darwin
+
+    final class DaemonPeerValidationTests: XCTestCase {
+        private final class UnixSocketServer: @unchecked Sendable {
+            let path: String
+            private let descriptor: Int32
+
+            init(path: String) throws {
+                self.path = path
+                descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+                guard descriptor >= 0 else {
+                    throw SocketDaemonClientError.connectFailed(errno)
+                }
+
+                var address = sockaddr_un()
+                address.sun_family = sa_family_t(AF_UNIX)
+                var pathBytes = Array(path.utf8)
+                pathBytes.append(0)
+                guard pathBytes.count <= MemoryLayout.size(ofValue: address.sun_path) else {
+                    close(descriptor)
+                    throw SocketDaemonClientError.pathTooLong(path)
+                }
+                withUnsafeMutableBytes(of: &address.sun_path) { rawBuffer in
+                    rawBuffer.copyBytes(from: pathBytes)
+                }
+
+                let bindStatus = withUnsafePointer(to: &address) { pointer in
+                    pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                        Darwin.bind(descriptor, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+                    }
+                }
+                guard bindStatus == 0 else {
+                    close(descriptor)
+                    throw SocketDaemonClientError.connectFailed(errno)
+                }
+                guard listen(descriptor, 1) == 0 else {
+                    close(descriptor)
+                    throw SocketDaemonClientError.connectFailed(errno)
+                }
+            }
+
+            func acceptOneConnection() {
+                let client = accept(descriptor, nil, nil)
+                if client >= 0 {
+                    close(client)
+                }
+            }
+
+            deinit {
+                close(descriptor)
+                unlink(path)
+            }
+        }
+
+        private static func currentExecutablePath() throws -> String {
+            try XCTUnwrap(Bundle.main.executableURL?.path)
+        }
+
+        private static func makeServer(testCase: XCTestCase) throws -> UnixSocketServer {
+            let directory = URL(fileURLWithPath: "/tmp")
+                .appendingPathComponent("agent-secret-swift-tests-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let path = directory.appendingPathComponent("daemon.sock").path
+            testCase.addTeardownBlock {
+                unlink(path)
+                try? FileManager.default.removeItem(at: directory)
+            }
+            return try UnixSocketServer(path: path)
+        }
+
+        func testTrustedDaemonValidatorAcceptsCurrentExecutablePeer() throws {
+            var descriptors = [Int32](repeating: -1, count: 2)
+            XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+            defer {
+                close(descriptors[0])
+                close(descriptors[1])
+            }
+
+            let info = try DaemonPeerInspector.inspect(socketFileDescriptor: descriptors[0])
+            let validator = try TrustedDaemonPeerValidator(
+                expectedExecutablePaths: [Self.currentExecutablePath()]
+            )
+
+            XCTAssertNoThrow(try validator.validateDaemonPeer(info))
+        }
+
+        func testTrustedDaemonValidatorRejectsUnexpectedExecutablePeer() throws {
+            var descriptors = [Int32](repeating: -1, count: 2)
+            XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+            defer {
+                close(descriptors[0])
+                close(descriptors[1])
+            }
+
+            let info = try DaemonPeerInspector.inspect(socketFileDescriptor: descriptors[0])
+            let validator = TrustedDaemonPeerValidator(expectedExecutablePaths: ["/bin/ls"])
+
+            XCTAssertThrowsError(try validator.validateDaemonPeer(info)) { error in
+                XCTAssertEqual(
+                    error as? SocketDaemonClientError,
+                    .untrustedDaemon("daemon executable is not trusted")
+                )
+            }
+        }
+
+        func testPathTransportRejectsSocketBeforeProtocolWhenPeerIsUntrusted() throws {
+            let server = try Self.makeServer(testCase: self)
+            let acceptThread = Thread {
+                server.acceptOneConnection()
+            }
+            acceptThread.start()
+
+            XCTAssertThrowsError(try UnixSocketLineTransport(path: server.path)) { error in
+                guard case .untrustedDaemon = error as? SocketDaemonClientError else {
+                    return XCTFail("expected untrusted daemon error, got \(error)")
+                }
+            }
+        }
+
+        func testPathTransportCanTrustCurrentExecutableForLocalPeer() throws {
+            let server = try Self.makeServer(testCase: self)
+            let acceptThread = Thread {
+                server.acceptOneConnection()
+            }
+            acceptThread.start()
+
+            let validator = try TrustedDaemonPeerValidator(
+                expectedExecutablePaths: [Self.currentExecutablePath()]
+            )
+            let transport = try UnixSocketLineTransport(
+                path: server.path,
+                maxFrameBytes: 64,
+                ioTimeout: 0.05,
+                peerValidator: validator
+            )
+
+            XCTAssertThrowsError(try transport.readLine()) { error in
+                XCTAssertEqual(error as? SocketDaemonClientError, .disconnected)
+            }
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif

--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -33,6 +33,7 @@ version="${AGENT_SECRET_VERSION:-$AGENT_SECRET_DEFAULT_VERSION}"
 bundle_version="${AGENT_SECRET_BUNDLE_VERSION:-$AGENT_SECRET_DEFAULT_BUNDLE_VERSION}"
 codesign_identity="${AGENT_SECRET_CODESIGN_IDENTITY:-"-"}"
 codesign_entitlements="${AGENT_SECRET_CODESIGN_ENTITLEMENTS:-}"
+approver_team_id=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -259,6 +260,8 @@ cat >"$app_bundle/Contents/Info.plist" <<PLIST
   <string>$AGENT_SECRET_ICON_FILE</string>
   <key>CFBundleIdentifier</key>
   <string>$AGENT_SECRET_APP_BUNDLE_ID</string>
+  <key>AgentSecretExpectedTeamID</key>
+  <string>$approver_team_id</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>$AGENT_SECRET_INFO_DICTIONARY_VERSION</string>
   <key>CFBundleName</key>


### PR DESCRIPTION
## Summary
- inspect Darwin Unix socket peer credentials in the Swift transport before reading approval protocol frames
- trust only the expected Agent Secret daemon executable, including file identity snapshot checks and production Team ID validation when packaged
- add Swift coverage for trusted peer acceptance and fake-socket rejection before UI metadata can be fetched

Closes #99

## Verification
- cd approver && swift test
- mise run lint:swift
- mise run lint
- mise run test:smoke
- mise run build
- /usr/libexec/PlistBuddy -c "Print :AgentSecretExpectedTeamID" "dist/Agent Secret.app/Contents/Info.plist"