### PR TITLE
ASR-038: Reject symlinked custom path parents

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,40 @@ require_custom_install_path_guard() {
   die "$label path override requires AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1: $path"
 }
 
+is_system_root_alias() {
+  case "$1" in
+    /etc | /tmp | /var)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+reject_symlinked_parent_dirs() {
+  label="$1"
+  path="$2"
+  current="${path%/*}"
+
+  if [ "$current" = "$path" ] || [ "$current" = "" ]; then
+    return
+  fi
+
+  while [ "$current" != "/" ]; do
+    if [ -L "$current" ] && ! is_system_root_alias "$current"; then
+      die "$label path must not contain symlinked parent directories: $current"
+    fi
+
+    next="${current%/*}"
+    if [ "$next" = "$current" ] || [ "$next" = "" ]; then
+      current="/"
+    else
+      current="$next"
+    fi
+  done
+}
+
 validate_install_dir() {
   label="$1"
   path="$(strip_trailing_slashes "$2")"
@@ -64,6 +98,7 @@ validate_install_dir() {
       die "$label path must not contain dot segments: $path"
       ;;
   esac
+  reject_symlinked_parent_dirs "$label" "$path"
   if [ -L "$path" ]; then
     die "$label path must not be a symlink: $path"
   fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -313,6 +313,29 @@ test_destination_validation_rejects_bad_paths() {
   fi
 }
 
+test_destination_validation_rejects_symlinked_parent_dirs() {
+  local run_dir="$tmp_dir/symlinked-parents"
+  local target="$run_dir/target"
+  local link="$run_dir/link-parent"
+
+  mkdir -p "$target"
+  printf 'keep\n' >"$target/keep.txt"
+  ln -s "$target" "$link"
+
+  if run_installer symlinked-app-parent AGENT_SECRET_APP_DIR="$link/apps"; then
+    fail "installer accepted a symlinked app parent"
+  fi
+  if run_installer symlinked-bin-parent AGENT_SECRET_BIN_DIR="$link/bin"; then
+    fail "installer accepted a symlinked bin parent"
+  fi
+  if run_installer symlinked-skills-parent AGENT_SECRET_SKILLS_DIR="$link/skills"; then
+    fail "installer accepted a symlinked skills parent"
+  fi
+  if [ -e "$target/apps" ] || [ -e "$target/bin" ] || [ -e "$target/skills" ]; then
+    fail "installer followed a symlinked parent directory"
+  fi
+}
+
 test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts() {
   run_installer unsigned-allowed \
     AGENT_SECRET_INSTALL_DEV_MODE=1 \
@@ -337,6 +360,7 @@ test_wrong_daemon_bundle_id_stops_install
 test_trust_root_overrides_require_dev_mode
 test_destination_overrides_require_guard
 test_destination_validation_rejects_bad_paths
+test_destination_validation_rejects_symlinked_parent_dirs
 test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts
 
 echo "test-install: ok"

--- a/scripts/test-uninstall.sh
+++ b/scripts/test-uninstall.sh
@@ -132,6 +132,50 @@ dangerous_destination_paths_are_rejected_even_with_guard() {
     AGENT_SECRET_SKILLS_DIR="$link"
 }
 
+symlinked_parent_dirs_are_rejected() {
+  local run_dir="$tmp_dir/symlinked-parents"
+  local target="$run_dir/target"
+  local link="$run_dir/link-parent"
+  mkdir -p "$target"
+  printf 'keep\n' >"$target/keep.txt"
+  make_symlink "$target" "$link"
+
+  expect_failure \
+    symlinked-app-parent \
+    "app path must not contain symlinked parent directories" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_APP_DIR="$link/apps"
+
+  expect_failure \
+    symlinked-bin-parent \
+    "bin path must not contain symlinked parent directories" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_BIN_DIR="$link/bin"
+
+  expect_failure \
+    symlinked-skills-parent \
+    "skills path must not contain symlinked parent directories" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_SKILLS_DIR="$link/skills"
+
+  expect_failure \
+    symlinked-support-parent \
+    "support path must not contain symlinked parent directories" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_SUPPORT_DIR="$link/agent-secret"
+
+  expect_failure \
+    symlinked-audit-parent \
+    "audit path must not contain symlinked parent directories" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_REMOVE_AUDIT_LOGS=1 \
+    AGENT_SECRET_AUDIT_DIR="$link/agent-secret"
+
+  if [ ! -f "$target/keep.txt" ]; then
+    fail "symlinked parent target was modified"
+  fi
+}
+
 symlinked_dirs_are_rejected() {
   local run_dir="$tmp_dir/symlink"
   local target="$run_dir/target"
@@ -197,6 +241,7 @@ custom_guard_rejects_override
 custom_destination_guard_rejects_override
 dangerous_paths_are_rejected_even_with_guard
 dangerous_destination_paths_are_rejected_even_with_guard
+symlinked_parent_dirs_are_rejected
 symlinked_dirs_are_rejected
 safe_custom_paths_remove_only_known_files
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -101,6 +101,40 @@ require_custom_path_guard() {
   fail "$label path override requires AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1: $path"
 }
 
+is_system_root_alias() {
+  case "$1" in
+    /etc | /tmp | /var)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+reject_symlinked_parent_dirs() {
+  label="$1"
+  path="$2"
+  current="${path%/*}"
+
+  if [ "$current" = "$path" ] || [ "$current" = "" ]; then
+    return
+  fi
+
+  while [ "$current" != "/" ]; do
+    if [ -L "$current" ] && ! is_system_root_alias "$current"; then
+      fail "$label path must not contain symlinked parent directories: $current"
+    fi
+
+    next="${current%/*}"
+    if [ "$next" = "$current" ] || [ "$next" = "" ]; then
+      current="/"
+    else
+      current="$next"
+    fi
+  done
+}
+
 validate_agent_secret_dir() {
   label="$1"
   path="$(strip_trailing_slashes "$2")"
@@ -130,6 +164,7 @@ validate_agent_secret_dir() {
   if [ "$leaf" != "agent-secret" ]; then
     fail "$label path must end with agent-secret: $path"
   fi
+  reject_symlinked_parent_dirs "$label" "$path"
   if [ -L "$path" ]; then
     fail "$label path must not be a symlink: $path"
   fi
@@ -163,6 +198,7 @@ validate_destination_dir() {
       ;;
   esac
 
+  reject_symlinked_parent_dirs "$label" "$path"
   if [ -L "$path" ]; then
     fail "$label path must not be a symlink: $path"
   fi


### PR DESCRIPTION
## Summary

Fixes #126.

- rejects custom install/uninstall destinations when an existing parent directory is a symlink
- preserves compatibility with macOS root aliases like `/var`, `/tmp`, and `/etc`
- covers install app/bin/skills roots and uninstall app/bin/skills/support/audit roots with regression tests

## Verification

- `AGENT_SECRET_IN_MISE=1 scripts/test-install.sh`
- `AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh`
- `mise run lint:shell`
- `mise exec -- env AGENT_SECRET_IN_MISE=1 scripts/lint-smart.sh --worktree`
- `mise run test:smoke`
- `mise run lint:smart`
- `git diff --check`
