### PR TITLE
ASR-030: Validate correlated daemon error responses

### DIFF
--- a/approver/Sources/AgentSecretApprover/SocketDaemonClient.swift
+++ b/approver/Sources/AgentSecretApprover/SocketDaemonClient.swift
@@ -77,25 +77,33 @@ public final class SocketDaemonClient: ApprovalDaemonClient {
             version: Self.protocolVersion
         )
         try send(request)
-        let response: DaemonEnvelope<EmptyPayload> = try readOKEnvelope()
-        try validateCorrelation(
-            response,
+        let _: DaemonEnvelope<EmptyPayload> = try readOKEnvelope(
             requestID: decision.requestID,
             nonce: decision.nonce
         )
     }
 
-    private func readOKEnvelope<Payload: Codable>() throws -> DaemonEnvelope<Payload> {
+    private func readOKEnvelope<Payload: Codable>(
+        requestID: String? = nil,
+        nonce: String? = nil
+    ) throws -> DaemonEnvelope<Payload> {
         let data: Data = try transport.readLine()
         let header: DaemonHeader = try decoder.decode(DaemonHeader.self, from: data)
         try validateHeader(header)
         if header.type == Self.typeError {
-            throw try daemonError(from: data)
+            let response: DaemonEnvelope<DaemonErrorPayload> = try decoder.decode(
+                DaemonEnvelope<DaemonErrorPayload>.self,
+                from: data
+            )
+            try validateCorrelationIfNeeded(response, requestID: requestID, nonce: nonce)
+            throw daemonError(from: response)
         }
         guard header.type == Self.typeOK else {
             throw SocketDaemonClientError.invalidResponse("unexpected response type \(header.type)")
         }
-        return try decoder.decode(DaemonEnvelope<Payload>.self, from: data)
+        let response: DaemonEnvelope<Payload> = try decoder.decode(DaemonEnvelope<Payload>.self, from: data)
+        try validateCorrelationIfNeeded(response, requestID: requestID, nonce: nonce)
+        return response
     }
 
     private func validateHeader(_ header: DaemonHeader) throws {
@@ -119,11 +127,18 @@ public final class SocketDaemonClient: ApprovalDaemonClient {
         }
     }
 
-    private func daemonError(from data: Data) throws -> SocketDaemonClientError {
-        let response: DaemonEnvelope<DaemonErrorPayload> = try decoder.decode(
-            DaemonEnvelope<DaemonErrorPayload>.self,
-            from: data
-        )
+    private func validateCorrelationIfNeeded(
+        _ response: DaemonEnvelope<some Codable>,
+        requestID: String?,
+        nonce: String?
+    ) throws {
+        guard let requestID, let nonce else {
+            return
+        }
+        try validateCorrelation(response, requestID: requestID, nonce: nonce)
+    }
+
+    private func daemonError(from response: DaemonEnvelope<DaemonErrorPayload>) -> SocketDaemonClientError {
         let payload: DaemonErrorPayload? = response.payload
         let code: String = DaemonErrorDisplay.sanitizedCode(payload?.code)
         return .daemonError(code, DaemonErrorDisplay.message(for: code))

--- a/approver/Tests/AgentSecretApproverTests/SocketDaemonClientErrorCorrelationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/SocketDaemonClientErrorCorrelationTests.swift
@@ -1,0 +1,133 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class SocketDaemonClientErrorCorrelationTests: XCTestCase {
+    private final class MemoryLineTransport: LineTransport {
+        private var reads: [Data]
+
+        init(reads: [Data]) {
+            self.reads = reads
+        }
+
+        func readLine() throws -> Data {
+            guard !reads.isEmpty else {
+                throw SocketDaemonClientError.disconnected
+            }
+            return reads.removeFirst()
+        }
+
+        func writeLine(_: Data) {
+            /* This test transport only needs to satisfy request writes. */
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+
+    private static let expectedProtocolVersion: Int = 1
+    private static let requestID: String = "req_123"
+    private static let staleNonce: String = "nonce_stale"
+    private static let staleRequestID: String = "req_stale"
+
+    private static var sampleDecision: ApprovalDecision {
+        ApprovalDecision(
+            requestID: requestID,
+            nonce: "nonce_456",
+            decision: .approveOnce
+        )
+    }
+
+    private static func errorResponse(
+        requestID: String?,
+        nonce: String?
+    ) throws -> Data {
+        try encode(
+            DaemonEnvelope(
+                nonce: nonce,
+                payload: DaemonErrorPayload(
+                    code: "stale_approval",
+                    message: "stale approval response"
+                ),
+                requestID: requestID,
+                type: "error",
+                version: expectedProtocolVersion
+            )
+        )
+    }
+
+    private static func encode(_ envelope: DaemonEnvelope<some Any>) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(envelope)
+    }
+
+    private func assertInvalidResponse(
+        _ expected: String,
+        _ expression: () throws -> Void
+    ) {
+        XCTAssertThrowsError(try expression()) { error in
+            XCTAssertEqual(error as? SocketDaemonClientError, .invalidResponse(expected))
+        }
+    }
+
+    func testSubmitRejectsMismatchedErrorResponseRequestID() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [
+                    Self.errorResponse(
+                        requestID: Self.staleRequestID,
+                        nonce: Self.sampleDecision.nonce
+                    )
+                ]
+            )
+        )
+
+        assertInvalidResponse("response request id mismatch") {
+            try client.submit(Self.sampleDecision)
+        }
+    }
+
+    func testSubmitRejectsMismatchedErrorResponseNonce() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [
+                    Self.errorResponse(
+                        requestID: Self.requestID,
+                        nonce: Self.staleNonce
+                    )
+                ]
+            )
+        )
+
+        assertInvalidResponse("response nonce mismatch") {
+            try client.submit(Self.sampleDecision)
+        }
+    }
+
+    func testFetchReportsUncorrelatedDaemonErrors() throws {
+        let client = try SocketDaemonClient(
+            transport: MemoryLineTransport(
+                reads: [
+                    Self.errorResponse(
+                        requestID: Self.staleRequestID,
+                        nonce: Self.staleNonce
+                    )
+                ]
+            )
+        )
+
+        XCTAssertThrowsError(try client.fetchPendingRequest()) { error in
+            XCTAssertEqual(
+                error as? SocketDaemonClientError,
+                .daemonError("stale_approval", "stale approval response")
+            )
+        }
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -140,6 +140,9 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 	if err := validateEnvelope(resp); err != nil {
 		return zero, fmt.Errorf("validate daemon response %s: %w", messageType, err)
 	}
+	if err := validateResponseCorrelation(resp, requestID, nonce); err != nil {
+		return zero, err
+	}
 	if resp.Type == TypeError {
 		payload, err := DecodePayload[ErrorPayload](resp)
 		if err != nil {
@@ -150,12 +153,6 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 	if resp.Type != TypeOK {
 		return zero, fmt.Errorf("%w: response type %s", ErrProtocolType, resp.Type)
 	}
-	if requestID != "" && resp.RequestID != requestID {
-		return zero, fmt.Errorf("%w: response request id mismatch", ErrMalformedEnvelope)
-	}
-	if nonce != "" && resp.Nonce != nonce {
-		return zero, ErrInvalidNonce
-	}
 	if len(resp.Payload) == 0 {
 		return zero, nil
 	}
@@ -164,6 +161,16 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 		return zero, fmt.Errorf("%w: %w", ErrMalformedEnvelope, err)
 	}
 	return out, nil
+}
+
+func validateResponseCorrelation(resp Envelope, requestID string, nonce string) error {
+	if requestID != "" && resp.RequestID != requestID {
+		return fmt.Errorf("%w: response request id mismatch", ErrMalformedEnvelope)
+	}
+	if nonce != "" && resp.Nonce != nonce {
+		return ErrInvalidNonce
+	}
+	return nil
 }
 
 func (c *Client) readEnvelope() (Envelope, error) {

--- a/internal/daemon/protocol_test.go
+++ b/internal/daemon/protocol_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -233,6 +234,102 @@ func TestClientAcceptsBoundedDaemonResponseFrame(t *testing.T) {
 	if got["padding"] != padding {
 		t.Fatalf("padding length = %d, want %d", len(got["padding"]), len(padding))
 	}
+}
+
+func TestClientRejectsMismatchedErrorResponseCorrelation(t *testing.T) {
+	t.Parallel()
+
+	execReq := testExecRequest(t, []request.SecretSpec{
+		{Alias: "TOKEN", Ref: "op://Example/Item/token"},
+	})
+	tests := []struct {
+		name       string
+		frame      []byte
+		call       func(context.Context, *Client) error
+		wantErr    error
+		wantErrMsg string
+	}{
+		{
+			name:       "request exec request id",
+			frame:      errorResponseFrame(t, "req_stale", "nonce_1"),
+			wantErr:    ErrMalformedEnvelope,
+			wantErrMsg: "response request id mismatch",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.RequestExec(
+					ctx,
+					"req_1",
+					"nonce_1",
+					execReq,
+				)
+				return err
+			},
+		},
+		{
+			name:    "command started nonce",
+			frame:   errorResponseFrame(t, "req_1", "nonce_stale"),
+			wantErr: ErrInvalidNonce,
+			call: func(ctx context.Context, client *Client) error {
+				return client.ReportStarted(ctx, "req_1", "nonce_1", 1234)
+			},
+		},
+		{
+			name:       "command completed request id",
+			frame:      errorResponseFrame(t, "req_stale", "nonce_1"),
+			wantErr:    ErrMalformedEnvelope,
+			wantErrMsg: "response request id mismatch",
+			call: func(ctx context.Context, client *Client) error {
+				return client.ReportCompleted(ctx, "req_1", "nonce_1", 0, "")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, cleanup := startRespondingDaemonClient(t, func(Envelope) []byte { return tc.frame })
+			defer cleanup()
+
+			err := tc.call(context.Background(), client)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+			if tc.wantErrMsg != "" && !strings.Contains(err.Error(), tc.wantErrMsg) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErrMsg)
+			}
+		})
+	}
+}
+
+func TestClientAllowsUncorrelatedStatusErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := startRespondingDaemonClient(t, func(Envelope) []byte {
+		return errorResponseFrame(t, "req_other", "nonce_other")
+	})
+	defer cleanup()
+
+	_, err := client.Status(context.Background())
+	if !IsProtocolError(err, "bad_request") {
+		t.Fatalf("expected daemon protocol error, got %v", err)
+	}
+}
+
+func errorResponseFrame(t *testing.T, requestID string, nonce string) []byte {
+	t.Helper()
+
+	env, err := NewEnvelope(TypeError, requestID, nonce, ErrorPayload{
+		Code:    "bad_request",
+		Message: "bad request",
+	})
+	if err != nil {
+		t.Fatalf("NewEnvelope returned error: %v", err)
+	}
+	frame, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal error response: %v", err)
+	}
+	return append(frame, '\n')
 }
 
 func boundedPaddingResponseFrame(t *testing.T, padding string) []byte {


### PR DESCRIPTION
## Summary
- validate Go daemon error envelopes against active request ID and nonce before returning protocol errors
- validate Swift approver decision error envelopes before surfacing daemon errors
- add Go and Swift regressions for mismatched error-envelope correlation while preserving uncorrelated status/pending behavior

Closes #114

## Verification
- mise exec -- go test ./internal/daemon -run 'TestClientRejectsMismatchedErrorResponseCorrelation|TestClientAllowsUncorrelatedStatusErrorResponse' -count=1
- mise exec -- swift test --package-path approver --filter 'SocketDaemonClientTests|SocketDaemonClientErrorCorrelationTests'
- mise exec -- go test ./internal/daemon -count=1
- mise run lint:go
- mise run lint:swift
- mise run test
- mise run test:smoke