### PR TITLE
ASR-036: Surface mutable executable warnings in approval prompt

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
@@ -28,7 +28,7 @@ import Foundation
                 }
                 secretSection
                 requestContext
-                if viewModel.printsEnvironmentWarning, !viewModel.highScopeWarning {
+                if !viewModel.cautionMessages.isEmpty {
                     caution
                 }
                 details
@@ -135,7 +135,7 @@ import Foundation
                     .accessibilityHidden(true)
                 Text("Caution: ")
                     .fontWeight(.semibold) +
-                    Text("This command can print environment variables.\nOnly approve if you expected this.")
+                    Text(viewModel.cautionMessages.joined(separator: "\n"))
             }
             .font(.system(size: Metric.bodyFontSize))
             .foregroundStyle(Palette.cautionText)

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Caution.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Caution.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+extension ApprovalRequestViewModel {
+    struct WarningPresentation: Equatable {
+        let printsEnvironment: Bool
+        let override: String?
+        let mutableExecutable: String?
+        let cautionMessages: [String]
+    }
+
+    private static var environmentWarningText: String {
+        "This command can print environment variables.\nOnly approve if you expected this."
+    }
+
+    static func warningPresentation(
+        for request: ApprovalRequest,
+        highScopeWarning: Bool
+    ) -> WarningPresentation {
+        let printsEnvironment: Bool = environmentWarning(for: request)
+        let mutableExecutable: String? = mutableExecutableWarning(for: request)
+        return WarningPresentation(
+            printsEnvironment: printsEnvironment,
+            override: overrideWarning(for: request),
+            mutableExecutable: mutableExecutable,
+            cautionMessages: cautionMessages(
+                printsEnvironmentWarning: printsEnvironment,
+                highScopeWarning: highScopeWarning,
+                mutableExecutableWarning: mutableExecutable
+            )
+        )
+    }
+
+    private static func overrideWarning(for request: ApprovalRequest) -> String? {
+        guard request.overrideEnv, !request.overriddenAliases.isEmpty else {
+            return nil
+        }
+        return "Will replace existing variables: \(request.overriddenAliases.joined(separator: ", "))"
+    }
+
+    private static func mutableExecutableWarning(for request: ApprovalRequest) -> String? {
+        guard request.allowMutableExecutable else {
+            return nil
+        }
+        return "Mutable executable opt-in: command path may be replaceable before launch."
+    }
+
+    private static func cautionMessages(
+        printsEnvironmentWarning: Bool,
+        highScopeWarning: Bool,
+        mutableExecutableWarning: String?
+    ) -> [String] {
+        var messages: [String] = []
+        if printsEnvironmentWarning, !highScopeWarning {
+            messages.append(environmentWarningText)
+        }
+        if let mutableExecutableWarning {
+            messages.append(mutableExecutableWarning)
+        }
+        return messages
+    }
+
+    private static func environmentWarning(for request: ApprovalRequest) -> Bool {
+        environmentPrinter(command: request.command, resolvedExecutable: request.resolvedExecutable)
+    }
+
+    private static func environmentPrinter(command: [String], resolvedExecutable: String?) -> Bool {
+        let executableName: String = URL(fileURLWithPath: resolvedExecutable ?? command.first ?? "")
+            .lastPathComponent
+        return executableName == "env" || executableName == "printenv"
+    }
+}

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
@@ -21,7 +21,7 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         let secretRows: [String]
         let timeRemaining: String
         let overrideWarning: String?
-        let mutableExecutableWarning: String?
+        let cautionMessages: [String]
     }
 
     private static let highScopeSecretThreshold: Int = 6
@@ -82,6 +82,8 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
     public let overrideWarning: String?
     /// Mutable executable opt-in warning when applicable.
     public let mutableExecutableWarning: String?
+    /// Caution messages visible in the default SwiftUI approval surface.
+    public let cautionMessages: [String]
     /// Footer copy with correct singular/plural wording.
     public let footerMessage: String
     /// Full sanitized prompt body for AppKit alerts.
@@ -117,9 +119,11 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         let remainingText: String = compactTimeRemaining
         scopeSummary = Self.scopeSummary(uses: reusableUseLimit, remaining: remainingText, expired: isExpired)
         allowReusableTitle = Self.reuseTitle(uses: reusableUseLimit, remaining: remainingText, expired: isExpired)
-        printsEnvironmentWarning = Self.environmentWarning(for: request)
-        overrideWarning = Self.overrideWarning(for: request)
-        mutableExecutableWarning = Self.mutableExecutableWarning(for: request)
+        let warnings: WarningPresentation = Self.warningPresentation(for: request, highScopeWarning: highScopeWarning)
+        printsEnvironmentWarning = warnings.printsEnvironment
+        overrideWarning = warnings.override
+        mutableExecutableWarning = warnings.mutableExecutable
+        cautionMessages = warnings.cautionMessages
         footerMessage = Self.footerMessage(secretCount: secretPresentation.count, expired: isExpired)
         renderedText = Self.renderedText(
             for: request,
@@ -134,7 +138,7 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
                 secretRows: secretRows,
                 timeRemaining: timeRemaining,
                 overrideWarning: overrideWarning,
-                mutableExecutableWarning: mutableExecutableWarning
+                cautionMessages: cautionMessages
             )
         )
     }
@@ -207,24 +211,8 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         if let overrideWarning: String = viewModel.overrideWarning {
             lines.append(overrideWarning)
         }
-        if let mutableExecutableWarning: String = viewModel.mutableExecutableWarning {
-            lines.append(mutableExecutableWarning)
-        }
+        lines.append(contentsOf: viewModel.cautionMessages)
         return lines.joined(separator: "\n")
-    }
-
-    private static func overrideWarning(for request: ApprovalRequest) -> String? {
-        guard request.overrideEnv, !request.overriddenAliases.isEmpty else {
-            return nil
-        }
-        return "Will replace existing variables: \(request.overriddenAliases.joined(separator: ", "))"
-    }
-
-    private static func mutableExecutableWarning(for request: ApprovalRequest) -> String? {
-        guard request.allowMutableExecutable else {
-            return nil
-        }
-        return "Mutable executable opt-in: command path may be replaceable before launch."
     }
 
     private static func commandArguments(_ command: [String]) -> [CommandArgumentViewModel] {
@@ -283,15 +271,5 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
 
     private static func visibleRemainingSeconds(_ interval: TimeInterval) -> Int {
         max(0, Int(interval.rounded(.up)))
-    }
-
-    private static func environmentPrinter(command: [String], resolvedExecutable: String?) -> Bool {
-        let executableName: String = URL(fileURLWithPath: resolvedExecutable ?? command.first ?? "")
-            .lastPathComponent
-        return executableName == "env" || executableName == "printenv"
-    }
-
-    private static func environmentWarning(for request: ApprovalRequest) -> Bool {
-        environmentPrinter(command: request.command, resolvedExecutable: request.resolvedExecutable)
     }
 }

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
@@ -172,6 +172,9 @@ final class ApprovalControllerTests: XCTestCase {
         XCTAssertTrue(viewModel.renderedText.contains("Time remaining: 2 minutes"))
         XCTAssertTrue(viewModel.renderedText.contains("Will replace existing variables: EXAMPLE_TOKEN"))
         XCTAssertTrue(viewModel.renderedText.contains("Mutable executable opt-in"))
+        XCTAssertTrue(viewModel.cautionMessages.contains { message in
+            message.contains("Mutable executable opt-in")
+        })
         XCTAssertEqual(viewModel.executable, "terraform")
         XCTAssertEqual(viewModel.promptQuestion, "Allow this command to use the following secret?")
         XCTAssertEqual(viewModel.accessSummary, "wants temporary access.")
@@ -202,6 +205,20 @@ final class ApprovalControllerTests: XCTestCase {
         XCTAssertEqual(viewModel.requestedSecrets.first?.symbolName, "person")
         XCTAssertTrue(viewModel.footerMessage.contains("The secrets are injected"))
         XCTAssertFalse(viewModel.renderedText.contains(Self.canarySecretValue))
+    }
+
+    func testMutableExecutableWarningIsVisibleOutsideCollapsedDetails() {
+        var request: ApprovalRequest = Self.multiSecretRequest
+        request.allowMutableExecutable = true
+        let viewModel = ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: Self.viewModelNow)
+        )
+
+        XCTAssertTrue(viewModel.highScopeWarning)
+        XCTAssertTrue(viewModel.printsEnvironmentWarning)
+        XCTAssertEqual(viewModel.cautionMessages.count, 1)
+        XCTAssertTrue(viewModel.cautionMessages[0].contains("Mutable executable opt-in"))
     }
 
     deinit {


### PR DESCRIPTION
## Summary

Fixes #124.

- renders mutable executable opt-in warnings in the default top-level caution area
- keeps warning/detail text centralized in `ApprovalRequestViewModel+Caution`
- keeps the details row as secondary context while making the warning visible before approval
- adds view-model coverage proving mutable executable requests expose first-view caution text

## Verification

- `mise run lint:swift`
- `mise exec -- swift test` from `approver`
- `mise run build`
- `git diff --check`
