### PR TITLE
ASR-043: Pin release signing preflight to Team ID

### DIFF
--- a/scripts/check-release-signing-env.sh
+++ b/scripts/check-release-signing-env.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 missing=0
+expected_team_id="B6L7QLWTZW"
 
 require_env() {
   local name="$1"
@@ -26,5 +27,10 @@ fi
 
 if [[ "$AGENT_SECRET_NOTARIZE" != "1" ]]; then
   echo "release signing configuration: AGENT_SECRET_NOTARIZE must be 1 for tag releases" >&2
+  exit 1
+fi
+
+if [[ ! "$AGENT_SECRET_CODESIGN_IDENTITY" =~ \(${expected_team_id}\)$ ]]; then
+  echo "release signing configuration: AGENT_SECRET_CODESIGN_IDENTITY must use Developer ID Team ID $expected_team_id" >&2
   exit 1
 fi

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -33,7 +33,7 @@ expect_failure() {
 release_env=(
   AGENT_SECRET_CODESIGN_CERT_P12_BASE64=dummy-p12
   AGENT_SECRET_CODESIGN_CERT_PASSWORD=dummy-password
-  "AGENT_SECRET_CODESIGN_IDENTITY=Developer ID Application: Example (TEAMID)"
+  "AGENT_SECRET_CODESIGN_IDENTITY=Developer ID Application: Oleksiy Kovyrin (B6L7QLWTZW)"
   AGENT_SECRET_NOTARY_KEY=dummy-key
   AGENT_SECRET_NOTARY_KEY_ID=dummy-key-id
   AGENT_SECRET_NOTARY_ISSUER_ID=dummy-issuer-id
@@ -44,6 +44,9 @@ expect_failure "missing AGENT_SECRET_CODESIGN_CERT_P12_BASE64" \
 
 expect_failure "AGENT_SECRET_NOTARIZE must be 1" \
   env -i "PATH=$test_path" "${release_env[@]}" AGENT_SECRET_NOTARIZE=0 "$check_script"
+
+expect_failure "AGENT_SECRET_CODESIGN_IDENTITY must use Developer ID Team ID B6L7QLWTZW" \
+  env -i "PATH=$test_path" "${release_env[@]}" "AGENT_SECRET_CODESIGN_IDENTITY=Developer ID Application: Example (TEAMID)" AGENT_SECRET_NOTARIZE=1 "$check_script"
 
 env -i "PATH=$test_path" "${release_env[@]}" AGENT_SECRET_NOTARIZE=1 "$check_script"
 


### PR DESCRIPTION
Fixes #138.

## Summary
- Require maintainer release signing identity to end with the documented Developer ID Team ID `B6L7QLWTZW`.
- Update the release-signing smoke test happy path to use the production Team ID.
- Add a wrong-Team regression so misconfigured release secrets fail before draft artifacts are published.

## Verification
- `AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh`
- `mise run lint:shell`
- `mise run test:smoke`
- `git diff --check`
- `mise run lint:smart`