### PR TITLE
ASR-031: Pin installer production trust roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,18 @@ The unattended installer verifies the DMG checksum, DMG code signature,
 Developer ID Team ID, Gatekeeper assessment, notarization ticket, mounted app
 bundle ID, daemon helper bundle ID, and bundled CLI signature before copying
 anything into place. Maintainer releases are expected to use Team ID
-`B6L7QLWTZW`. For local unsigned test artifacts only, set
-`AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`. For signed but intentionally unstapled
-local artifacts, set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`.
+`B6L7QLWTZW`. Release trust roots such as the GitHub host, repository, Team ID,
+bundle IDs, unsigned mode, and notarization mode are pinned for production
+installs. Local unsigned or intentionally unstapled artifacts require explicit
+development mode with local files:
+
+```bash
+AGENT_SECRET_INSTALL_DEV_MODE=1 \
+AGENT_SECRET_DMG=./dist/Agent-Secret-v0.3.1-macos-arm64.dmg \
+AGENT_SECRET_CHECKSUMS_FILE=./dist/checksums.txt \
+AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1 \
+./install.sh
+```
 
 Unattended uninstall:
 

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -110,12 +110,14 @@ AGENT_SECRET_BIN_DIR="$HOME/.local/bin" install.sh
 AGENT_SECRET_SKILLS_DIR="$HOME/.agents/skills" install.sh
 ```
 
-For local smoke tests, `AGENT_SECRET_DMG` and
-`AGENT_SECRET_CHECKSUMS_FILE` can point at a locally built artifact. Unsigned
-local artifacts must also set `AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`; signed
-but unstapled local artifacts can set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`.
-Maintainer release installs expect Team ID `B6L7QLWTZW` and bundle identifiers
-`com.kovyrin.agent-secret` and `com.kovyrin.agent-secret.daemon`.
+For local smoke tests, set `AGENT_SECRET_INSTALL_DEV_MODE=1` and point
+`AGENT_SECRET_DMG` plus `AGENT_SECRET_CHECKSUMS_FILE` at locally built
+artifacts. Unsigned local artifacts must also set
+`AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`; signed but unstapled local artifacts
+can set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`. Production installs pin the
+GitHub host, repository, Team ID `B6L7QLWTZW`, and bundle identifiers
+`com.kovyrin.agent-secret` and `com.kovyrin.agent-secret.daemon`; overriding
+those release trust roots requires development mode and local artifacts.
 
 ### Upgrade
 

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,66 @@
 #!/bin/sh
 set -eu
 
-repo="${AGENT_SECRET_REPO:-kovyrin/agent-secret}"
-github_url="${AGENT_SECRET_GITHUB_URL:-https://github.com}"
-github_api="${AGENT_SECRET_GITHUB_API:-https://api.github.com}"
+die() {
+  echo "agent-secret install: $*" >&2
+  exit 1
+}
+
+env_is_set() {
+  eval "[ \"\${$1+x}\" = x ]"
+}
+
+require_dev_mode_for_env() {
+  name="$1"
+  if [ "$install_dev_mode" != "1" ] && env_is_set "$name"; then
+    die "$name requires AGENT_SECRET_INSTALL_DEV_MODE=1"
+  fi
+}
+
+production_repo="kovyrin/agent-secret"
+production_github_url="https://github.com"
+production_github_api="https://api.github.com"
+production_expected_team_id="B6L7QLWTZW"
+production_expected_app_bundle_id="com.kovyrin.agent-secret"
+production_expected_daemon_bundle_id="com.kovyrin.agent-secret.daemon"
+
+install_dev_mode="${AGENT_SECRET_INSTALL_DEV_MODE:-0}"
+case "$install_dev_mode" in
+  0 | 1) ;;
+  *)
+    die "AGENT_SECRET_INSTALL_DEV_MODE must be 0 or 1"
+    ;;
+esac
+
+repo="$production_repo"
+github_url="$production_github_url"
+github_api="$production_github_api"
+allow_unsigned_install=0
+require_notarization=1
+expected_team_id="$production_expected_team_id"
+expected_app_bundle_id="$production_expected_app_bundle_id"
+expected_daemon_bundle_id="$production_expected_daemon_bundle_id"
+
+if [ "$install_dev_mode" != "1" ]; then
+  require_dev_mode_for_env AGENT_SECRET_REPO
+  require_dev_mode_for_env AGENT_SECRET_GITHUB_URL
+  require_dev_mode_for_env AGENT_SECRET_GITHUB_API
+  require_dev_mode_for_env AGENT_SECRET_ALLOW_UNSIGNED_INSTALL
+  require_dev_mode_for_env AGENT_SECRET_REQUIRE_NOTARIZATION
+  require_dev_mode_for_env AGENT_SECRET_EXPECTED_TEAM_ID
+  require_dev_mode_for_env AGENT_SECRET_EXPECTED_APP_BUNDLE_ID
+  require_dev_mode_for_env AGENT_SECRET_EXPECTED_DAEMON_BUNDLE_ID
+else
+  repo="${AGENT_SECRET_REPO:-$production_repo}"
+  github_url="${AGENT_SECRET_GITHUB_URL:-$production_github_url}"
+  github_api="${AGENT_SECRET_GITHUB_API:-$production_github_api}"
+  allow_unsigned_install="${AGENT_SECRET_ALLOW_UNSIGNED_INSTALL:-0}"
+  require_notarization="${AGENT_SECRET_REQUIRE_NOTARIZATION:-1}"
+  expected_team_id="${AGENT_SECRET_EXPECTED_TEAM_ID:-$production_expected_team_id}"
+  expected_app_bundle_id="${AGENT_SECRET_EXPECTED_APP_BUNDLE_ID:-$production_expected_app_bundle_id}"
+  expected_daemon_bundle_id="${AGENT_SECRET_EXPECTED_DAEMON_BUNDLE_ID:-$production_expected_daemon_bundle_id}"
+fi
+
 app_dir="${AGENT_SECRET_APP_DIR:-/Applications}"
 bin_dir="${AGENT_SECRET_BIN_DIR:-$HOME/.local/bin}"
 skills_dir="${AGENT_SECRET_SKILLS_DIR:-$HOME/.agents/skills}"
@@ -11,11 +68,12 @@ version="${AGENT_SECRET_VERSION:-}"
 local_dmg="${AGENT_SECRET_DMG:-}"
 local_checksums="${AGENT_SECRET_CHECKSUMS_FILE:-}"
 no_stop_daemon="${AGENT_SECRET_NO_STOP_DAEMON:-0}"
-allow_unsigned_install="${AGENT_SECRET_ALLOW_UNSIGNED_INSTALL:-0}"
-require_notarization="${AGENT_SECRET_REQUIRE_NOTARIZATION:-1}"
-expected_team_id="${AGENT_SECRET_EXPECTED_TEAM_ID:-B6L7QLWTZW}"
-expected_app_bundle_id="${AGENT_SECRET_EXPECTED_APP_BUNDLE_ID:-com.kovyrin.agent-secret}"
-expected_daemon_bundle_id="${AGENT_SECRET_EXPECTED_DAEMON_BUNDLE_ID:-com.kovyrin.agent-secret.daemon}"
+
+if [ "$install_dev_mode" = "1" ]; then
+  echo "agent-secret install: development installer mode enabled" >&2
+  [ -n "$local_dmg" ] || die "AGENT_SECRET_INSTALL_DEV_MODE=1 requires AGENT_SECRET_DMG"
+  [ -n "$local_checksums" ] || die "AGENT_SECRET_INSTALL_DEV_MODE=1 requires AGENT_SECRET_CHECKSUMS_FILE"
+fi
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-install.XXXXXX")"
 mount_dir="$tmp_dir/mount"
@@ -28,11 +86,6 @@ cleanup() {
   rm -rf "$tmp_dir"
 }
 trap cleanup EXIT HUP INT TERM
-
-die() {
-  echo "agent-secret install: $*" >&2
-  exit 1
-}
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -272,8 +272,25 @@ test_wrong_daemon_bundle_id_stops_install() {
   fi
 }
 
-test_unsigned_override_skips_identity_checks() {
+test_trust_root_overrides_require_dev_mode() {
+  if run_installer expected-team-override AGENT_SECRET_EXPECTED_TEAM_ID=BADTEAM123; then
+    fail "installer accepted expected Team ID override without dev mode"
+  fi
+  if run_installer expected-app-bundle-override \
+    AGENT_SECRET_EXPECTED_APP_BUNDLE_ID=com.example.not-agent-secret; then
+    fail "installer accepted expected app bundle override without dev mode"
+  fi
+  if run_installer github-url-override AGENT_SECRET_GITHUB_URL=https://example.invalid; then
+    fail "installer accepted GitHub URL override without dev mode"
+  fi
+  if run_installer unsigned-without-dev-mode AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1; then
+    fail "installer accepted unsigned override without dev mode"
+  fi
+}
+
+test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts() {
   run_installer unsigned-allowed \
+    AGENT_SECRET_INSTALL_DEV_MODE=1 \
     AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1 \
     AGENT_SECRET_INSTALL_TEST_CODESIGN_STATUS=23 \
     AGENT_SECRET_INSTALL_TEST_SPCTL_STATUS=23 \
@@ -292,6 +309,7 @@ test_identity_failure_stops_install
 test_wrong_team_id_stops_install
 test_wrong_app_bundle_id_stops_install
 test_wrong_daemon_bundle_id_stops_install
-test_unsigned_override_skips_identity_checks
+test_trust_root_overrides_require_dev_mode
+test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts
 
 echo "test-install: ok"


### PR DESCRIPTION
## Summary
- pin production installer trust roots for repo, GitHub host/API, Team ID, bundle IDs, unsigned mode, and notarization mode
- require AGENT_SECRET_INSTALL_DEV_MODE=1 plus local DMG/checksums before trust-root overrides or unsigned local installs are allowed
- expand installer tests and docs for the explicit development mode

Closes #115

## Verification
- AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
- AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh
- npx --yes markdownlint-cli README.md docs/macos-distribution-plan.md
- mise run lint:shell
- mise run lint
- mise run test:smoke