### PR TITLE
ASR-029: Bound Go client daemon response frames

### DIFF
--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -24,7 +25,7 @@ func (e *ProtocolError) Error() string {
 type Client struct {
 	conn    *net.UnixConn
 	encoder *json.Encoder
-	decoder *json.Decoder
+	reader  *bufio.Reader
 }
 
 func Connect(ctx context.Context, path string) (*Client, error) {
@@ -58,7 +59,7 @@ func NewClient(conn *net.UnixConn) *Client {
 	return &Client{
 		conn:    conn,
 		encoder: json.NewEncoder(conn),
-		decoder: json.NewDecoder(conn),
+		reader:  bufio.NewReader(conn),
 	}
 }
 
@@ -129,8 +130,8 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 	if err := c.setReadDeadline(ctx); err != nil {
 		return zero, fmt.Errorf("set daemon read deadline %s: %w", messageType, err)
 	}
-	var resp Envelope
-	if err := c.decoder.Decode(&resp); err != nil {
+	resp, err := c.readEnvelope()
+	if err != nil {
 		if ctxErr := contextErrorAfterIOError(ctx, err); ctxErr != nil {
 			return zero, fmt.Errorf("daemon request canceled: %w", ctxErr)
 		}
@@ -163,6 +164,10 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 		return zero, fmt.Errorf("%w: %w", ErrMalformedEnvelope, err)
 	}
 	return out, nil
+}
+
+func (c *Client) readEnvelope() (Envelope, error) {
+	return readEnvelopeFrame(c.reader, DefaultMaxProtocolFrameBytes)
 }
 
 func (c *Client) closeOnContextCancel(ctx context.Context) func() {

--- a/internal/daemon/protocol_test.go
+++ b/internal/daemon/protocol_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -202,12 +203,119 @@ func TestClientRoundTripHonorsContextDeadlineWaitingForResponse(t *testing.T) {
 	}
 }
 
+func TestClientRejectsOversizedDaemonResponseFrame(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := startRespondingDaemonClient(t, func(Envelope) []byte {
+		frame := bytes.Repeat([]byte("x"), int(DefaultMaxProtocolFrameBytes)+1)
+		return append(frame, '\n')
+	})
+	defer cleanup()
+
+	_, err := client.Status(context.Background())
+	if !errors.Is(err, ErrProtocolFrameSize) {
+		t.Fatalf("expected protocol frame size error, got %v", err)
+	}
+}
+
+func TestClientAcceptsBoundedDaemonResponseFrame(t *testing.T) {
+	t.Parallel()
+
+	padding := string(bytes.Repeat([]byte("a"), 512*1024))
+	frame := boundedPaddingResponseFrame(t, padding)
+	client, cleanup := startRespondingDaemonClient(t, func(Envelope) []byte { return frame })
+	defer cleanup()
+
+	got, err := roundTrip[map[string]string](context.Background(), client, TypeDaemonStatus, "", "", nil)
+	if err != nil {
+		t.Fatalf("roundTrip returned error: %v", err)
+	}
+	if got["padding"] != padding {
+		t.Fatalf("padding length = %d, want %d", len(got["padding"]), len(padding))
+	}
+}
+
+func boundedPaddingResponseFrame(t *testing.T, padding string) []byte {
+	t.Helper()
+
+	env, err := NewEnvelope(TypeOK, "", "", map[string]string{"padding": padding})
+	if err != nil {
+		t.Fatalf("NewEnvelope returned error: %v", err)
+	}
+	frame, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if int64(len(frame)+1) > DefaultMaxProtocolFrameBytes {
+		t.Fatalf("test frame size %d exceeds max %d", len(frame)+1, DefaultMaxProtocolFrameBytes)
+	}
+	return append(frame, '\n')
+}
+
 func TestSameUIDValidatorRejectsInspectFailure(t *testing.T) {
 	t.Parallel()
 
 	err := (SameUIDValidator{}).Validate(&net.UnixConn{})
 	if err == nil {
 		t.Fatal("expected invalid unix connection error")
+	}
+}
+
+func startRespondingDaemonClient(t *testing.T, response func(Envelope) []byte) (*Client, func()) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("/tmp", "agent-secret-response-")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // G302: socket tests need an owner-searchable private listener directory.
+		_ = os.RemoveAll(dir)
+		t.Fatalf("secure socket test directory: %v", err)
+	}
+	path := filepath.Join(dir, "daemon.sock")
+	listener, err := ListenUnix(path)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		var env Envelope
+		if err := json.NewDecoder(conn).Decode(&env); err != nil {
+			serverDone <- err
+			return
+		}
+		_, err = conn.Write(response(env))
+		serverDone <- err
+	}()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		_ = listener.Close()
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	client := NewClient(conn)
+
+	return client, func() {
+		_ = client.Close()
+		_ = listener.Close()
+		defer func() { _ = os.RemoveAll(dir) }()
+		select {
+		case err := <-serverDone:
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				t.Fatalf("responding daemon returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("responding daemon did not stop")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the Go daemon client response decoder with the shared bounded newline-frame reader
- keep existing context cancellation and deadline handling around daemon response reads
- add oversized and bounded daemon response frame regression tests

Closes #113

## Verification
- mise exec -- go test ./internal/daemon -run 'TestClientRejectsOversizedDaemonResponseFrame|TestClientAcceptsBoundedDaemonResponseFrame|TestClientRoundTripHonorsContext' -count=1
- mise exec -- go test ./internal/daemon -count=1
- mise run lint:go
- mise run test:smoke