### PR TITLE
ASR-032: Bind account environment defaults into exec requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,12 +263,13 @@ the command path even when it was left behind as an older regular binary.
 By default, `agent-secret` uses the personal 1Password sign-in address
 `my.1password.com`. Set `OP_ACCOUNT` or `AGENT_SECRET_1PASSWORD_ACCOUNT` in the
 shell that will run `agent-secret exec` only when you want to force a specific
-account; the daemon inherits that value when it auto-starts. Project config can
-also set `account` globally, per profile, or per secret, and those config values
-take precedence for the affected secret refs. On macOS, `agent-secret` starts
-the daemon through the nested `AgentSecretDaemon.app` inside `Agent Secret.app`
-so 1Password sees the SDK caller as Agent Secret instead of the terminal or
-agent desktop app that launched the CLI.
+account; the CLI binds that account into the approval request so already-running
+daemons resolve the same account the approver sees. Project config can also set
+`account` globally, per profile, or per secret, and those config values take
+precedence for the affected secret refs. On macOS, `agent-secret` starts the
+daemon through the nested `AgentSecretDaemon.app` inside `Agent Secret.app` so
+1Password sees the SDK caller as Agent Secret instead of the terminal or agent
+desktop app that launched the CLI.
 
 Local release artifact build:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,9 @@ Agent Secret chooses the account for each secret independently:
 
 The account is part of the secret identity used for resolution, reusable
 approval matching, and in-memory caching. The same `op://` reference in two
-different accounts is treated as two different secrets.
+different accounts is treated as two different secrets. Environment and built-in
+defaults are bound into each exec request so the approval UI, audit event, reuse
+key, and resolver use the same account scope.
 
 ## Exec Command Options
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kovyrin/agent-secret/internal/envfile"
 	"github.com/kovyrin/agent-secret/internal/install"
+	"github.com/kovyrin/agent-secret/internal/opresolver"
 	"github.com/kovyrin/agent-secret/internal/profileconfig"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
@@ -346,16 +347,17 @@ func (p Parser) parseExec(args []string) (Command, error) {
 		return Command{}, missingOnlyError(remainingOnly)
 	}
 
+	accountFallback := execAccountFallback(*account)
 	var effectiveSecrets []request.SecretSpec
 	if loadedProfile {
-		profileSecrets = applyDefaultAccount(profileSecrets, *account)
+		profileSecrets = applyDefaultAccount(profileSecrets, accountFallback)
 		cliAccount := profile.Account
 		if strings.TrimSpace(cliAccount) == "" {
-			cliAccount = *account
+			cliAccount = accountFallback
 		}
 		effectiveSecrets = append(slices.Clone(profileSecrets), applyDefaultAccount(append(slices.Clone(secrets.specs), envFileSecrets...), cliAccount)...)
 	} else {
-		effectiveSecrets = append(applyDefaultAccount(slices.Clone(secrets.specs), *account), applyDefaultAccount(envFileSecrets, *account)...)
+		effectiveSecrets = append(applyDefaultAccount(slices.Clone(secrets.specs), accountFallback), applyDefaultAccount(envFileSecrets, accountFallback)...)
 	}
 
 	req, err := request.NewExec(request.ExecOptions{
@@ -414,6 +416,19 @@ func applyDefaultAccount(secrets []request.SecretSpec, account string) []request
 		updated = append(updated, secret)
 	}
 	return updated
+}
+
+func execAccountFallback(cliAccount string) string {
+	if account := strings.TrimSpace(cliAccount); account != "" {
+		return account
+	}
+	if account := strings.TrimSpace(os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT")); account != "" {
+		return account
+	}
+	if account := strings.TrimSpace(os.Getenv("OP_ACCOUNT")); account != "" {
+		return account
+	}
+	return opresolver.DefaultDesktopAccount
 }
 
 func newOnlySet(aliases []string) map[string]struct{} {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kovyrin/agent-secret/internal/opresolver"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
 
@@ -387,6 +388,96 @@ func TestParseExecAccountAppliesToExplicitAndEnvFileSecrets(t *testing.T) {
 	}
 }
 
+func TestParseExecAccountAppliesAgentSecretEnvironmentDefault(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	writeExecutable(t, binDir, "tool")
+	t.Chdir(root)
+	t.Setenv("PATH", binDir)
+	t.Setenv("OP_ACCOUNT", " Personal ")
+	t.Setenv("AGENT_SECRET_1PASSWORD_ACCOUNT", " Work ")
+	parser := NewParser(func() time.Time { return time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC) })
+
+	command, err := parser.Parse([]string{
+		"exec",
+		"--reason", "Environment account",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--allow-mutable-executable",
+		"--",
+		"tool",
+	})
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	req := command.ExecRequest
+	if len(req.Secrets) != 1 || req.Secrets[0].Account != "Work" {
+		t.Fatalf("secrets = %+v, want AGENT_SECRET_1PASSWORD_ACCOUNT default", req.Secrets)
+	}
+}
+
+func TestParseExecAccountFallsBackToOPAccountEnvironment(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	writeExecutable(t, binDir, "tool")
+	t.Chdir(root)
+	t.Setenv("PATH", binDir)
+	t.Setenv("OP_ACCOUNT", " Personal ")
+	parser := NewParser(func() time.Time { return time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC) })
+
+	command, err := parser.Parse([]string{
+		"exec",
+		"--reason", "OP account",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--allow-mutable-executable",
+		"--",
+		"tool",
+	})
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	req := command.ExecRequest
+	if len(req.Secrets) != 1 || req.Secrets[0].Account != "Personal" {
+		t.Fatalf("secrets = %+v, want OP_ACCOUNT default", req.Secrets)
+	}
+}
+
+func TestParseExecAccountRecordsBuiltInDefault(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	writeExecutable(t, binDir, "tool")
+	t.Chdir(root)
+	t.Setenv("PATH", binDir)
+	parser := NewParser(func() time.Time { return time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC) })
+
+	command, err := parser.Parse([]string{
+		"exec",
+		"--reason", "Default account",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--allow-mutable-executable",
+		"--",
+		"tool",
+	})
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	req := command.ExecRequest
+	if len(req.Secrets) != 1 || req.Secrets[0].Account != opresolver.DefaultDesktopAccount {
+		t.Fatalf("secrets = %+v, want built-in default account", req.Secrets)
+	}
+}
+
 func TestParseExecAccountPrecedenceInCombinedSources(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")
@@ -711,8 +802,8 @@ profiles:
 	if len(req.Secrets) != 1 || req.Secrets[0].Alias != "TOKEN" {
 		t.Fatalf("default profile leaked into explicit secret request: %+v", req.Secrets)
 	}
-	if req.Secrets[0].Account != "" {
-		t.Fatalf("default account leaked into explicit secret request: %+v", req.Secrets)
+	if req.Secrets[0].Account != opresolver.DefaultDesktopAccount {
+		t.Fatalf("secret account = %q, want built-in default", req.Secrets[0].Account)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #120.

- resolves CLI/account-environment/built-in account fallback before building exec requests
- serializes the resolved account into explicit and env-file secret refs so approval, audit, reuse, and daemon resolution agree
- updates docs to describe request-bound account defaults
- adds parser coverage for `AGENT_SECRET_1PASSWORD_ACCOUNT`, `OP_ACCOUNT`, and built-in default behavior

## Verification

- `mise exec -- go test ./internal/cli`
- `npx --yes markdownlint-cli README.md docs/configuration.md`
- `mise exec -- go test ./...`
- `mise exec -- go test -race ./...`
- `mise run build`
- `git diff --check`

Note: local `mise run lint` repeatedly hit the pre-existing `TestProcessApproverLauncherHealthCheck` timeout during the coverage phase; the same daemon test passes focused and under race. I will follow CI and address if it reproduces there.
