### PR TITLE
ASR-035: Apply top-level account to explicit exec sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,9 +485,10 @@ agent-secret exec --profile ansible --only CADDY_TOKEN,POSTGRES_PASSWORD -- \
 
 `--secret` flags can be combined with a profile for one-off additional refs; in
 that mode, explicit secrets inherit the loaded profile account. Explicit
-`--secret`-only invocations do not load `default_profile`. CLI `--reason` and
-`--ttl` override profile defaults. CLI `--account` supplies a default account
-for refs that do not already have a config/profile account. `--only` filters
+`--secret`-only invocations do not load `default_profile`, but still inherit a
+discovered or explicit config's top-level `account`. CLI `--reason` and `--ttl`
+override profile defaults. CLI `--account` supplies a default account for refs
+that do not already have a config/profile account. `--only` filters
 profile-loaded aliases and env-file secret refs before one-off `--secret` refs
 are added.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,7 +198,8 @@ Explicit `--secret` flags may be combined with `--profile` for one-off
 additional refs. In that mode, explicit secrets inherit the loaded profile
 account. `--only` filters profile-loaded aliases and env-file secret refs
 before one-off `--secret` refs are added. Explicit `--secret`-only invocations
-do not load `default_profile`.
+do not load `default_profile`, but still inherit a discovered or explicit
+config's top-level `account`.
 
 `--env-file` may be combined with `--profile` or `--secret`. It is intended for
 migrating `op run --env-file` workflows without rewriting every caller at once:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -327,6 +327,10 @@ func (p Parser) parseExec(args []string) (Command, error) {
 	if err != nil {
 		return Command{}, err
 	}
+	configAccount, err := loadExecConfigAccount(*profileName, *configPath, hasExplicitSource, loadedProfile)
+	if err != nil {
+		return Command{}, err
+	}
 	onlyActive := len(only.aliases) > 0
 	if onlyActive && !loadedProfile && len(envFileValues.Secrets) == 0 {
 		return Command{}, fmt.Errorf("%w: --only requires a profile, default_profile, or --env-file secret refs", ErrInvalidArguments)
@@ -348,6 +352,9 @@ func (p Parser) parseExec(args []string) (Command, error) {
 	}
 
 	accountFallback := execAccountFallback(*account)
+	if !loadedProfile && strings.TrimSpace(configAccount) != "" {
+		accountFallback = configAccount
+	}
 	var effectiveSecrets []request.SecretSpec
 	if loadedProfile {
 		profileSecrets = applyDefaultAccount(profileSecrets, accountFallback)
@@ -401,6 +408,22 @@ func loadExecProfile(profileName string, configPath string, hasExplicitSource bo
 		label = "default"
 	}
 	return profileconfig.Profile{}, false, fmt.Errorf("load profile %q: %w", label, err)
+}
+
+func loadExecConfigAccount(profileName string, configPath string, hasExplicitSource bool, loadedProfile bool) (string, error) {
+	if profileName != "" || !hasExplicitSource || loadedProfile {
+		return "", nil
+	}
+	metadata, err := profileconfig.LoadMetadata(profileconfig.LoadOptions{
+		ConfigPath: configPath,
+	})
+	if err == nil {
+		return metadata.Account, nil
+	}
+	if configPath == "" && errors.Is(err, profileconfig.ErrConfigNotFound) {
+		return "", nil
+	}
+	return "", fmt.Errorf("load config metadata: %w", err)
 }
 
 func applyDefaultAccount(secrets []request.SecretSpec, account string) []request.SecretSpec {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -802,8 +802,96 @@ profiles:
 	if len(req.Secrets) != 1 || req.Secrets[0].Alias != "TOKEN" {
 		t.Fatalf("default profile leaked into explicit secret request: %+v", req.Secrets)
 	}
-	if req.Secrets[0].Account != opresolver.DefaultDesktopAccount {
-		t.Fatalf("secret account = %q, want built-in default", req.Secrets[0].Account)
+	if req.Secrets[0].Account != "Default Account" {
+		t.Fatalf("secret account = %q, want top-level config account", req.Secrets[0].Account)
+	}
+}
+
+func TestParseExecExplicitEnvFileSecretsUseTopLevelConfigAccount(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	writeExecutable(t, binDir, "tool")
+	writeProfileConfig(t, root, `
+version: 1
+account: Default Account
+default_profile: extra
+profiles:
+  extra:
+    reason: Extra
+    secrets:
+      EXTRA_TOKEN: op://Example/Extra/token
+`)
+	envPath := filepath.Join(root, ".env.deploy")
+	writeConfigFile(t, envPath, "TOKEN=op://Example/Item/token\n")
+	t.Chdir(root)
+	t.Setenv("PATH", binDir)
+	parser := NewParser(func() time.Time { return time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC) })
+
+	command, err := parser.Parse([]string{
+		"exec",
+		"--reason", "Explicit env file",
+		"--env-file", envPath,
+		"--allow-mutable-executable",
+		"--",
+		"tool",
+	})
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	req := command.ExecRequest
+	if len(req.Secrets) != 1 || req.Secrets[0].Alias != "TOKEN" {
+		t.Fatalf("default profile leaked into explicit env-file request: %+v", req.Secrets)
+	}
+	if req.Secrets[0].Account != "Default Account" {
+		t.Fatalf("secret account = %q, want top-level config account", req.Secrets[0].Account)
+	}
+}
+
+func TestParseExecExplicitConfigSecretsUseTopLevelAccount(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	writeExecutable(t, binDir, "tool")
+	configPath := filepath.Join(root, "explicit.yml")
+	writeConfigFile(t, configPath, `
+version: 1
+account: Explicit Config Account
+default_profile: extra
+profiles:
+  extra:
+    reason: Extra
+    secrets:
+      EXTRA_TOKEN: op://Example/Extra/token
+`)
+	t.Chdir(t.TempDir())
+	t.Setenv("PATH", binDir)
+	parser := NewParser(func() time.Time { return time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC) })
+
+	command, err := parser.Parse([]string{
+		"exec",
+		"--config", configPath,
+		"--reason", "Explicit config",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--allow-mutable-executable",
+		"--",
+		"tool",
+	})
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	req := command.ExecRequest
+	if len(req.Secrets) != 1 || req.Secrets[0].Alias != "TOKEN" {
+		t.Fatalf("default profile leaked into explicit config request: %+v", req.Secrets)
+	}
+	if req.Secrets[0].Account != "Explicit Config Account" {
+		t.Fatalf("secret account = %q, want explicit config account", req.Secrets[0].Account)
 	}
 }
 

--- a/internal/profileconfig/profileconfig.go
+++ b/internal/profileconfig/profileconfig.go
@@ -29,6 +29,11 @@ type LoadOptions struct {
 	StartDir   string
 }
 
+type Metadata struct {
+	SourcePath string
+	Account    string
+}
+
 type Profile struct {
 	Name       string
 	SourcePath string
@@ -108,25 +113,9 @@ func (s *secretYAML) unmarshalMapping(value *yaml.Node) error {
 }
 
 func Load(opts LoadOptions) (Profile, error) {
-	path, err := Find(opts.ConfigPath, opts.StartDir)
+	path, doc, err := loadConfigFile(opts)
 	if err != nil {
 		return Profile{}, err
-	}
-
-	//nolint:gosec // G304: config path is selected from explicit project config discovery and parsed as configuration only.
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return Profile{}, fmt.Errorf("read profile config %s: %w", path, err)
-	}
-
-	var doc configFile
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true)
-	if err := decoder.Decode(&doc); err != nil {
-		return Profile{}, fmt.Errorf("%w: parse %s: %w", ErrInvalidConfig, path, err)
-	}
-	if doc.Version != currentVersion {
-		return Profile{}, fmt.Errorf("%w: %s version must be %d", ErrInvalidConfig, path, currentVersion)
 	}
 	if len(doc.Profiles) == 0 {
 		return Profile{}, fmt.Errorf("%w: %s must define at least one profile", ErrInvalidConfig, path)
@@ -157,6 +146,41 @@ func Load(opts LoadOptions) (Profile, error) {
 		Secrets:    secrets,
 		TTL:        resolved.ttl,
 	}, nil
+}
+
+func LoadMetadata(opts LoadOptions) (Metadata, error) {
+	path, doc, err := loadConfigFile(opts)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return Metadata{
+		SourcePath: path,
+		Account:    strings.TrimSpace(doc.Account),
+	}, nil
+}
+
+func loadConfigFile(opts LoadOptions) (string, configFile, error) {
+	path, err := Find(opts.ConfigPath, opts.StartDir)
+	if err != nil {
+		return "", configFile{}, err
+	}
+
+	//nolint:gosec // G304: config path is selected from explicit project config discovery and parsed as configuration only.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", configFile{}, fmt.Errorf("read profile config %s: %w", path, err)
+	}
+
+	var doc configFile
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&doc); err != nil {
+		return "", configFile{}, fmt.Errorf("%w: parse %s: %w", ErrInvalidConfig, path, err)
+	}
+	if doc.Version != currentVersion {
+		return "", configFile{}, fmt.Errorf("%w: %s version must be %d", ErrInvalidConfig, path, currentVersion)
+	}
+	return path, doc, nil
 }
 
 func resolveProfile(doc configFile, path string, profileName string, stack []string) (resolvedProfile, error) {

--- a/internal/profileconfig/profileconfig_test.go
+++ b/internal/profileconfig/profileconfig_test.go
@@ -264,6 +264,30 @@ profiles:
 	}
 }
 
+func TestLoadMetadataReadsTopLevelAccountWithoutDefaultProfile(t *testing.T) {
+	root := t.TempDir()
+	writeConfig(t, filepath.Join(root, "agent-secret.yml"), `
+version: 1
+account: Default Account
+profiles:
+  one:
+    reason: One
+    secrets:
+      TOKEN: op://Example/Item/token
+`)
+
+	metadata, err := LoadMetadata(LoadOptions{StartDir: root})
+	if err != nil {
+		t.Fatalf("LoadMetadata returned error: %v", err)
+	}
+	if metadata.Account != "Default Account" {
+		t.Fatalf("Account = %q", metadata.Account)
+	}
+	if metadata.SourcePath != filepath.Join(root, "agent-secret.yml") {
+		t.Fatalf("SourcePath = %q", metadata.SourcePath)
+	}
+}
+
 func TestLoadReportsMissingDefaultProfile(t *testing.T) {
 	root := t.TempDir()
 	writeConfig(t, filepath.Join(root, "agent-secret.yml"), `


### PR DESCRIPTION
## Summary

Fixes #123.

- adds profile config metadata loading that reads top-level account without resolving default profile secrets
- applies discovered or explicit config `account` to `--secret` and `--env-file` requests that do not select a profile
- preserves the existing behavior that explicit sources do not load `default_profile`
- documents the explicit-source account behavior

## Verification

- `mise exec -- go test ./internal/cli ./internal/profileconfig`
- `mise exec -- go test -race ./internal/cli ./internal/profileconfig`
- `mise run lint:go`
- `npx --yes markdownlint-cli README.md docs/configuration.md`
- `mise exec -- go test ./...`
- `mise exec -- go test -race ./...`
- `git diff --check`
