### PR TITLE
ASR-037: Pin GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
           install: true
           cache: true
@@ -45,10 +45,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
           install: true
           cache: true
@@ -76,10 +76,10 @@ jobs:
             runner: macos-15-intel
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
           install: true
           cache: true
@@ -124,7 +124,7 @@ jobs:
           test -f "dist/Agent-Secret-${GITHUB_REF_NAME}-macos-${{ matrix.arch }}.dmg"
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: release-${{ matrix.arch }}
           if-no-files-found: error
@@ -150,7 +150,7 @@ jobs:
       contents: write
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           path: dist/release-artifacts
           pattern: release-*

--- a/mise.toml
+++ b/mise.toml
@@ -81,6 +81,7 @@ AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-workflow-actions-pinned.sh
 cd approver && swift run agent-secret-approver-smoke
 """
 

--- a/scripts/check-workflow-actions-pinned.sh
+++ b/scripts/check-workflow-actions-pinned.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$root"
+
+workflow_files=("$@")
+if [ ${#workflow_files[@]} -eq 0 ] && [ -d .github/workflows ]; then
+  while IFS= read -r -d '' file; do
+    workflow_files+=("$file")
+  done < <(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) -print0)
+fi
+
+status=0
+for file in "${workflow_files[@]}"; do
+  [ -f "$file" ] || continue
+
+  line_no=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_no=$((line_no + 1))
+
+    if [[ "$line" =~ ^[[:space:]-]*uses:[[:space:]]*([^[:space:]#]+) ]]; then
+      action="${BASH_REMATCH[1]}"
+      action="${action%\"}"
+      action="${action#\"}"
+      action="${action%\'}"
+      action="${action#\'}"
+
+      if [[ "$action" == ./* ]]; then
+        continue
+      fi
+
+      if [[ "$action" != *@* ]]; then
+        echo "$file:$line_no: action must be pinned to a full commit SHA: $action" >&2
+        status=1
+        continue
+      fi
+
+      ref="${action##*@}"
+      if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "$file:$line_no: action must be pinned to a full commit SHA: $action" >&2
+        status=1
+      fi
+    fi
+  done <"$file"
+done
+
+if [ "$status" -ne 0 ]; then
+  {
+    echo
+    echo "GitHub Actions workflows must pin third-party actions to immutable 40-character commit SHAs."
+    echo "Use \`gh api repos/<owner>/<repo>/git/ref/tags/<tag> --jq .object.sha\` to resolve a tag before updating the workflow."
+  } >&2
+fi
+
+exit "$status"

--- a/scripts/lint-smart.sh
+++ b/scripts/lint-smart.sh
@@ -252,6 +252,8 @@ fi
 if [ ${#workflow_files[@]} -gt 0 ]; then
   echo "Running actionlint on changed workflows..."
   actionlint "${workflow_files[@]}"
+  echo "Checking changed workflow action pins..."
+  scripts/check-workflow-actions-pinned.sh "${workflow_files[@]}"
 fi
 
 if [ ${#toml_files[@]} -gt 0 ]; then

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -35,11 +35,14 @@ if [ -d .github/workflows ]; then
 
   if [ ${#workflow_files[@]} -gt 0 ]; then
     actionlint "${workflow_files[@]}"
+    scripts/check-workflow-actions-pinned.sh "${workflow_files[@]}"
   fi
 fi
 scripts/check-format.sh toml
 scripts/check-format.sh swift
 swiftlint lint --strict --no-cache
 npx --no-install markdownlint '**/*.md'
+
+scripts/test-workflow-actions-pinned.sh
 
 (cd approver && swift test)

--- a/scripts/test-workflow-actions-pinned.sh
+++ b/scripts/test-workflow-actions-pinned.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd -- "$script_dir/.." && pwd)"
+check_script="$project_root/scripts/check-workflow-actions-pinned.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-workflow-pinning-test.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "test-workflow-actions-pinned: $*" >&2
+  exit 1
+}
+
+expect_failure() {
+  local want="$1"
+  shift
+
+  if "$@" >"$tmp_dir/stdout" 2>"$tmp_dir/stderr"; then
+    fail "expected failure containing $want"
+  fi
+  if ! grep -F "$want" "$tmp_dir/stderr" >/dev/null; then
+    fail "stderr did not contain $want: $(cat "$tmp_dir/stderr")"
+  fi
+}
+
+cat >"$tmp_dir/pinned.yml" <<'YAML'
+name: pinned
+on: push
+jobs:
+  pinned:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ./.github/actions/local-action
+YAML
+"$check_script" "$tmp_dir/pinned.yml"
+
+cat >"$tmp_dir/floating.yml" <<'YAML'
+name: floating
+on: push
+jobs:
+  floating:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+YAML
+expect_failure "actions/checkout@v4" "$check_script" "$tmp_dir/floating.yml"
+
+cat >"$tmp_dir/no-ref.yml" <<'YAML'
+name: no-ref
+on: push
+jobs:
+  no-ref:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout
+YAML
+expect_failure "actions/checkout" "$check_script" "$tmp_dir/no-ref.yml"
+
+cat >"$tmp_dir/short-sha.yml" <<'YAML'
+name: short-sha
+on: push
+jobs:
+  short-sha:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e1148
+YAML
+expect_failure "actions/checkout@34e1148" "$check_script" "$tmp_dir/short-sha.yml"
+
+echo "test-workflow-actions-pinned: ok"


### PR DESCRIPTION
## Summary

Fixes #125.

- pins every third-party workflow `uses:` entry to the currently resolved full commit SHA
- adds `scripts/check-workflow-actions-pinned.sh` to reject floating action tags, missing refs, and short SHAs
- runs the pinning check from full lint and smart lint for changed workflows
- adds a smoke regression for pinned, floating, missing-ref, and short-SHA workflow entries

## Verification

- `mise run lint:shell`
- `mise exec -- actionlint .github/workflows/ci.yml`
- `scripts/check-workflow-actions-pinned.sh`
- `scripts/test-workflow-actions-pinned.sh`
- `mise run lint:toml`
- `mise exec -- env AGENT_SECRET_IN_MISE=1 scripts/lint-smart.sh --worktree`
- `mise run test:smoke`
- `mise exec -- go test -race ./...`
- `mise exec -- scripts/check-go-coverage.sh`
- `mise run lint:vuln`
- `mise run lint:secrets`
- `npm ci --ignore-scripts --no-audit --no-fund && npx --no-install markdownlint '**/*.md'`
- `mise run build`
- `mise exec -- bash -lc 'cd approver && swift test'`
- `git diff --check`

Note: `mise run lint` was attempted twice locally and both attempts hit the known `internal/daemon` `TestProcessApproverLauncherHealthCheck` timeout during the aggregate run. The focused daemon health test, full race suite, and all remaining lint/build stages passed when rerun explicitly.
