### PR TITLE
ASR-041: Reject accountless daemon exec secrets

### DIFF
--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -43,12 +43,12 @@ func TestServerExecProtocolLifecycle(t *testing.T) {
 	aud := &memoryAudit{}
 	client, cleanup := startTestServer(t, BrokerOptions{
 		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
-		Resolver: &mockResolver{values: map[string]string{ref: "value"}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
 		Audit:    aud,
 	})
 	defer cleanup()
 
-	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}})
 	payload, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req)
 	if err != nil {
 		t.Fatalf("RequestExec returned error: %v", err)
@@ -88,12 +88,12 @@ func TestServerRebasesExecRequestTimeToDaemonClock(t *testing.T) {
 	}
 	client, cleanup := startTestServer(t, BrokerOptions{
 		Approver: approver,
-		Resolver: &mockResolver{values: map[string]string{ref: "value"}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
 		Audit:    &memoryAudit{},
 	})
 	defer cleanup()
 
-	req := testExecRequestAt(t, daemonNow.Add(24*time.Hour), []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req := testExecRequestAt(t, daemonNow.Add(24*time.Hour), []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}})
 	req.TTL = 10 * time.Minute
 	req.ExpiresAt = req.ReceivedAt.Add(req.TTL)
 	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); err != nil {
@@ -120,7 +120,7 @@ func TestServerAllowsCommandCompletionAfterProtocolReadTimeout(t *testing.T) {
 	aud := &memoryAudit{}
 	broker := newTestBroker(t, BrokerOptions{
 		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
-		Resolver: &mockResolver{values: map[string]string{ref: "value"}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
 		Audit:    aud,
 	})
 	path, stop := startRawServerWithOptions(t, ServerOptions{
@@ -139,7 +139,7 @@ func TestServerAllowsCommandCompletionAfterProtocolReadTimeout(t *testing.T) {
 	defer func() { _ = client.Close() }()
 
 	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", testExecRequest(t, []request.SecretSpec{
-		{Alias: "TOKEN", Ref: ref},
+		{Alias: "TOKEN", Ref: ref, Account: "Work"},
 	})); err != nil {
 		t.Fatalf("RequestExec returned error: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestServerRejectsBadProtocolVersionAndNonceMismatch(t *testing.T) {
 
 	client, cleanup := startTestServer(t, BrokerOptions{
 		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
-		Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey("op://Example/Item/token", "Work"): "value"}},
 		Audit:    &memoryAudit{},
 	})
 	defer cleanup()
@@ -174,7 +174,7 @@ func TestServerRejectsBadProtocolVersionAndNonceMismatch(t *testing.T) {
 		t.Fatal("unexpectedly connected to unrelated test socket path")
 	}
 
-	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"}})
 	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); err != nil {
 		t.Fatalf("RequestExec returned error: %v", err)
 	}
@@ -341,13 +341,13 @@ func TestServerClientDisconnectAfterPayloadAudits(t *testing.T) {
 	aud := &memoryAudit{}
 	client, cleanup := startTestServer(t, BrokerOptions{
 		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
-		Resolver: &mockResolver{values: map[string]string{ref: "value"}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
 		Audit:    aud,
 	})
 	defer cleanup()
 
 	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", testExecRequest(t, []request.SecretSpec{
-		{Alias: "TOKEN", Ref: ref},
+		{Alias: "TOKEN", Ref: ref, Account: "Work"},
 	})); err != nil {
 		t.Fatalf("RequestExec returned error: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestServerRejectsSecondExecOnSameSocketWithoutOrphaningFirst(t *testing.T) 
 	ref := "op://Example/Item/token"
 	aud := &memoryAudit{}
 	approver := &mockApprover{decision: ApprovalDecision{Approved: true}}
-	resolver := &mockResolver{values: map[string]string{ref: "value"}}
+	resolver := &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}}
 	path, stop := startRawTestServer(t, BrokerOptions{
 		Approver: approver,
 		Resolver: resolver,
@@ -385,7 +385,7 @@ func TestServerRejectsSecondExecOnSameSocketWithoutOrphaningFirst(t *testing.T) 
 	}
 	encoder := json.NewEncoder(conn)
 	decoder := json.NewDecoder(conn)
-	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}})
 
 	writeRawExecRequest(t, encoder, "req_1", "nonce_1", req)
 	first := readRawEnvelope(t, decoder)
@@ -431,13 +431,13 @@ func TestServerClientDisconnectAfterStartAuditsIncompleteLifecycle(t *testing.T)
 	aud := &memoryAudit{}
 	client, cleanup := startTestServer(t, BrokerOptions{
 		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
-		Resolver: &mockResolver{values: map[string]string{ref: canarySecretValue}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): canarySecretValue}},
 		Audit:    aud,
 	})
 	defer cleanup()
 
 	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", testExecRequest(t, []request.SecretSpec{
-		{Alias: "TOKEN", Ref: ref},
+		{Alias: "TOKEN", Ref: ref, Account: "Work"},
 	})); err != nil {
 		t.Fatalf("RequestExec returned error: %v", err)
 	}
@@ -772,8 +772,32 @@ func TestServerRejectsMalformedExecRequestBeforeApproval(t *testing.T) {
 	})
 	defer cleanup()
 
-	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"}})
 	req.Reason = "  fabricated metadata  "
+	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); !IsProtocolError(err, "bad_request") {
+		t.Fatalf("expected bad_request protocol error, got %v", err)
+	}
+	if approver.calls != 0 {
+		t.Fatalf("approver calls = %d, want 0", approver.calls)
+	}
+	if calls := resolver.Calls(); len(calls) != 0 {
+		t.Fatalf("resolver calls = %v, want none", calls)
+	}
+}
+
+func TestServerRejectsAccountlessExecRequestBeforeApproval(t *testing.T) {
+	t.Parallel()
+
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true}}
+	resolver := &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}}
+	client, cleanup := startTestServer(t, BrokerOptions{
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    &memoryAudit{},
+	})
+	defer cleanup()
+
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
 	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); !IsProtocolError(err, "bad_request") {
 		t.Fatalf("expected bad_request protocol error, got %v", err)
 	}
@@ -797,7 +821,7 @@ func TestServerRejectsSessionSocketDeliveryBeforeApproval(t *testing.T) {
 	})
 	defer cleanup()
 
-	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"}})
 	req.DeliveryMode = request.DeliverySessionSocket
 	req.MaxReads = 1
 	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); !IsProtocolError(err, "bad_request") {
@@ -837,7 +861,7 @@ func TestServerRejectsUntrustedExecPeerBeforeSecretPayload(t *testing.T) {
 	}
 	defer func() { _ = conn.Close() }()
 	client := NewClient(conn)
-	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"}})
 	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); !IsProtocolError(err, "untrusted_client") {
 		t.Fatalf("expected untrusted_client protocol error, got %v", err)
 	}
@@ -878,7 +902,7 @@ func TestServerRejectsRawSameUIDExecSocketClientBeforeApprovalOrFetch(t *testing
 	}
 	defer func() { _ = conn.Close() }()
 
-	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"}})
 	payload, err := marshalPayload(req)
 	if err != nil {
 		t.Fatalf("marshal exec request: %v", err)

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -411,6 +411,9 @@ func parseSecrets(specs []SecretSpec) ([]Secret, error) {
 func validateDaemonSecrets(secrets []Secret) ([]Secret, error) {
 	specs := make([]SecretSpec, 0, len(secrets))
 	for _, secret := range secrets {
+		if strings.TrimSpace(secret.Account) == "" {
+			return nil, fmt.Errorf("%w: secret %q account is required", ErrInvalidReference, secret.Alias)
+		}
 		parsed, err := ParseSecretRef(secret.Ref.Raw)
 		if err != nil {
 			return nil, err

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -215,6 +215,7 @@ func TestExecRequestValidateForDaemonAcceptsClientNormalizedRequest(t *testing.T
 	if err != nil {
 		t.Fatalf("NewExec returned error: %v", err)
 	}
+	req.Secrets[0].Account = "Work"
 	if err := req.ValidateForDaemon(); err != nil {
 		t.Fatalf("ValidateForDaemon returned error: %v", err)
 	}
@@ -229,6 +230,7 @@ func TestExecRequestValidateForDaemonRejectsFabricatedMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExec returned error: %v", err)
 	}
+	req.Secrets[0].Account = "Work"
 
 	tests := []struct {
 		name   string
@@ -247,6 +249,9 @@ func TestExecRequestValidateForDaemonRejectsFabricatedMetadata(t *testing.T) {
 			r.MaxReads = 1
 		}, want: ErrInvalidDeliveryMode},
 		{name: "tampered ref metadata", mutate: func(r *ExecRequest) { r.Secrets[0].Ref.Field = "other" }, want: ErrInvalidReference},
+		{name: "empty account", mutate: func(r *ExecRequest) { r.Secrets[0].Account = "" }, want: ErrInvalidReference},
+		{name: "blank account", mutate: func(r *ExecRequest) { r.Secrets[0].Account = " \t " }, want: ErrInvalidReference},
+		{name: "unnormalized account", mutate: func(r *ExecRequest) { r.Secrets[0].Account = " Work " }, want: ErrInvalidReference},
 		{name: "duplicate alias", mutate: func(r *ExecRequest) {
 			r.Secrets = append(r.Secrets, r.Secrets[0])
 		}, want: ErrInvalidAlias},


### PR DESCRIPTION
Fixes #136.

## Summary
- Reject daemon-facing exec requests whose secret metadata has an empty or blank account.
- Keep CLI-side account defaulting intact by preserving `NewExec` behavior and testing CLI parse paths.
- Add request and server regressions that prove account-less payloads fail before approval or secret resolution.

## Verification
- `mise exec -- go test ./internal/request ./internal/daemon`
- `mise exec -- go test ./internal/request ./internal/daemon ./internal/cli`
- `mise exec -- go test -race ./internal/request ./internal/daemon ./internal/cli`
- `mise run lint:go`
- `mise exec -- go test ./...`
- `mise exec -- go test -race ./...`
- `mise run build`
- `mise run lint:smart`