### PR TITLE
ASR-025: Reject symlinked audit log paths

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/kovyrin/agent-secret/internal/policy"
@@ -176,44 +177,114 @@ func openPath(path string, now func() time.Time) (*Writer, error) {
 	if now == nil {
 		now = time.Now
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return nil, fmt.Errorf("create audit directory: %w", err)
-	}
-	if err := os.Chmod(filepath.Dir(path), 0o700); err != nil { //nolint:gosec // G302: audit directories need owner execute/search while denying group and other access.
-		return nil, fmt.Errorf("secure audit directory: %w", err)
+	if err := prepareAuditDirectory(filepath.Dir(path)); err != nil {
+		return nil, err
 	}
 	if err := rejectInsecureFile(path); err != nil {
 		return nil, err
 	}
 
-	//nolint:gosec // G304: audit path is daemon-owned; openPath rejects insecure existing files before and after creation.
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	file, err := openAuditLog(path)
 	if err != nil {
-		return nil, fmt.Errorf("open audit log: %w", err)
-	}
-	if err := rejectInsecureFile(path); err != nil {
-		_ = file.Close()
 		return nil, err
 	}
 
 	return &Writer{now: now, file: file}, nil
 }
 
+func prepareAuditDirectory(dir string) error {
+	_, err := os.Lstat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("create audit directory: %w", err)
+		}
+		return rejectInsecureDirectory(dir)
+	}
+	if err != nil {
+		return fmt.Errorf("stat audit directory: %w", err)
+	}
+	return rejectInsecureDirectory(dir)
+}
+
+func rejectInsecureDirectory(dir string) error {
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("stat audit directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: %s is a symlink", ErrInsecureAuditLog, dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %s is not a directory", ErrInsecureAuditLog, dir)
+	}
+	if info.Mode().Perm() != 0o700 {
+		return fmt.Errorf("%w: %s has mode %s", ErrInsecureAuditLog, dir, info.Mode().Perm())
+	}
+	if uid, ok := fileOwnerUID(info); ok && uid != os.Getuid() {
+		return fmt.Errorf("%w: %s is owned by uid %d", ErrInsecureAuditLog, dir, uid)
+	}
+	return nil
+}
+
 func rejectInsecureFile(path string) error {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("stat audit log: %w", err)
 	}
-	if info.IsDir() {
-		return fmt.Errorf("%w: %s is a directory", ErrInsecureAuditLog, path)
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: %s is a symlink", ErrInsecureAuditLog, path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: %s is not a regular file", ErrInsecureAuditLog, path)
 	}
 	if info.Mode().Perm() != 0o600 {
 		return fmt.Errorf("%w: %s has mode %s", ErrInsecureAuditLog, path, info.Mode().Perm())
 	}
+	if uid, ok := fileOwnerUID(info); ok && uid != os.Getuid() {
+		return fmt.Errorf("%w: %s is owned by uid %d", ErrInsecureAuditLog, path, uid)
+	}
 	return nil
+}
+
+func openAuditLog(path string) (*os.File, error) {
+	//nolint:gosec // G304: audit path is fixed under the user's home; O_NOFOLLOW and fstat checks bind it to a regular owner-private file.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY|syscall.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open audit log: %w", err)
+	}
+	if err := rejectInsecureOpenFile(file, path); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func rejectInsecureOpenFile(file *os.File, path string) error {
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat open audit log: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: %s is not a regular file", ErrInsecureAuditLog, path)
+	}
+	if info.Mode().Perm() != 0o600 {
+		return fmt.Errorf("%w: %s has mode %s", ErrInsecureAuditLog, path, info.Mode().Perm())
+	}
+	if uid, ok := fileOwnerUID(info); ok && uid != os.Getuid() {
+		return fmt.Errorf("%w: %s is owned by uid %d", ErrInsecureAuditLog, path, uid)
+	}
+	return nil
+}
+
+func fileOwnerUID(info os.FileInfo) (int, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(stat.Uid), true
 }
 
 func secretRefs(secrets []request.Secret) []SecretRef {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -103,6 +103,64 @@ func TestOpenDefaultRejectsPermissiveExistingAuditFile(t *testing.T) {
 	}
 }
 
+func TestOpenDefaultRejectsSymlinkAuditLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := expectedPath(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir audit dir: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "target.jsonl")
+	if err := os.WriteFile(target, []byte("target\n"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("symlink audit log: %v", err)
+	}
+
+	_, err := OpenDefault(time.Now)
+	if !errors.Is(err, ErrInsecureAuditLog) {
+		t.Fatalf("expected insecure audit log error, got %v", err)
+	}
+	//nolint:gosec // G304: test reads a symlink target created under t.TempDir.
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read symlink target: %v", err)
+	}
+	if string(data) != "target\n" {
+		t.Fatalf("symlink target was modified: %q", data)
+	}
+}
+
+func TestOpenDefaultRejectsSymlinkAuditDirectoryWithoutChmodTarget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := expectedPath(home)
+	parent := filepath.Dir(filepath.Dir(path))
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		t.Fatalf("mkdir audit parent: %v", err)
+	}
+	target := t.TempDir()
+	if err := os.Chmod(target, 0o755); err != nil { //nolint:gosec // G302: this test intentionally creates a permissive symlink target to prove it is not chmodded.
+		t.Fatalf("chmod symlink target: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Dir(path)); err != nil {
+		t.Fatalf("symlink audit dir: %v", err)
+	}
+
+	_, err := OpenDefault(time.Now)
+	if !errors.Is(err, ErrInsecureAuditLog) {
+		t.Fatalf("expected insecure audit log error, got %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat symlink target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("symlink target mode = %s, want unchanged 0755", got)
+	}
+}
+
 func TestDefaultPathIgnoresEnvironmentOverrides(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -272,6 +330,71 @@ func TestOpenPathRejectsDirectoryAtAuditPath(t *testing.T) {
 	}
 
 	_, err := openPath(path, time.Now)
+	if !errors.Is(err, ErrInsecureAuditLog) {
+		t.Fatalf("expected insecure audit log error, got %v", err)
+	}
+}
+
+func TestOpenPathRejectsPermissiveExistingAuditDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "agent-secret")
+	if err := os.Mkdir(dir, 0o755); err != nil { //nolint:gosec // G301: this test intentionally creates a permissive audit directory.
+		t.Fatalf("mkdir audit dir: %v", err)
+	}
+
+	_, err := openPath(filepath.Join(dir, "audit.jsonl"), time.Now)
+	if !errors.Is(err, ErrInsecureAuditLog) {
+		t.Fatalf("expected insecure audit log error, got %v", err)
+	}
+}
+
+func TestOpenPathRejectsFileAtAuditDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "agent-secret")
+	if err := os.WriteFile(dir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write audit dir placeholder: %v", err)
+	}
+
+	_, err := openPath(filepath.Join(dir, "audit.jsonl"), time.Now)
+	if !errors.Is(err, ErrInsecureAuditLog) {
+		t.Fatalf("expected insecure audit log error, got %v", err)
+	}
+}
+
+func TestOpenAuditLogRejectsSymlinkWithoutPrecheck(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.jsonl")
+	if err := os.WriteFile(target, []byte("target\n"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	path := filepath.Join(dir, "audit.jsonl")
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("symlink audit log: %v", err)
+	}
+
+	file, err := openAuditLog(path)
+	if err == nil {
+		_ = file.Close()
+		t.Fatal("openAuditLog accepted symlink path")
+	}
+	//nolint:gosec // G304: test reads a symlink target created under t.TempDir.
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read symlink target: %v", err)
+	}
+	if string(data) != "target\n" {
+		t.Fatalf("symlink target was modified: %q", data)
+	}
+}
+
+func TestRejectInsecureOpenFileRejectsDirectoryHandle(t *testing.T) {
+	dir := t.TempDir()
+	//nolint:gosec // G304: test opens a directory created by t.TempDir.
+	file, err := os.Open(dir)
+	if err != nil {
+		t.Fatalf("open dir: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	err = rejectInsecureOpenFile(file, dir)
 	if !errors.Is(err, ErrInsecureAuditLog) {
 		t.Fatalf("expected insecure audit log error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- validate the audit directory with lstat and stop chmodding existing/symlinked targets
- reject symlinked audit log paths before open and use O_NOFOLLOW for the final open
- verify the opened audit log handle is a regular, owner-private file owned by the current user
- add regression tests for symlinked logs, symlinked directories, and descriptor-level validation

Closes #100

## Verification
- mise exec -- go test ./internal/audit
- mise exec -- golangci-lint run --timeout 5m ./internal/audit
- mise run lint
- mise run test:smoke
- mise run build