### PR TITLE
ASR-039: Rebase exec request TTL on daemon receipt

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -133,6 +133,7 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 	if requestID == "" || nonce == "" {
 		return ExecGrant{}, ErrInvalidNonce
 	}
+	req = req.WithReceiptTime(b.now())
 	if err := b.preflightAudit(ctx); err != nil {
 		return ExecGrant{}, err
 	}

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -40,6 +40,21 @@ func (m *mockApprover) ApproveExec(
 	return m.decision, m.err
 }
 
+type recordingApprover struct {
+	decision ApprovalDecision
+	seen     chan request.ExecRequest
+}
+
+func (r *recordingApprover) ApproveExec(
+	_ context.Context,
+	_ string,
+	_ string,
+	req request.ExecRequest,
+) (ApprovalDecision, error) {
+	r.seen <- req
+	return r.decision, nil
+}
+
 type sleepingApprover struct {
 	delay    time.Duration
 	decision ApprovalDecision
@@ -1086,8 +1101,10 @@ func TestBrokerAuditFailureStopsBeforePayload(t *testing.T) {
 
 func newTestBroker(t *testing.T, opts BrokerOptions) *Broker {
 	t.Helper()
-	now := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
-	opts.Now = func() time.Time { return now }
+	if opts.Now == nil {
+		now := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
+		opts.Now = func() time.Time { return now }
+	}
 	broker, err := NewBroker(opts)
 	if err != nil {
 		t.Fatalf("NewBroker returned error: %v", err)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -77,6 +77,42 @@ func TestServerExecProtocolLifecycle(t *testing.T) {
 	}
 }
 
+func TestServerRebasesExecRequestTimeToDaemonClock(t *testing.T) {
+	t.Parallel()
+
+	daemonNow := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
+	ref := "op://Example/Item/token"
+	approver := &recordingApprover{
+		decision: ApprovalDecision{Approved: true},
+		seen:     make(chan request.ExecRequest, 1),
+	}
+	client, cleanup := startTestServer(t, BrokerOptions{
+		Approver: approver,
+		Resolver: &mockResolver{values: map[string]string{ref: "value"}},
+		Audit:    &memoryAudit{},
+	})
+	defer cleanup()
+
+	req := testExecRequestAt(t, daemonNow.Add(24*time.Hour), []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req.TTL = 10 * time.Minute
+	req.ExpiresAt = req.ReceivedAt.Add(req.TTL)
+	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); err != nil {
+		t.Fatalf("RequestExec returned error: %v", err)
+	}
+
+	select {
+	case got := <-approver.seen:
+		if !got.ReceivedAt.Equal(daemonNow) {
+			t.Fatalf("received_at = %s, want daemon clock %s", got.ReceivedAt, daemonNow)
+		}
+		if !got.ExpiresAt.Equal(daemonNow.Add(req.TTL)) {
+			t.Fatalf("expires_at = %s, want daemon clock plus ttl %s", got.ExpiresAt, daemonNow.Add(req.TTL))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("approver did not receive exec request")
+	}
+}
+
 func TestServerAllowsCommandCompletionAfterProtocolReadTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -516,6 +552,7 @@ func TestServerApprovalProtocolOverSingleSocket(t *testing.T) {
 	launcher := &recordingLauncher{expected: ExpectedApprover{PID: peer.PID, ExecutablePath: peer.ExecutablePath}}
 	approver := newSocketApproverForTest(t, launcher, time.Now)
 	broker := newTestBroker(t, BrokerOptions{
+		Now:      time.Now,
 		Approver: approver,
 		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
 		Audit:    &memoryAudit{},
@@ -577,6 +614,7 @@ func TestServerAllowsApprovalDecisionAfterProtocolReadTimeout(t *testing.T) {
 	launcher := &recordingLauncher{expected: ExpectedApprover{PID: peer.PID, ExecutablePath: peer.ExecutablePath}}
 	approver := newSocketApproverForTest(t, launcher, time.Now)
 	broker := newTestBroker(t, BrokerOptions{
+		Now:      time.Now,
 		Approver: approver,
 		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
 		Audit:    &memoryAudit{},

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -99,6 +99,12 @@ func (r ExecRequest) Expired(at time.Time) bool {
 	return !at.Before(r.ExpiresAt)
 }
 
+func (r ExecRequest) WithReceiptTime(receivedAt time.Time) ExecRequest {
+	r.ReceivedAt = receivedAt
+	r.ExpiresAt = receivedAt.Add(r.TTL)
+	return r
+}
+
 func (r ExecRequest) ValidateForDaemon() error {
 	reason, err := validateReason(r.Reason)
 	if err != nil {

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -294,6 +294,30 @@ func TestExecRequestExpiryUsesDaemonReceiptTTL(t *testing.T) {
 	}
 }
 
+func TestExecRequestWithReceiptTimeRebasesExpiry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeExecutable(t, dir)
+	clientTime := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	daemonTime := clientTime.Add(24 * time.Hour)
+
+	req, err := NewExec(mutate(baseOptions(dir, "reason"), func(o *ExecOptions) {
+		o.ReceivedAt = clientTime
+		o.TTL = time.Minute
+	}))
+	if err != nil {
+		t.Fatalf("NewExec returned error: %v", err)
+	}
+	rebased := req.WithReceiptTime(daemonTime)
+	if !rebased.ReceivedAt.Equal(daemonTime) {
+		t.Fatalf("received_at = %s, want %s", rebased.ReceivedAt, daemonTime)
+	}
+	if !rebased.ExpiresAt.Equal(daemonTime.Add(time.Minute)) {
+		t.Fatalf("expires_at = %s, want %s", rebased.ExpiresAt, daemonTime.Add(time.Minute))
+	}
+}
+
 func TestParseSecretRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #134.

## Summary
- Rebase exec request receipt and expiry timestamps to the daemon clock before approval or secret resolution.
- Add request-level and daemon protocol regression coverage for future-dated client requests.

## Verification
- `mise exec -- go test ./internal/request ./internal/daemon`
- `mise exec -- go test -race ./internal/request ./internal/daemon`
- `mise run lint:go`
- `mise exec -- go test ./...`
- `mise exec -- go test -race ./...`
- `mise run lint:smart`