### PR TITLE
ASR-045: Replace stale threat model finding map

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -243,24 +243,14 @@ Use these priorities for review findings:
 
 Severity should describe concrete product harm, not generic security anxiety.
 
-## Current Finding Map
+## Review Finding Ledger
 
-The 2026-05-03 review produced these findings against this model:
+This document is the stable review contract, not the live issue tracker.
+Current open findings live in GitHub issues named `ASR-NNN`. Historical review
+reports live in `docs/release-code-review-*.md` and may describe findings that
+have since been fixed.
 
-- ASR-021 violates the release and install boundary because the installer checks
-  Apple acceptance but not the expected Agent Secret signer or bundle identity.
-- ASR-022 is a residual CLI-to-child-process launch issue because executable
-  identity is verified by path before `exec`, not launched atomically.
-- ASR-023 violates the CLI-to-daemon startup boundary because readiness can be
-  reported against a live but untrusted socket.
-- ASR-024 violates the daemon-to-approver boundary because the Swift approver
-  renders requests from any socket it is pointed at.
-- ASR-025 violates the audit filesystem boundary because audit log opens follow
-  symlinks and can append to an arbitrary user-owned file.
-- ASR-026 violates the release and install boundary because uninstall can
-  recursively delete environment-selected paths.
-- ASR-027 violates the documentation goal because release and smoke-test docs
-  describe behavior that no longer matches the code.
-
-Future reviews should either map findings to the boundaries above or propose an
-explicit update to this document.
+When a review produces a finding, the finding should map to one of the trust
+boundaries above, or it should propose an explicit update to this threat model.
+Fix status, PR links, and closure evidence belong in the GitHub issue and PR
+history rather than in this model.

--- a/scripts/test-release-docs.sh
+++ b/scripts/test-release-docs.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 readme="$project_root/README.md"
+threat_model="$project_root/docs/threat-model.md"
 
 fail() {
   echo "test-release-docs: $*" >&2
@@ -26,6 +27,22 @@ reject_text() {
   fi
 }
 
+require_threat_model_text() {
+  local needle="$1"
+
+  if ! grep -F -- "$needle" "$threat_model" >/dev/null; then
+    fail "docs/threat-model.md is missing expected review documentation: $needle"
+  fi
+}
+
+reject_threat_model_text() {
+  local needle="$1"
+
+  if grep -F -- "$needle" "$threat_model" >/dev/null; then
+    fail "docs/threat-model.md still contains stale review documentation: $needle"
+  fi
+}
+
 require_text "AGENT_SECRET_IN_MISE=1 scripts/test-install.sh"
 require_text "AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh"
 require_text "AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh"
@@ -38,5 +55,12 @@ require_text "--require-production-signing"
 require_text "Tag-triggered GitHub releases require production"
 reject_text "Local and CI builds are ad-hoc signed by default"
 reject_text "Developer ID signing and notarization are opt-in release settings"
+
+require_threat_model_text "## Review Finding Ledger"
+require_threat_model_text "Current open findings live in GitHub issues named"
+require_threat_model_text "Historical review"
+reject_threat_model_text "## Current Finding Map"
+reject_threat_model_text "The 2026-05-03 review produced these findings against this model:"
+reject_threat_model_text "ASR-021 violates"
 
 echo "test-release-docs: ok"


### PR DESCRIPTION
Fixes #140.

## Summary
- Replace the stale `Current Finding Map` with a status-neutral review finding ledger.
- Point current ASR status to GitHub issues and historical context to review report files.
- Extend the docs smoke guard to require the new ledger wording and reject the stale current-finding text.

## Verification
- `AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh`
- `npx --no-install markdownlint docs/threat-model.md`
- `mise run lint:shell`
- `mise run test:smoke`
- `git diff --check`
- `mise run lint:smart`