### PR TITLE
ASR-034: Treat user-owned executables as mutable

### DIFF
--- a/internal/fileidentity/identity_test.go
+++ b/internal/fileidentity/identity_test.go
@@ -79,6 +79,21 @@ func TestValidateStableExecutableRejectsCurrentUserWritableFile(t *testing.T) {
 	}
 }
 
+func TestValidateStableExecutableRejectsCurrentUserOwnedReadOnlyFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecutable(t, path, "exit 0\n")
+	if err := os.Chmod(path, 0o555); err != nil { //nolint:gosec // G302: stability test needs executable permissions without owner write.
+		t.Fatalf("chmod executable: %v", err)
+	}
+
+	err := ValidateStableExecutable(path)
+	if !errors.Is(err, ErrMutable) {
+		t.Fatalf("ValidateStableExecutable error = %v, want %v", err, ErrMutable)
+	}
+}
+
 func TestValidateStableExecutableRejectsCurrentUserWritableParent(t *testing.T) {
 	t.Parallel()
 
@@ -87,6 +102,34 @@ func TestValidateStableExecutableRejectsCurrentUserWritableParent(t *testing.T) 
 	if err := os.Chmod(path, 0o555); err != nil { //nolint:gosec // G302: stability test needs executable permissions without owner write.
 		t.Fatalf("chmod executable: %v", err)
 	}
+
+	err := ValidateStableExecutable(path)
+	if !errors.Is(err, ErrMutable) {
+		t.Fatalf("ValidateStableExecutable error = %v, want %v", err, ErrMutable)
+	}
+}
+
+func TestValidateStableExecutableRejectsCurrentUserOwnedReadOnlyParent(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "darwin" {
+		t.Skip("system executable symlink fixture is macOS-specific")
+	}
+	root := t.TempDir()
+	dir := filepath.Join(root, "bin")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatalf("mkdir executable dir: %v", err)
+	}
+	path := filepath.Join(dir, "sh")
+	if err := os.Symlink("/bin/sh", path); err != nil {
+		t.Fatalf("symlink executable: %v", err)
+	}
+	if err := os.Chmod(dir, 0o550); err != nil { //nolint:gosec // G302: stability test needs executable permissions without owner write.
+		t.Fatalf("chmod executable parent: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(dir, 0o750) //nolint:gosec // G302: restore temp fixture permissions for cleanup.
+	})
 
 	err := ValidateStableExecutable(path)
 	if !errors.Is(err, ErrMutable) {

--- a/internal/fileidentity/stability_unix.go
+++ b/internal/fileidentity/stability_unix.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 var ErrMutable = errors.New("mutable executable identity")
@@ -18,8 +19,8 @@ func ValidateStableExecutable(path string) error {
 	if err != nil {
 		return fmt.Errorf("stat executable %q: %w", path, err)
 	}
-	if writableByCurrentUser(info, false) {
-		return fmt.Errorf("%w: executable %q is writable by the current user", ErrMutable, path)
+	if mutableByCurrentUser(path, info, false) {
+		return fmt.Errorf("%w: executable %q is mutable by the current user", ErrMutable, path)
 	}
 
 	for dir := filepath.Dir(path); ; dir = filepath.Dir(dir) {
@@ -27,8 +28,8 @@ func ValidateStableExecutable(path string) error {
 		if err != nil {
 			return fmt.Errorf("stat executable parent %q: %w", dir, err)
 		}
-		if writableByCurrentUser(info, true) {
-			return fmt.Errorf("%w: executable parent directory %q is writable by the current user", ErrMutable, dir)
+		if mutableByCurrentUser(dir, info, true) {
+			return fmt.Errorf("%w: executable parent directory %q is mutable by the current user", ErrMutable, dir)
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -37,42 +38,19 @@ func ValidateStableExecutable(path string) error {
 	}
 }
 
-func writableByCurrentUser(info os.FileInfo, requireSearch bool) bool {
+func mutableByCurrentUser(path string, info os.FileInfo, requireSearch bool) bool {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
 		return true
 	}
 
-	mode := info.Mode().Perm()
-	uid := os.Getuid()
-	gids := currentGroups()
+	if int64(stat.Uid) == int64(os.Getuid()) {
+		return true
+	}
 
-	if int64(stat.Uid) == int64(uid) {
-		return modeAllowsWrite(mode, 0o200, 0o100, requireSearch)
+	mode := uint32(unix.W_OK)
+	if requireSearch {
+		mode |= unix.X_OK
 	}
-	if slices.ContainsFunc(gids, func(gid int) bool { return int64(stat.Gid) == int64(gid) }) {
-		return modeAllowsWrite(mode, 0o020, 0o010, requireSearch)
-	}
-	return modeAllowsWrite(mode, 0o002, 0o001, requireSearch)
-}
-
-func currentGroups() []int {
-	groups, err := os.Getgroups()
-	if err != nil {
-		return nil
-	}
-	out := make([]int, 0, len(groups))
-	for _, group := range groups {
-		if group >= 0 {
-			out = append(out, group)
-		}
-	}
-	return out
-}
-
-func modeAllowsWrite(mode os.FileMode, write os.FileMode, search os.FileMode, requireSearch bool) bool {
-	if mode&write == 0 {
-		return false
-	}
-	return !requireSearch || mode&search != 0
+	return unix.Access(path, mode) == nil
 }


### PR DESCRIPTION
## Summary

Fixes #122.

- treats any current-user-owned executable or parent directory as mutable even when POSIX write bits are currently unset
- uses `access(2)` for non-owner write/search authority so ACL/group/other write paths remain covered
- adds regressions for read-only user-owned executable files and parent directories

## Verification

- `mise exec -- go test ./internal/fileidentity ./internal/request ./internal/execwrap ./internal/cli`
- `mise exec -- go test -race ./internal/fileidentity ./internal/request ./internal/execwrap ./internal/cli`
- `mise run lint:go`
- `mise exec -- go test ./...`
- `mise exec -- go test -race ./...`

Note: local `scripts/check-go-coverage.sh` reproduced the pre-existing daemon health-check timeout during coverage, outside the changed package. CI will run the full lint job on a clean runner.
