### PR TITLE
ASR-027: Refresh release signing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,19 @@ cd approver && swift test
 scripts/build-app-bundle.sh
 ```
 
-`mise run test:smoke` runs the non-secret approver smoke executable:
+`mise run test:smoke` runs the non-secret install, uninstall, release
+configuration, release version, release docs, and approver smoke checks:
+
+```bash
+AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh
+cd approver && swift run agent-secret-approver-smoke
+```
+
+The approver smoke executable can also be run directly:
 
 ```bash
 swift run agent-secret-approver-smoke
@@ -255,14 +267,24 @@ Local release artifact build:
 scripts/build-release.sh v0.0.0-dev
 ```
 
-That produces a DMG and `checksums.txt` in `dist/`.
-Tag pushes matching `v*` build the same artifacts in CI and attach them to a
-draft GitHub Release. Local and CI builds are ad-hoc signed by default.
+That produces a DMG and `checksums.txt` in `dist/`. Local builds are ad-hoc
+signed unless Developer ID signing and notarization settings are present, which
+makes the local command useful for layout, checksum, and installer smoke checks.
+
+Tag pushes matching `v*` run the GitHub release workflow and attach artifacts
+to a draft GitHub Release. Tag-triggered GitHub releases require production
+signing: CI runs `scripts/check-release-signing-env.sh`, imports the Developer
+ID certificate, and then calls `scripts/build-release.sh "$GITHUB_REF_NAME"
+--require-production-signing`. Missing certificate, Developer ID identity,
+`AGENT_SECRET_NOTARIZE=1`, or notary credentials fail the tag workflow instead
+of publishing ad-hoc artifacts.
+
 The maintainer release checklist is documented in
 [Release Process](docs/release-process.md), and release notes are copied from
 the matching section in [Changelog](CHANGELOG.md).
 
-Developer ID signing and notarization are opt-in release settings:
+Developer ID signing and notarization are optional for local release-candidate
+builds and required for this repository's tag-triggered maintainer releases:
 
 ```bash
 AGENT_SECRET_CODESIGN_IDENTITY="Developer ID Application: Example, Inc. (TEAMID)"
@@ -271,12 +293,14 @@ AGENT_SECRET_NOTARIZE=1
 AGENT_SECRET_NOTARY_KEY="$(cat AuthKey_KEYID.p8)"
 AGENT_SECRET_NOTARY_KEY_ID=KEYID
 AGENT_SECRET_NOTARY_ISSUER_ID=ISSUER_UUID
-scripts/build-release.sh v0.3.1
+scripts/check-release-signing-env.sh
+scripts/build-release.sh v0.3.1 --require-production-signing
 ```
 
 `AGENT_SECRET_NOTARY_KEY` may also point at a local `.p8` file. Notarization is
 only attempted when `AGENT_SECRET_NOTARIZE=1`; without Apple Developer ID and
-App Store Connect API key credentials, release artifacts remain ad-hoc signed.
+App Store Connect API key credentials, local release artifacts remain ad-hoc
+signed.
 
 For this repository's maintainer releases, the current Developer ID identity is:
 

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -422,14 +422,15 @@ test -f "$TMPDIR/agent-secret-skills/agent-secret/SKILL.md"
 
 ### Epic 3: Release Artifact Builder
 
-Status: Implemented for unsigned/ad-hoc artifacts
+Status: Implemented for local ad-hoc artifacts and tag-triggered signed
+artifacts when release secrets are configured
 
 Deliverables:
 
 - Script to produce `Agent-Secret-vX.Y.Z-macos-arm64.dmg`.
 - DMG contains app bundle and `/Applications` symlink.
 - Checksums are generated.
-- CI can build artifacts on tag push.
+- CI can build artifacts on tag push after production signing preflight passes.
 
 Acceptance checks:
 
@@ -441,13 +442,16 @@ hdiutil verify dist/Agent-Secret-v0.0.0-dev-macos-arm64.dmg
 
 ### Epic 4: Signed and Notarized Releases
 
-Status: Signing hooks implemented; full verification blocked on Developer ID
+Status: Implemented; tag-triggered maintainer releases require Developer ID
 certificate and notarization secrets
 
 Deliverables:
 
-- Optional Developer ID signing in the app bundle and release artifact builder.
-- Optional notarization using App Store Connect API key credentials.
+- Optional Developer ID signing in local app bundle and release artifact builds.
+- Required Developer ID signing and notarization for tag-triggered GitHub
+  releases from this repository.
+- Release signing preflight before GitHub Actions imports certificates or
+  builds artifacts.
 - Stapled artifact when `AGENT_SECRET_NOTARIZE=1` is used.
 - Gatekeeper verification documented for signed/notarized releases.
 
@@ -462,12 +466,17 @@ AGENT_SECRET_NOTARY_KEY_ID=KEYID
 AGENT_SECRET_NOTARY_ISSUER_ID=ISSUER_UUID
 ```
 
-`AGENT_SECRET_NOTARY_KEY` may also be a path to a `.p8` API key file. Without
-`AGENT_SECRET_CODESIGN_IDENTITY`, builds use ad-hoc signing. Without
-`AGENT_SECRET_NOTARIZE=1`, the release builder does not submit to Apple.
+`AGENT_SECRET_NOTARY_KEY` may also be a path to a `.p8` API key file. Local
+builds without `AGENT_SECRET_CODESIGN_IDENTITY` use ad-hoc signing, and local
+builds without `AGENT_SECRET_NOTARIZE=1` do not submit to Apple. Tag-triggered
+GitHub releases fail preflight instead of publishing ad-hoc artifacts when any
+production signing input is missing.
 
 GitHub release signing imports a Developer ID certificate into a temporary
-keychain before building artifacts. Configure these repository secrets:
+keychain before building artifacts. Before import, the workflow runs
+`scripts/check-release-signing-env.sh`; artifact builds then call
+`scripts/build-release.sh "$GITHUB_REF_NAME" --require-production-signing`.
+Configure these repository secrets:
 
 ```text
 AGENT_SECRET_CODESIGN_IDENTITY
@@ -494,14 +503,16 @@ Acceptance checks:
 
 ```bash
 scripts/build-release.sh v0.0.0-dev
+scripts/check-release-signing-env.sh
+scripts/build-release.sh v0.0.0-dev --require-production-signing
 codesign --verify --deep --strict "/Applications/Agent Secret.app"
 spctl --assess --type execute --verbose "/Applications/Agent Secret.app"
 xcrun stapler validate "/Applications/Agent Secret.app"
 ```
 
 Only the ad-hoc release builder path can be verified locally without Apple
-credentials. The Developer ID path must be verified once the certificate and App
-Store Connect API key are available in the release environment.
+credentials. The Developer ID path requires the certificate and App Store
+Connect API key in the release environment.
 
 ### Epic 5: Unattended Installer
 

--- a/mise.toml
+++ b/mise.toml
@@ -80,6 +80,7 @@ AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh
 cd approver && swift run agent-secret-approver-smoke
 """
 

--- a/scripts/test-release-docs.sh
+++ b/scripts/test-release-docs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd -- "$script_dir/.." && pwd)"
+readme="$project_root/README.md"
+
+fail() {
+  echo "test-release-docs: $*" >&2
+  exit 1
+}
+
+require_text() {
+  local needle="$1"
+
+  if ! grep -F -- "$needle" "$readme" >/dev/null; then
+    fail "README.md is missing expected release documentation: $needle"
+  fi
+}
+
+reject_text() {
+  local needle="$1"
+
+  if grep -F -- "$needle" "$readme" >/dev/null; then
+    fail "README.md still contains stale release documentation: $needle"
+  fi
+}
+
+require_text "AGENT_SECRET_IN_MISE=1 scripts/test-install.sh"
+require_text "AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh"
+require_text "AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh"
+require_text "AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh"
+require_text "AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh"
+require_text "swift run agent-secret-approver-smoke"
+require_text "scripts/check-release-signing-env.sh"
+require_text "--require-production-signing"
+require_text "Tag-triggered GitHub releases require production"
+reject_text "Local and CI builds are ad-hoc signed by default"
+reject_text "Developer ID signing and notarization are opt-in release settings"
+
+echo "test-release-docs: ok"


### PR DESCRIPTION
## Summary

- update README smoke-test documentation to list every non-secret smoke check
- distinguish local ad-hoc release-candidate builds from tag-triggered production-signed releases
- update the macOS distribution plan with the current release signing preflight and required tag-release behavior
- add a README drift smoke test so stale release-signing claims fail `mise run test:smoke`

Closes #102

## Verification

- `AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh`
- `shellcheck scripts/test-release-docs.sh`
- `npx --yes markdownlint-cli README.md docs/macos-distribution-plan.md`
- `mise run lint`
- `mise run test:smoke`
- `mise run build`