### PR TITLE
ASR-040: Validate trusted peer process signatures

### DIFF
--- a/internal/daemon/approver_identity.go
+++ b/internal/daemon/approver_identity.go
@@ -28,6 +28,21 @@ type BundleApproverIdentityPolicy struct {
 	VerifySignature    bool
 }
 
+type codeSignatureVerifier interface {
+	VerifyPath(path string) (string, error)
+	VerifyProcess(pid int) (string, error)
+}
+
+type codesignSignatureVerifier struct{}
+
+func (codesignSignatureVerifier) VerifyPath(path string) (string, error) {
+	return verifyCodeSignature(path)
+}
+
+func (codesignSignatureVerifier) VerifyProcess(pid int) (string, error) {
+	return verifyProcessCodeSignature(pid)
+}
+
 func DefaultApproverIdentityPolicy() BundleApproverIdentityPolicy {
 	return BundleApproverIdentityPolicy{
 		ExpectedBundleID:   DefaultApproverBundleID,
@@ -160,16 +175,27 @@ func plistString(path string, key string) (string, error) {
 }
 
 func verifyCodeSignature(bundlePath string) (string, error) {
+	return verifyCodeSignatureTarget(bundlePath, "code signature for "+bundlePath)
+}
+
+func verifyProcessCodeSignature(pid int) (string, error) {
+	if pid <= 0 {
+		return "", fmt.Errorf("%w: invalid process id %d", ErrApproverIdentity, pid)
+	}
+	return verifyCodeSignatureTarget(fmt.Sprintf("+%d", pid), fmt.Sprintf("code signature for process %d", pid))
+}
+
+func verifyCodeSignatureTarget(target string, description string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	//nolint:gosec // G204: codesign path is fixed and bundlePath is canonicalized before signature verification.
-	if err := exec.CommandContext(ctx, "/usr/bin/codesign", "--verify", "--strict", "--deep", bundlePath).Run(); err != nil {
-		return "", fmt.Errorf("%w: verify code signature for %s: %w", ErrApproverIdentity, bundlePath, err)
+	//nolint:gosec // G204: codesign path is fixed; targets are canonicalized paths or codesign +PID selectors.
+	if err := exec.CommandContext(ctx, "/usr/bin/codesign", "--verify", "--strict", "--deep", target).Run(); err != nil {
+		return "", fmt.Errorf("%w: verify %s: %w", ErrApproverIdentity, description, err)
 	}
-	//nolint:gosec // G204: codesign path is fixed and bundlePath is canonicalized before signature inspection.
-	output, err := exec.CommandContext(ctx, "/usr/bin/codesign", "-dv", "--verbose=4", bundlePath).CombinedOutput()
+	//nolint:gosec // G204: codesign path is fixed; targets are canonicalized paths or codesign +PID selectors.
+	output, err := exec.CommandContext(ctx, "/usr/bin/codesign", "-dv", "--verbose=4", target).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%w: inspect code signature for %s: %w", ErrApproverIdentity, bundlePath, err)
+		return "", fmt.Errorf("%w: inspect %s: %w", ErrApproverIdentity, description, err)
 	}
 	for line := range strings.SplitSeq(string(output), "\n") {
 		teamID, ok := strings.CutPrefix(strings.TrimSpace(line), "TeamIdentifier=")

--- a/internal/daemon/trusted_client.go
+++ b/internal/daemon/trusted_client.go
@@ -22,9 +22,11 @@ type TrustedExecutableValidator struct {
 }
 
 type trustedExecutableSet struct {
-	entries        []trustedExecutable
-	expectedTeamID string
-	err            error
+	entries           []trustedExecutable
+	expectedTeamID    string
+	err               error
+	signatureVerifier codeSignatureVerifier
+	verifySignature   bool
 }
 
 type trustedExecutable struct {
@@ -44,6 +46,22 @@ func newTrustedExecutableValidator(paths []string, expectedTeamID string) Truste
 }
 
 func newTrustedExecutableSet(paths []string, expectedTeamID string, err error) trustedExecutableSet {
+	return newTrustedExecutableSetWithVerifier(
+		paths,
+		expectedTeamID,
+		err,
+		codesignSignatureVerifier{},
+		runtime.GOOS == "darwin",
+	)
+}
+
+func newTrustedExecutableSetWithVerifier(
+	paths []string,
+	expectedTeamID string,
+	err error,
+	verifier codeSignatureVerifier,
+	verifySignature bool,
+) trustedExecutableSet {
 	seen := make(map[string]struct{}, len(paths))
 	entries := make([]trustedExecutable, 0, len(paths))
 	for _, path := range paths {
@@ -70,9 +88,11 @@ func newTrustedExecutableSet(paths []string, expectedTeamID string, err error) t
 		entries = append(entries, entry)
 	}
 	return trustedExecutableSet{
-		entries:        entries,
-		expectedTeamID: strings.TrimSpace(expectedTeamID),
-		err:            err,
+		entries:           entries,
+		expectedTeamID:    strings.TrimSpace(expectedTeamID),
+		err:               err,
+		signatureVerifier: verifier,
+		verifySignature:   verifySignature,
 	}
 }
 
@@ -172,7 +192,7 @@ func (v trustedExecutableSet) validatePeer(info peercred.Info) error {
 		if entry.path != got {
 			continue
 		}
-		if err := entry.validate(got, v.expectedTeamID, v.err); err != nil {
+		if err := entry.validatePeer(info, got, v.expectedTeamID, v.signatureVerifier, v.verifySignature, v.err); err != nil {
 			return err
 		}
 		return nil
@@ -180,15 +200,22 @@ func (v trustedExecutableSet) validatePeer(info peercred.Info) error {
 	return fmt.Errorf("%w: executable %q is not trusted", v.err, got)
 }
 
-func (e trustedExecutable) validate(path string, expectedTeamID string, errKind error) error {
+func (e trustedExecutable) validatePeer(
+	info peercred.Info,
+	path string,
+	expectedTeamID string,
+	verifier codeSignatureVerifier,
+	verifySignature bool,
+	errKind error,
+) error {
 	if errKind == nil {
 		errKind = ErrUntrustedClient
 	}
-	info, err := os.Stat(path)
+	fileInfo, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("%w: stat trusted executable %q: %w", errKind, path, err)
 	}
-	if !os.SameFile(info, e.fileInfo) {
+	if !os.SameFile(fileInfo, e.fileInfo) {
 		return fmt.Errorf("%w: executable %q changed since trust snapshot", errKind, path)
 	}
 	if e.bundlePath != "" {
@@ -197,14 +224,38 @@ func (e trustedExecutable) validate(path string, expectedTeamID string, errKind 
 			return fmt.Errorf("%w: executable %q is outside expected app bundle %q", errKind, path, e.bundlePath)
 		}
 	}
-	if expectedTeamID != "" && runtime.GOOS == "darwin" {
-		teamID, err := verifyCodeSignature(path)
-		if err != nil {
-			return fmt.Errorf("%w: verify code signature: %w", errKind, err)
-		}
-		if teamID != expectedTeamID {
-			return fmt.Errorf("%w: team id %q != %q", errKind, teamID, expectedTeamID)
-		}
+	if expectedTeamID != "" && verifySignature {
+		return validatePeerSignature(info, path, expectedTeamID, verifier, errKind)
+	}
+	return nil
+}
+
+func validatePeerSignature(
+	info peercred.Info,
+	path string,
+	expectedTeamID string,
+	verifier codeSignatureVerifier,
+	errKind error,
+) error {
+	if verifier == nil {
+		verifier = codesignSignatureVerifier{}
+	}
+	if info.PID <= 0 {
+		return fmt.Errorf("%w: peer pid is unavailable for signature validation", errKind)
+	}
+	teamID, err := verifier.VerifyPath(path)
+	if err != nil {
+		return fmt.Errorf("%w: verify trusted executable signature: %w", errKind, err)
+	}
+	if teamID != expectedTeamID {
+		return fmt.Errorf("%w: trusted executable team id %q != %q", errKind, teamID, expectedTeamID)
+	}
+	teamID, err = verifier.VerifyProcess(info.PID)
+	if err != nil {
+		return fmt.Errorf("%w: verify peer process signature: %w", errKind, err)
+	}
+	if teamID != expectedTeamID {
+		return fmt.Errorf("%w: peer process team id %q != %q", errKind, teamID, expectedTeamID)
 	}
 	return nil
 }

--- a/internal/daemon/trusted_client_test.go
+++ b/internal/daemon/trusted_client_test.go
@@ -11,6 +11,40 @@ import (
 	"github.com/kovyrin/agent-secret/internal/peercred"
 )
 
+type recordingSignatureVerifier struct {
+	pathTeamID    string
+	processTeamID string
+	pathErr       error
+	processErr    error
+	paths         []string
+	pids          []int
+}
+
+func (v *recordingSignatureVerifier) VerifyPath(path string) (string, error) {
+	v.paths = append(v.paths, path)
+	if v.pathErr != nil {
+		return "", v.pathErr
+	}
+	return v.pathTeamID, nil
+}
+
+func (v *recordingSignatureVerifier) VerifyProcess(pid int) (string, error) {
+	v.pids = append(v.pids, pid)
+	if v.processErr != nil {
+		return "", v.processErr
+	}
+	return v.processTeamID, nil
+}
+
+func newTestTrustedExecutableValidator(
+	paths []string,
+	verifier codeSignatureVerifier,
+) TrustedExecutableValidator {
+	return TrustedExecutableValidator{
+		set: newTrustedExecutableSetWithVerifier(paths, "TEAMID", ErrUntrustedClient, verifier, true),
+	}
+}
+
 func TestTrustedExecutableValidatorMatchesComparableExecutablePath(t *testing.T) {
 	t.Parallel()
 
@@ -59,6 +93,93 @@ func TestTrustedExecutableValidatorRejectsExecutableReplacedAfterStartup(t *test
 	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted})
 	if !errors.Is(err, ErrUntrustedClient) {
 		t.Fatalf("expected ErrUntrustedClient after replacement, got %v", err)
+	}
+}
+
+func TestTrustedExecutableValidatorVerifiesPeerProcessSignature(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	trusted := writeExecutableAt(t, dir, "agent-secret")
+	verifier := &recordingSignatureVerifier{
+		pathTeamID:    "TEAMID",
+		processTeamID: "TEAMID",
+	}
+	validator := newTestTrustedExecutableValidator([]string{trusted}, verifier)
+
+	if err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted, PID: 4321}); err != nil {
+		t.Fatalf("ValidateExecPeer returned error: %v", err)
+	}
+	wantPath := comparablePath(trusted)
+	if !slices.Equal(verifier.paths, []string{wantPath}) {
+		t.Fatalf("verified paths = %v, want [%s]", verifier.paths, wantPath)
+	}
+	if !slices.Equal(verifier.pids, []int{4321}) {
+		t.Fatalf("verified pids = %v, want [4321]", verifier.pids)
+	}
+}
+
+func TestTrustedExecutableValidatorRejectsPeerProcessSignatureMismatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	trusted := writeExecutableAt(t, dir, "agent-secret")
+	verifier := &recordingSignatureVerifier{
+		pathTeamID:    "TEAMID",
+		processTeamID: "OTHERTEAM",
+	}
+	validator := newTestTrustedExecutableValidator([]string{trusted}, verifier)
+
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted, PID: 4321})
+	if !errors.Is(err, ErrUntrustedClient) {
+		t.Fatalf("expected ErrUntrustedClient, got %v", err)
+	}
+	wantPath := comparablePath(trusted)
+	if !slices.Equal(verifier.paths, []string{wantPath}) {
+		t.Fatalf("verified paths = %v, want [%s]", verifier.paths, wantPath)
+	}
+	if !slices.Equal(verifier.pids, []int{4321}) {
+		t.Fatalf("verified pids = %v, want [4321]", verifier.pids)
+	}
+}
+
+func TestTrustedExecutableValidatorRejectsMissingPIDForSignatureValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	trusted := writeExecutableAt(t, dir, "agent-secret")
+	verifier := &recordingSignatureVerifier{
+		pathTeamID:    "TEAMID",
+		processTeamID: "TEAMID",
+	}
+	validator := newTestTrustedExecutableValidator([]string{trusted}, verifier)
+
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted})
+	if !errors.Is(err, ErrUntrustedClient) {
+		t.Fatalf("expected ErrUntrustedClient, got %v", err)
+	}
+	if len(verifier.paths) != 0 || len(verifier.pids) != 0 {
+		t.Fatalf("signature verifier called for missing pid: paths=%v pids=%v", verifier.paths, verifier.pids)
+	}
+}
+
+func TestTrustedExecutableValidatorWrapsPeerProcessSignatureFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	trusted := writeExecutableAt(t, dir, "agent-secret")
+	verifier := &recordingSignatureVerifier{
+		pathTeamID: "TEAMID",
+		processErr: errors.New("codesign refused pid"),
+	}
+	validator := newTestTrustedExecutableValidator([]string{trusted}, verifier)
+
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted, PID: 4321})
+	if !errors.Is(err, ErrUntrustedClient) {
+		t.Fatalf("expected ErrUntrustedClient, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "verify peer process signature") {
+		t.Fatalf("error = %q, want peer process signature context", err.Error())
 	}
 }
 


### PR DESCRIPTION
Fixes #135.

## Summary
- Keep trusted executable path snapshot validation, and add PID-based codesign validation when a production Team ID is configured.
- Reuse the signature verifier for daemon and CLI peer trust, so the trusted path and the live connected process must both match the expected Team ID.
- Add daemon tests for live process signature validation, mismatched process identity, missing peer PID, and verifier error wrapping.

## Verification
- `mise exec -- go test ./internal/daemon`
- `mise exec -- go test -race ./internal/daemon`
- `mise run lint:go`
- `mise exec -- go test ./...`
- `mise exec -- go test -race ./...`
- `mise run build`
- `mise run lint:smart`
- `/usr/bin/codesign --verify --strict --deep +$$ && /usr/bin/codesign -dv --verbose=4 +$$`