### PR TITLE
ASR-042: Remove duplicate env aliases on override

### DIFF
--- a/internal/execwrap/execwrap.go
+++ b/internal/execwrap/execwrap.go
@@ -167,35 +167,38 @@ func Run(ctx context.Context, spec Spec, interrupts <-chan os.Signal) (Result, e
 }
 
 func MergeEnv(base []string, overlay map[string]string, override bool) ([]string, error) {
-	positions := make(map[string]int, len(base))
-	out := slices.Clone(base)
-
-	for i, entry := range out {
-		key, _, ok := strings.Cut(entry, "=")
-		if ok {
-			positions[key] = i
-		}
-	}
-
 	aliases := make([]string, 0, len(overlay))
 	for alias := range overlay {
 		aliases = append(aliases, alias)
 	}
 	slices.Sort(aliases)
 
+	overlayAliases := make(map[string]struct{}, len(aliases))
 	for _, alias := range aliases {
-		value := overlay[alias]
-		entry := alias + "=" + value
-		if pos, exists := positions[alias]; exists {
-			if !override {
-				return nil, fmt.Errorf("%w: %s", ErrEnvironmentConflict, alias)
+		overlayAliases[alias] = struct{}{}
+	}
+
+	out := make([]string, 0, len(base)+len(overlay))
+	existing := make(map[string]struct{}, len(base))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			existing[key] = struct{}{}
+			if override {
+				if _, exists := overlayAliases[key]; exists {
+					continue
+				}
 			}
-			out[pos] = entry
-			continue
+		}
+		out = append(out, entry)
+	}
+
+	for _, alias := range aliases {
+		if _, exists := existing[alias]; exists && !override {
+			return nil, fmt.Errorf("%w: %s", ErrEnvironmentConflict, alias)
 		}
 
-		positions[alias] = len(out)
-		out = append(out, entry)
+		out = append(out, alias+"="+overlay[alias])
 	}
 
 	return out, nil

--- a/internal/execwrap/execwrap_test.go
+++ b/internal/execwrap/execwrap_test.go
@@ -65,6 +65,21 @@ func TestMergeEnvRejectsConflictsByDefault(t *testing.T) {
 	}
 }
 
+func TestMergeEnvRejectsDuplicateConflictsByDefault(t *testing.T) {
+	t.Parallel()
+
+	_, err := MergeEnv([]string{
+		"AGENT_SECRET_CANARY=first-stale-value",
+		"PATH=/usr/bin",
+		"AGENT_SECRET_CANARY=second-stale-value",
+	}, map[string]string{
+		"AGENT_SECRET_CANARY": syntheticSecret,
+	}, false)
+	if !errors.Is(err, ErrEnvironmentConflict) {
+		t.Fatalf("expected environment conflict, got %v", err)
+	}
+}
+
 func TestMergeEnvCanOverrideExistingAlias(t *testing.T) {
 	t.Parallel()
 
@@ -73,6 +88,36 @@ func TestMergeEnvCanOverrideExistingAlias(t *testing.T) {
 	}, true)
 	if err != nil {
 		t.Fatalf("MergeEnv returned error: %v", err)
+	}
+	if got := findEnv(env, "AGENT_SECRET_CANARY"); got != syntheticSecret {
+		t.Fatalf("merged env value = %q, want synthetic secret", got)
+	}
+}
+
+func TestMergeEnvOverrideRemovesDuplicateExistingAliases(t *testing.T) {
+	t.Parallel()
+
+	env, err := MergeEnv([]string{
+		"AGENT_SECRET_CANARY=first-stale-value",
+		"PATH=/usr/bin",
+		"AGENT_SECRET_CANARY=second-stale-value",
+		"KEEP=kept",
+	}, map[string]string{
+		"AGENT_SECRET_CANARY": syntheticSecret,
+	}, true)
+	if err != nil {
+		t.Fatalf("MergeEnv returned error: %v", err)
+	}
+	want := []string{
+		"PATH=/usr/bin",
+		"KEEP=kept",
+		"AGENT_SECRET_CANARY=" + syntheticSecret,
+	}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("merged env = %v, want %v", env, want)
+	}
+	if got := countEnv(env, "AGENT_SECRET_CANARY"); got != 1 {
+		t.Fatalf("merged env has %d canary entries, want 1: %v", got, env)
 	}
 	if got := findEnv(env, "AGENT_SECRET_CANARY"); got != syntheticSecret {
 		t.Fatalf("merged env value = %q, want synthetic secret", got)
@@ -441,6 +486,17 @@ func findEnv(env []string, key string) string {
 		}
 	}
 	return ""
+}
+
+func countEnv(env []string, key string) int {
+	count := 0
+	for _, entry := range env {
+		gotKey, _, ok := strings.Cut(entry, "=")
+		if ok && gotKey == key {
+			count++
+		}
+	}
+	return count
 }
 
 func helperEnv(pairs ...string) map[string]string {


### PR DESCRIPTION
Fixes #137.

## Summary
- Make `MergeEnv` remove every inherited entry for approved aliases when override is enabled.
- Preserve non-override conflict behavior even when the inherited environment contains duplicate aliases.
- Add duplicate-base-env regressions for both override and non-override modes.

## Verification
- `mise exec -- go test ./internal/execwrap`
- `mise exec -- go test -race ./internal/execwrap`
- `mise run lint:go`
- `mise exec -- go test ./...` (initial daemon health-check timeout flaked, immediate rerun passed)
- `mise exec -- go test -race ./...`
- `mise run build`
- `mise run lint:smart`