### PR TITLE
ASR-026: Harden uninstall path removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,12 @@ curl -fsSL \
   https://raw.githubusercontent.com/kovyrin/agent-secret/main/uninstall.sh | sh
 ```
 
-By default uninstall removes the app, CLI symlink, skill symlink, and
-application support state, but leaves `~/Library/Logs/agent-secret` audit logs
+By default uninstall removes the app, CLI symlink, skill symlink, and known
+application support files, but leaves `~/Library/Logs/agent-secret` audit logs
 in place. Set `AGENT_SECRET_REMOVE_AUDIT_LOGS=1` to remove those logs too.
+Custom support or audit paths require
+`AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1`; the script refuses broad,
+relative, symlinked, or non-`agent-secret` directory targets.
 
 ## Development Install
 

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -170,7 +170,9 @@ AGENT_SECRET_REMOVE_AUDIT_LOGS=1 uninstall.sh
 ```
 
 For isolated tests, `AGENT_SECRET_SUPPORT_DIR` and `AGENT_SECRET_AUDIT_DIR`
-override the state/log directories.
+may point at temporary `agent-secret` directories only when
+`AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1` is also set. The script refuses
+empty, relative, broad, symlinked, and non-`agent-secret` directory targets.
 
 Audit logs are durable by design and should require an explicit separate
 removal command:

--- a/mise.toml
+++ b/mise.toml
@@ -77,6 +77,7 @@ run = "scripts/check-go-coverage.sh"
 description = "Run non-secret smoke tests"
 run = """
 AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh
 cd approver && swift run agent-secret-approver-smoke

--- a/scripts/test-uninstall.sh
+++ b/scripts/test-uninstall.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd -- "$script_dir/.." && pwd)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-uninstall-test.XXXXXX")"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "test-uninstall: $*" >&2
+  exit 1
+}
+
+run_uninstall() {
+  local name="$1"
+  shift
+
+  mkdir -p "$tmp_dir/$name"
+  (
+    cd "$project_root"
+    env -i \
+      PATH="$PATH" \
+      HOME="$tmp_dir/$name/home" \
+      AGENT_SECRET_NO_STOP_DAEMON=1 \
+      "$@" \
+      "$project_root/uninstall.sh"
+  ) >"$tmp_dir/$name/stdout" 2>"$tmp_dir/$name/stderr"
+}
+
+expect_failure() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+
+  if run_uninstall "$name" "$@"; then
+    fail "$name succeeded unexpectedly"
+  fi
+  if ! grep -F "$expected" "$tmp_dir/$name/stderr" >/dev/null; then
+    fail "$name stderr did not contain $expected: $(cat "$tmp_dir/$name/stderr")"
+  fi
+}
+
+make_symlink() {
+  local target="$1"
+  local link="$2"
+
+  mkdir -p "$(dirname "$link")"
+  ln -s "$target" "$link"
+}
+
+custom_guard_rejects_override() {
+  local run_dir="$tmp_dir/custom-guard"
+  local support="$run_dir/important/agent-secret"
+  mkdir -p "$support"
+  printf 'keep\n' >"$support/keep.txt"
+
+  expect_failure \
+    custom-guard \
+    "support path override requires AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1" \
+    AGENT_SECRET_SUPPORT_DIR="$support"
+
+  if [ ! -f "$support/keep.txt" ]; then
+    fail "custom support override removed data without guard"
+  fi
+}
+
+dangerous_paths_are_rejected_even_with_guard() {
+  local run_dir="$tmp_dir/dangerous"
+  local home="$run_dir/home"
+  local audit="$run_dir/not-agent-secret"
+  mkdir -p "$home" "$audit"
+  printf 'keep\n' >"$home/keep.txt"
+
+  expect_failure \
+    dangerous-home \
+    "support path is too broad" \
+    HOME="$home" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_SUPPORT_DIR="$home"
+
+  expect_failure \
+    dangerous-leaf \
+    "audit path must end with agent-secret" \
+    HOME="$home" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_REMOVE_AUDIT_LOGS=1 \
+    AGENT_SECRET_AUDIT_DIR="$audit"
+
+  if [ ! -f "$home/keep.txt" ]; then
+    fail "dangerous home path was modified"
+  fi
+}
+
+symlinked_dirs_are_rejected() {
+  local run_dir="$tmp_dir/symlink"
+  local target="$run_dir/target"
+  local link="$run_dir/link/agent-secret"
+  mkdir -p "$target"
+  printf 'keep\n' >"$target/keep.txt"
+  make_symlink "$target" "$link"
+
+  expect_failure \
+    symlink \
+    "support path must not be a symlink" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_SUPPORT_DIR="$link"
+
+  if [ ! -f "$target/keep.txt" ]; then
+    fail "symlink target was modified"
+  fi
+}
+
+safe_custom_paths_remove_only_known_files() {
+  local run_dir="$tmp_dir/safe"
+  local home="$run_dir/home"
+  local app_dir="$run_dir/apps"
+  local bin_dir="$run_dir/bin"
+  local skills_dir="$run_dir/skills"
+  local support="$run_dir/support/agent-secret"
+  local audit="$run_dir/audit/agent-secret"
+  local app="$app_dir/Agent Secret.app"
+
+  mkdir -p \
+    "$app/Contents/Resources/bin" \
+    "$app/Contents/Resources/skills/agent-secret" \
+    "$bin_dir" \
+    "$skills_dir" \
+    "$support" \
+    "$audit" \
+    "$home"
+  touch "$app/Contents/Resources/bin/agent-secret"
+  ln -s "$app/Contents/Resources/bin/agent-secret" "$bin_dir/agent-secret"
+  ln -s "$app/Contents/Resources/skills/agent-secret" "$skills_dir/agent-secret"
+  touch "$support/agent-secretd.sock"
+  touch "$audit/audit.jsonl"
+
+  run_uninstall \
+    safe \
+    HOME="$home" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_REMOVE_AUDIT_LOGS=1 \
+    AGENT_SECRET_APP_DIR="$app_dir" \
+    AGENT_SECRET_BIN_DIR="$bin_dir" \
+    AGENT_SECRET_SKILLS_DIR="$skills_dir" \
+    AGENT_SECRET_SUPPORT_DIR="$support" \
+    AGENT_SECRET_AUDIT_DIR="$audit"
+
+  for path in "$app" "$bin_dir/agent-secret" "$skills_dir/agent-secret" "$support" "$audit"; do
+    if [ -e "$path" ] || [ -L "$path" ]; then
+      fail "safe uninstall left expected removed path in place: $path"
+    fi
+  done
+}
+
+custom_guard_rejects_override
+dangerous_paths_are_rejected_even_with_guard
+symlinked_dirs_are_rejected
+safe_custom_paths_remove_only_known_files
+
+echo "test-uninstall: ok"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,12 +6,20 @@ bin_dir="${AGENT_SECRET_BIN_DIR:-$HOME/.local/bin}"
 skills_dir="${AGENT_SECRET_SKILLS_DIR:-$HOME/.agents/skills}"
 remove_audit_logs="${AGENT_SECRET_REMOVE_AUDIT_LOGS:-0}"
 no_stop_daemon="${AGENT_SECRET_NO_STOP_DAEMON:-0}"
+allow_custom_uninstall_paths="${AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS:-0}"
+default_support_dir="$HOME/Library/Application Support/agent-secret"
+default_audit_dir="$HOME/Library/Logs/agent-secret"
 
 target_app="$app_dir/Agent Secret.app"
 cli_link="$bin_dir/agent-secret"
 skill_link="$skills_dir/agent-secret"
-app_support_dir="${AGENT_SECRET_SUPPORT_DIR:-$HOME/Library/Application Support/agent-secret}"
-audit_dir="${AGENT_SECRET_AUDIT_DIR:-$HOME/Library/Logs/agent-secret}"
+app_support_dir="${AGENT_SECRET_SUPPORT_DIR-$default_support_dir}"
+audit_dir="${AGENT_SECRET_AUDIT_DIR-$default_audit_dir}"
+
+fail() {
+  echo "agent-secret uninstall: $*" >&2
+  exit 1
+}
 
 stop_existing_daemon() {
   if [ "$no_stop_daemon" = "1" ]; then
@@ -70,6 +78,100 @@ remove_skill_link() {
   esac
 }
 
+strip_trailing_slashes() {
+  value="$1"
+  while [ "$value" != "/" ] && [ "${value%/}" != "$value" ]; do
+    value="${value%/}"
+  done
+  printf '%s\n' "$value"
+}
+
+require_custom_path_guard() {
+  label="$1"
+  path="$2"
+  default_path="$3"
+
+  if [ "$path" = "$default_path" ]; then
+    return
+  fi
+  if [ "$allow_custom_uninstall_paths" = "1" ]; then
+    return
+  fi
+
+  fail "$label path override requires AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1: $path"
+}
+
+validate_agent_secret_dir() {
+  label="$1"
+  path="$(strip_trailing_slashes "$2")"
+  default_path="$(strip_trailing_slashes "$3")"
+
+  require_custom_path_guard "$label" "$path" "$default_path"
+
+  if [ "$path" = "" ]; then
+    fail "$label path is empty"
+  fi
+  case "$path" in
+    /*) ;;
+    *)
+      fail "$label path must be absolute: $path"
+      ;;
+  esac
+  case "$path" in
+    "/" | "$HOME")
+      fail "$label path is too broad: $path"
+      ;;
+    */../* | */.. | */./* | */.)
+      fail "$label path must not contain dot segments: $path"
+      ;;
+  esac
+
+  leaf="${path##*/}"
+  if [ "$leaf" != "agent-secret" ]; then
+    fail "$label path must end with agent-secret: $path"
+  fi
+  if [ -L "$path" ]; then
+    fail "$label path must not be a symlink: $path"
+  fi
+  if [ -e "$path" ] && [ ! -d "$path" ]; then
+    fail "$label path is not a directory: $path"
+  fi
+}
+
+remove_known_support_dir() {
+  validate_agent_secret_dir "support" "$app_support_dir" "$default_support_dir"
+
+  echo "Removing $app_support_dir"
+  if [ ! -d "$app_support_dir" ]; then
+    return
+  fi
+  rm -f "$app_support_dir/agent-secretd.sock"
+  if ! rmdir "$app_support_dir" 2>/dev/null; then
+    echo "agent-secret uninstall: leaving non-empty support directory $app_support_dir in place" >&2
+  fi
+}
+
+remove_known_audit_dir() {
+  validate_agent_secret_dir "audit" "$audit_dir" "$default_audit_dir"
+
+  echo "Removing $audit_dir"
+  if [ ! -d "$audit_dir" ]; then
+    return
+  fi
+  rm -f "$audit_dir/audit.jsonl"
+  if ! rmdir "$audit_dir" 2>/dev/null; then
+    echo "agent-secret uninstall: leaving non-empty audit directory $audit_dir in place" >&2
+  fi
+}
+
+validate_uninstall_paths() {
+  validate_agent_secret_dir "support" "$app_support_dir" "$default_support_dir"
+  if [ "$remove_audit_logs" = "1" ]; then
+    validate_agent_secret_dir "audit" "$audit_dir" "$default_audit_dir"
+  fi
+}
+
+validate_uninstall_paths
 stop_existing_daemon
 remove_cli_link
 remove_skill_link
@@ -77,12 +179,10 @@ remove_skill_link
 echo "Removing $target_app"
 rm -rf "$target_app"
 
-echo "Removing $app_support_dir"
-rm -rf "$app_support_dir"
+remove_known_support_dir
 
 if [ "$remove_audit_logs" = "1" ]; then
-  echo "Removing $audit_dir"
-  rm -rf "$audit_dir"
+  remove_known_audit_dir
 else
   echo "Leaving audit logs in place: $audit_dir"
 fi


### PR DESCRIPTION
## Summary
- require AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 before honoring custom support/audit removal roots
- reject empty, relative, broad, dot-segment, symlinked, and non-agent-secret support/audit targets before destructive work
- remove only known files from support/audit directories and rmdir the leaf instead of rm -rf arbitrary env-selected directories
- add uninstall smoke tests to the non-secret smoke suite and document the guard

Closes #101

## Verification
- AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh
- mise run lint:shell
- npx --yes markdownlint-cli README.md docs/macos-distribution-plan.md
- mise run lint
- mise run test:smoke
- mise run build