### PR TITLE
ASR-033: Guard custom install and uninstall destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ AGENT_SECRET_VERSION=v0.3.1
 AGENT_SECRET_APP_DIR="$HOME/Applications"
 AGENT_SECRET_BIN_DIR="$HOME/.local/bin"
 AGENT_SECRET_SKILLS_DIR="$HOME/.agents/skills"
+AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1
 ```
 
 The unattended installer verifies the DMG checksum, DMG code signature,
@@ -235,9 +236,10 @@ curl -fsSL \
 By default uninstall removes the app, CLI symlink, skill symlink, and known
 application support files, but leaves `~/Library/Logs/agent-secret` audit logs
 in place. Set `AGENT_SECRET_REMOVE_AUDIT_LOGS=1` to remove those logs too.
-Custom support or audit paths require
+Custom app, command, skill, support, or audit paths require
 `AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1`; the script refuses broad,
-relative, symlinked, or non-`agent-secret` directory targets.
+relative, or symlinked destination roots, and support/audit paths must end in
+`agent-secret`.
 
 ## Development Install
 

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -108,6 +108,7 @@ AGENT_SECRET_VERSION=v0.3.1 install.sh
 AGENT_SECRET_APP_DIR="$HOME/Applications" install.sh
 AGENT_SECRET_BIN_DIR="$HOME/.local/bin" install.sh
 AGENT_SECRET_SKILLS_DIR="$HOME/.agents/skills" install.sh
+AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1 install.sh
 ```
 
 For local smoke tests, set `AGENT_SECRET_INSTALL_DEV_MODE=1` and point
@@ -118,6 +119,9 @@ can set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`. Production installs pin the
 GitHub host, repository, Team ID `B6L7QLWTZW`, and bundle identifiers
 `com.kovyrin.agent-secret` and `com.kovyrin.agent-secret.daemon`; overriding
 those release trust roots requires development mode and local artifacts.
+Custom app, command, or skill destination roots require
+`AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1` and are rejected when empty,
+relative, broad, or symlinked.
 
 ### Upgrade
 
@@ -174,7 +178,9 @@ AGENT_SECRET_REMOVE_AUDIT_LOGS=1 uninstall.sh
 For isolated tests, `AGENT_SECRET_SUPPORT_DIR` and `AGENT_SECRET_AUDIT_DIR`
 may point at temporary `agent-secret` directories only when
 `AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1` is also set. The script refuses
-empty, relative, broad, symlinked, and non-`agent-secret` directory targets.
+empty, relative, broad, symlinked, and non-`agent-secret` support or audit
+directory targets. The same custom-path guard applies to app, command, and
+skill destination roots.
 
 Audit logs are durable by design and should require an explicit separate
 removal command:

--- a/install.sh
+++ b/install.sh
@@ -17,12 +17,80 @@ require_dev_mode_for_env() {
   fi
 }
 
+strip_trailing_slashes() {
+  value="$1"
+  while [ "$value" != "/" ] && [ "${value%/}" != "$value" ]; do
+    value="${value%/}"
+  done
+  printf '%s\n' "$value"
+}
+
+require_custom_install_path_guard() {
+  label="$1"
+  path="$2"
+  default_path="$3"
+
+  if [ "$path" = "$default_path" ]; then
+    return
+  fi
+  if [ "$allow_custom_install_paths" = "1" ]; then
+    return
+  fi
+
+  die "$label path override requires AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1: $path"
+}
+
+validate_install_dir() {
+  label="$1"
+  path="$(strip_trailing_slashes "$2")"
+  default_path="$(strip_trailing_slashes "$3")"
+
+  require_custom_install_path_guard "$label" "$path" "$default_path"
+
+  if [ "$path" = "" ]; then
+    die "$label path is empty"
+  fi
+  case "$path" in
+    /*) ;;
+    *)
+      die "$label path must be absolute: $path"
+      ;;
+  esac
+  case "$path" in
+    "/" | "$HOME")
+      die "$label path is too broad: $path"
+      ;;
+    */../* | */.. | */./* | */.)
+      die "$label path must not contain dot segments: $path"
+      ;;
+  esac
+  if [ -L "$path" ]; then
+    die "$label path must not be a symlink: $path"
+  fi
+  if [ -e "$path" ] && [ ! -d "$path" ]; then
+    die "$label path is not a directory: $path"
+  fi
+}
+
+validate_install_paths() {
+  validate_install_dir "app" "$app_dir" "$default_app_dir"
+  validate_install_dir "bin" "$bin_dir" "$default_bin_dir"
+  validate_install_dir "skills" "$skills_dir" "$default_skills_dir"
+
+  app_dir="$(strip_trailing_slashes "$app_dir")"
+  bin_dir="$(strip_trailing_slashes "$bin_dir")"
+  skills_dir="$(strip_trailing_slashes "$skills_dir")"
+}
+
 production_repo="kovyrin/agent-secret"
 production_github_url="https://github.com"
 production_github_api="https://api.github.com"
 production_expected_team_id="B6L7QLWTZW"
 production_expected_app_bundle_id="com.kovyrin.agent-secret"
 production_expected_daemon_bundle_id="com.kovyrin.agent-secret.daemon"
+default_app_dir="/Applications"
+default_bin_dir="$HOME/.local/bin"
+default_skills_dir="$HOME/.agents/skills"
 
 install_dev_mode="${AGENT_SECRET_INSTALL_DEV_MODE:-0}"
 case "$install_dev_mode" in
@@ -61,13 +129,23 @@ else
   expected_daemon_bundle_id="${AGENT_SECRET_EXPECTED_DAEMON_BUNDLE_ID:-$production_expected_daemon_bundle_id}"
 fi
 
-app_dir="${AGENT_SECRET_APP_DIR:-/Applications}"
-bin_dir="${AGENT_SECRET_BIN_DIR:-$HOME/.local/bin}"
-skills_dir="${AGENT_SECRET_SKILLS_DIR:-$HOME/.agents/skills}"
+app_dir="${AGENT_SECRET_APP_DIR:-$default_app_dir}"
+bin_dir="${AGENT_SECRET_BIN_DIR:-$default_bin_dir}"
+skills_dir="${AGENT_SECRET_SKILLS_DIR:-$default_skills_dir}"
 version="${AGENT_SECRET_VERSION:-}"
 local_dmg="${AGENT_SECRET_DMG:-}"
 local_checksums="${AGENT_SECRET_CHECKSUMS_FILE:-}"
 no_stop_daemon="${AGENT_SECRET_NO_STOP_DAEMON:-0}"
+allow_custom_install_paths="${AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS:-0}"
+
+case "$allow_custom_install_paths" in
+  0 | 1) ;;
+  *)
+    die "AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS must be 0 or 1"
+    ;;
+esac
+
+validate_install_paths
 
 if [ "$install_dev_mode" = "1" ]; then
   echo "agent-secret install: development installer mode enabled" >&2

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -208,6 +208,7 @@ run_installer() {
     AGENT_SECRET_APP_DIR="$run_dir/apps" \
     AGENT_SECRET_BIN_DIR="$run_dir/bin-dir" \
     AGENT_SECRET_SKILLS_DIR="$run_dir/skills" \
+    AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1 \
     AGENT_SECRET_NO_STOP_DAEMON=1 \
     AGENT_SECRET_INSTALL_TEST_LOG="$log" \
     "$@" \
@@ -288,6 +289,30 @@ test_trust_root_overrides_require_dev_mode() {
   fi
 }
 
+test_destination_overrides_require_guard() {
+  if run_installer destination-guard AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=0; then
+    fail "installer accepted custom destination overrides without guard"
+  fi
+  if grep -F "ditto " "$tmp_dir/destination-guard/tools.log" >/dev/null; then
+    fail "installer copied an app before rejecting unguarded custom destinations"
+  fi
+}
+
+test_destination_validation_rejects_bad_paths() {
+  local target="$tmp_dir/symlink-target"
+  local link="$tmp_dir/symlink-app-dir"
+
+  mkdir -p "$target"
+  ln -s "$target" "$link"
+
+  if run_installer relative-app-dir AGENT_SECRET_APP_DIR=relative-apps; then
+    fail "installer accepted a relative app destination"
+  fi
+  if run_installer symlink-app-dir AGENT_SECRET_APP_DIR="$link"; then
+    fail "installer accepted a symlinked app destination"
+  fi
+}
+
 test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts() {
   run_installer unsigned-allowed \
     AGENT_SECRET_INSTALL_DEV_MODE=1 \
@@ -310,6 +335,8 @@ test_wrong_team_id_stops_install
 test_wrong_app_bundle_id_stops_install
 test_wrong_daemon_bundle_id_stops_install
 test_trust_root_overrides_require_dev_mode
+test_destination_overrides_require_guard
+test_destination_validation_rejects_bad_paths
 test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts
 
 echo "test-install: ok"

--- a/scripts/test-uninstall.sh
+++ b/scripts/test-uninstall.sh
@@ -68,6 +68,23 @@ custom_guard_rejects_override() {
   fi
 }
 
+custom_destination_guard_rejects_override() {
+  local run_dir="$tmp_dir/custom-destination-guard"
+  local app_dir="$run_dir/apps"
+  local app="$app_dir/Agent Secret.app"
+  mkdir -p "$app"
+  printf 'keep\n' >"$app/keep.txt"
+
+  expect_failure \
+    custom-destination-guard \
+    "app path override requires AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1" \
+    AGENT_SECRET_APP_DIR="$app_dir"
+
+  if [ ! -f "$app/keep.txt" ]; then
+    fail "custom app override removed data without guard"
+  fi
+}
+
 dangerous_paths_are_rejected_even_with_guard() {
   local run_dir="$tmp_dir/dangerous"
   local home="$run_dir/home"
@@ -93,6 +110,26 @@ dangerous_paths_are_rejected_even_with_guard() {
   if [ ! -f "$home/keep.txt" ]; then
     fail "dangerous home path was modified"
   fi
+}
+
+dangerous_destination_paths_are_rejected_even_with_guard() {
+  local run_dir="$tmp_dir/dangerous-destinations"
+  local target="$run_dir/target"
+  local link="$run_dir/skills-link"
+  mkdir -p "$target"
+  make_symlink "$target" "$link"
+
+  expect_failure \
+    dangerous-destination-relative \
+    "bin path must be absolute" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_BIN_DIR=relative-bin
+
+  expect_failure \
+    dangerous-destination-symlink \
+    "skills path must not be a symlink" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_SKILLS_DIR="$link"
 }
 
 symlinked_dirs_are_rejected() {
@@ -157,7 +194,9 @@ safe_custom_paths_remove_only_known_files() {
 }
 
 custom_guard_rejects_override
+custom_destination_guard_rejects_override
 dangerous_paths_are_rejected_even_with_guard
+dangerous_destination_paths_are_rejected_even_with_guard
 symlinked_dirs_are_rejected
 safe_custom_paths_remove_only_known_files
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
 set -eu
 
-app_dir="${AGENT_SECRET_APP_DIR:-/Applications}"
-bin_dir="${AGENT_SECRET_BIN_DIR:-$HOME/.local/bin}"
-skills_dir="${AGENT_SECRET_SKILLS_DIR:-$HOME/.agents/skills}"
+default_app_dir="/Applications"
+default_bin_dir="$HOME/.local/bin"
+default_skills_dir="$HOME/.agents/skills"
+app_dir="${AGENT_SECRET_APP_DIR:-$default_app_dir}"
+bin_dir="${AGENT_SECRET_BIN_DIR:-$default_bin_dir}"
+skills_dir="${AGENT_SECRET_SKILLS_DIR:-$default_skills_dir}"
 remove_audit_logs="${AGENT_SECRET_REMOVE_AUDIT_LOGS:-0}"
 no_stop_daemon="${AGENT_SECRET_NO_STOP_DAEMON:-0}"
 allow_custom_uninstall_paths="${AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS:-0}"
 default_support_dir="$HOME/Library/Application Support/agent-secret"
 default_audit_dir="$HOME/Library/Logs/agent-secret"
 
-target_app="$app_dir/Agent Secret.app"
-cli_link="$bin_dir/agent-secret"
-skill_link="$skills_dir/agent-secret"
 app_support_dir="${AGENT_SECRET_SUPPORT_DIR-$default_support_dir}"
 audit_dir="${AGENT_SECRET_AUDIT_DIR-$default_audit_dir}"
 
@@ -138,6 +138,39 @@ validate_agent_secret_dir() {
   fi
 }
 
+validate_destination_dir() {
+  label="$1"
+  path="$(strip_trailing_slashes "$2")"
+  default_path="$(strip_trailing_slashes "$3")"
+
+  require_custom_path_guard "$label" "$path" "$default_path"
+
+  if [ "$path" = "" ]; then
+    fail "$label path is empty"
+  fi
+  case "$path" in
+    /*) ;;
+    *)
+      fail "$label path must be absolute: $path"
+      ;;
+  esac
+  case "$path" in
+    "/" | "$HOME")
+      fail "$label path is too broad: $path"
+      ;;
+    */../* | */.. | */./* | */.)
+      fail "$label path must not contain dot segments: $path"
+      ;;
+  esac
+
+  if [ -L "$path" ]; then
+    fail "$label path must not be a symlink: $path"
+  fi
+  if [ -e "$path" ] && [ ! -d "$path" ]; then
+    fail "$label path is not a directory: $path"
+  fi
+}
+
 remove_known_support_dir() {
   validate_agent_secret_dir "support" "$app_support_dir" "$default_support_dir"
 
@@ -165,13 +198,23 @@ remove_known_audit_dir() {
 }
 
 validate_uninstall_paths() {
+  validate_destination_dir "app" "$app_dir" "$default_app_dir"
+  validate_destination_dir "bin" "$bin_dir" "$default_bin_dir"
+  validate_destination_dir "skills" "$skills_dir" "$default_skills_dir"
   validate_agent_secret_dir "support" "$app_support_dir" "$default_support_dir"
   if [ "$remove_audit_logs" = "1" ]; then
     validate_agent_secret_dir "audit" "$audit_dir" "$default_audit_dir"
   fi
+
+  app_dir="$(strip_trailing_slashes "$app_dir")"
+  bin_dir="$(strip_trailing_slashes "$bin_dir")"
+  skills_dir="$(strip_trailing_slashes "$skills_dir")"
 }
 
 validate_uninstall_paths
+target_app="$app_dir/Agent Secret.app"
+cli_link="$bin_dir/agent-secret"
+skill_link="$skills_dir/agent-secret"
 stop_existing_daemon
 remove_cli_link
 remove_skill_link


### PR DESCRIPTION
## Summary

Fixes #121.

- requires explicit custom-path opt-ins for non-default install and uninstall roots
- validates app/bin/skill destination roots before mutation
- extends uninstall destination validation beyond support/audit paths
- updates install/uninstall docs and shell smoke tests

## Verification

- `AGENT_SECRET_IN_MISE=1 scripts/test-install.sh`
- `AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh`
- `mise run test:smoke`
- `mise exec -- shellcheck install.sh uninstall.sh scripts/test-install.sh scripts/test-uninstall.sh`
- `mise exec -- scripts/check-format.sh shell`
- `npx --yes markdownlint-cli README.md docs/macos-distribution-plan.md`
- `git diff --check`
