### PR TITLE
ASR-028: Reject symlinked daemon socket directories

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -58,15 +58,21 @@ func ValidateSocketDirectory(path string) error {
 }
 
 func prepareDefaultSocketDirectory(dir string) error {
+	if err := rejectSocketDirectorySymlinkOrOwner(dir); err != nil {
+		return err
+	}
 	//nolint:gosec // G703: dir is the managed default socket directory under Application Support.
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create socket directory: %w", err)
+	}
+	if err := rejectSocketDirectorySymlinkOrOwner(dir); err != nil {
+		return err
 	}
 	//nolint:gosec // G703: only the managed default socket directory is chmodded.
 	if err := os.Chmod(dir, 0o700); err != nil {
 		return fmt.Errorf("secure socket directory: %w", err)
 	}
-	return nil
+	return rejectInsecureSocketDirectory(dir)
 }
 
 func prepareCustomSocketDirectory(dir string) error {
@@ -78,22 +84,41 @@ func prepareCustomSocketDirectory(dir string) error {
 }
 
 func rejectInsecureSocketDirectory(dir string) error {
-	//nolint:gosec // G703: stat is required to validate the custom socket parent before use.
-	info, err := os.Stat(dir)
+	info, err := socketDirectoryInfo(dir)
 	if err != nil {
-		return fmt.Errorf("stat socket directory: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("%w: %s is not a directory", ErrInsecureSocketDirectory, dir)
+		return err
 	}
 	if info.Mode().Perm()&0o077 != 0 {
 		return fmt.Errorf("%w: %s has mode %s", ErrInsecureSocketDirectory, dir, info.Mode().Perm())
 	}
+	return nil
+}
+
+func rejectSocketDirectorySymlinkOrOwner(dir string) error {
+	_, err := socketDirectoryInfo(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func socketDirectoryInfo(dir string) (os.FileInfo, error) {
+	//nolint:gosec // G703: lstat validates the socket parent itself before use.
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("stat socket directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%w: %s is a symlink", ErrInsecureSocketDirectory, dir)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%w: %s is not a directory", ErrInsecureSocketDirectory, dir)
+	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if ok && int(stat.Uid) != os.Getuid() {
-		return fmt.Errorf("%w: %s is owned by uid %d", ErrInsecureSocketDirectory, dir, stat.Uid)
+		return nil, fmt.Errorf("%w: %s is owned by uid %d", ErrInsecureSocketDirectory, dir, stat.Uid)
 	}
-	return nil
+	return info, nil
 }
 
 func Dial(ctx context.Context, path string) (*net.UnixConn, error) {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -46,6 +46,36 @@ func TestListenUnixCreatesDefaultSocketDirectoryPrivate(t *testing.T) {
 	}
 }
 
+func TestListenUnixRejectsSymlinkDefaultSocketDirectoryWithoutChmodTarget(t *testing.T) {
+	home := shortTempDir(t, "agent-secret-home-")
+	t.Setenv("HOME", home)
+	path, err := DefaultSocketPath()
+	if err != nil {
+		t.Fatalf("DefaultSocketPath returned error: %v", err)
+	}
+	target := shortTempDir(t, "agent-secret-socket-target-")
+	if err := os.Chmod(target, 0o755); err != nil { //nolint:gosec // G302: test target is intentionally permissive to prove chmod does not follow the symlink.
+		t.Fatalf("chmod target: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(filepath.Dir(path)), 0o700); err != nil {
+		t.Fatalf("create app support dir: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Dir(path)); err != nil {
+		t.Fatalf("symlink default socket dir: %v", err)
+	}
+
+	listener, err := ListenUnix(path)
+	if listener != nil {
+		_ = listener.Close()
+	}
+	if !errors.Is(err, ErrInsecureSocketDirectory) {
+		t.Fatalf("expected insecure socket directory error, got %v", err)
+	}
+	if got := statMode(t, target); got != 0o755 {
+		t.Fatalf("symlink target mode = %s, want unchanged 0755", got)
+	}
+}
+
 func TestListenUnixAcceptsPrivateCustomSocketParent(t *testing.T) {
 	t.Parallel()
 
@@ -62,6 +92,49 @@ func TestListenUnixAcceptsPrivateCustomSocketParent(t *testing.T) {
 	defer func() { _ = listener.Close() }()
 	if got := statMode(t, dir); got != 0o700 {
 		t.Fatalf("custom socket dir mode changed to %s", got)
+	}
+}
+
+func TestListenUnixRejectsSymlinkCustomSocketParent(t *testing.T) {
+	t.Parallel()
+
+	target := shortTempDir(t, "agent-secret-socket-target-")
+	if err := os.Chmod(target, 0o700); err != nil { //nolint:gosec // G302: custom socket targets are private in this test.
+		t.Fatalf("chmod target: %v", err)
+	}
+	link := filepath.Join(shortTempDir(t, "agent-secret-socket-parent-"), "socket-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink custom socket dir: %v", err)
+	}
+	path := filepath.Join(link, "agent-secretd.sock")
+
+	listener, err := ListenUnix(path)
+	if listener != nil {
+		_ = listener.Close()
+	}
+	if !errors.Is(err, ErrInsecureSocketDirectory) {
+		t.Fatalf("expected insecure socket directory error, got %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(target, "agent-secretd.sock")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("socket in symlink target exists or stat failed: %v", err)
+	}
+}
+
+func TestValidateSocketDirectoryRejectsSymlinkParent(t *testing.T) {
+	t.Parallel()
+
+	target := shortTempDir(t, "agent-secret-socket-target-")
+	if err := os.Chmod(target, 0o700); err != nil { //nolint:gosec // G302: custom socket targets are private in this test.
+		t.Fatalf("chmod target: %v", err)
+	}
+	link := filepath.Join(shortTempDir(t, "agent-secret-socket-parent-"), "socket-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink socket dir: %v", err)
+	}
+
+	err := ValidateSocketDirectory(filepath.Join(link, "agent-secretd.sock"))
+	if !errors.Is(err, ErrInsecureSocketDirectory) {
+		t.Fatalf("expected insecure socket directory error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject symlinked daemon socket parents with lstat-based validation
- avoid chmodding a symlink target when preparing the managed default socket directory
- add daemon socket symlink regression tests for default, custom, and doctor validation paths

Closes #112

## Verification
- mise exec -- go test ./internal/daemon -run 'TestListenUnix|TestValidateSocketDirectory' -count=1
- mise exec -- go test ./internal/daemon -count=1
- mise run lint:go
- mise run test:smoke