### PR TITLE
ASR-046: Pin mise binary in GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  AGENT_SECRET_MISE_VERSION: "2026.4.28"
+  AGENT_SECRET_MISE_SHA256_MACOS_ARM64: f0f5fa48643a00442c8cc066f8350285896561f2491bcbbee93b1a9a8249816d
 
 permissions:
   contents: read
@@ -25,6 +27,8 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
+          version: ${{ env.AGENT_SECRET_MISE_VERSION }}
+          sha256: ${{ env.AGENT_SECRET_MISE_SHA256_MACOS_ARM64 }}
           install: true
           cache: true
 
@@ -50,6 +54,8 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
+          version: ${{ env.AGENT_SECRET_MISE_VERSION }}
+          sha256: ${{ env.AGENT_SECRET_MISE_SHA256_MACOS_ARM64 }}
           install: true
           cache: true
 
@@ -72,8 +78,10 @@ jobs:
         include:
           - arch: arm64
             runner: macos-latest
+            mise_sha256: f0f5fa48643a00442c8cc066f8350285896561f2491bcbbee93b1a9a8249816d
           - arch: x86_64
             runner: macos-15-intel
+            mise_sha256: 43c02a612949a37ba53bb4e1e89859da2b198b6e7dad753f31cf66db5af36b19
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -81,6 +89,8 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
+          version: ${{ env.AGENT_SECRET_MISE_VERSION }}
+          sha256: ${{ matrix.mise_sha256 }}
           install: true
           cache: true
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -153,6 +153,29 @@ Do not print, commit, paste, or attach `.p8`, `.p12`, private key, or password
 material. If a notary API key must be recreated, use an App Store Connect Team
 Key and store the downloaded `.p8` directly in GitHub Secrets.
 
+## Toolchain Pin Maintenance
+
+The GitHub workflow pins both `jdx/mise-action` and the `mise` binary that the
+action downloads. When updating the CI toolchain, update these values together
+in `.github/workflows/ci.yml`:
+
+- `AGENT_SECRET_MISE_VERSION`
+- `AGENT_SECRET_MISE_SHA256_MACOS_ARM64`
+- each release matrix `mise_sha256` value
+
+Resolve checksums from the official `jdx/mise` release archive for every GitHub
+runner architecture:
+
+```bash
+version=2026.4.28
+shasum -a 256 "mise-v${version}-macos-arm64.tar.gz"
+shasum -a 256 "mise-v${version}-macos-x64.tar.gz"
+```
+
+Run `AGENT_SECRET_IN_MISE=1 scripts/test-workflow-actions-pinned.sh` after any
+workflow change. That smoke test fails if a `jdx/mise-action` step does not set
+both `version` and `sha256`.
+
 ## Failed Release Runs
 
 If a tag-triggered release fails before publication:

--- a/scripts/check-workflow-actions-pinned.sh
+++ b/scripts/check-workflow-actions-pinned.sh
@@ -16,8 +16,31 @@ for file in "${workflow_files[@]}"; do
   [ -f "$file" ] || continue
 
   line_no=0
+  mise_action_line=0
+  mise_has_version=0
+  mise_has_sha256=0
+
+  finish_mise_action() {
+    if [ "$mise_action_line" -eq 0 ]; then
+      return
+    fi
+
+    if [ "$mise_has_version" -eq 0 ] || [ "$mise_has_sha256" -eq 0 ]; then
+      echo "$file:$mise_action_line: jdx/mise-action must pin mise version and sha256" >&2
+      status=1
+    fi
+
+    mise_action_line=0
+    mise_has_version=0
+    mise_has_sha256=0
+  }
+
   while IFS= read -r line || [ -n "$line" ]; do
     line_no=$((line_no + 1))
+
+    if [ "$mise_action_line" -ne 0 ] && [[ "$line" =~ ^[[:space:]]*-[[:space:]] ]]; then
+      finish_mise_action
+    fi
 
     if [[ "$line" =~ ^[[:space:]-]*uses:[[:space:]]*([^[:space:]#]+) ]]; then
       action="${BASH_REMATCH[1]}"
@@ -41,8 +64,22 @@ for file in "${workflow_files[@]}"; do
         echo "$file:$line_no: action must be pinned to a full commit SHA: $action" >&2
         status=1
       fi
+
+      if [[ "$action" == jdx/mise-action@* ]]; then
+        mise_action_line="$line_no"
+      fi
+    fi
+
+    if [ "$mise_action_line" -ne 0 ]; then
+      if [[ "$line" =~ ^[[:space:]]*version:[[:space:]]*.+$ ]]; then
+        mise_has_version=1
+      fi
+      if [[ "$line" =~ ^[[:space:]]*sha256:[[:space:]]*.+$ ]]; then
+        mise_has_sha256=1
+      fi
     fi
   done <"$file"
+  finish_mise_action
 done
 
 if [ "$status" -ne 0 ]; then
@@ -50,6 +87,7 @@ if [ "$status" -ne 0 ]; then
     echo
     echo "GitHub Actions workflows must pin third-party actions to immutable 40-character commit SHAs."
     echo "Use \`gh api repos/<owner>/<repo>/git/ref/tags/<tag> --jq .object.sha\` to resolve a tag before updating the workflow."
+    echo "jdx/mise-action must also pin the downloaded mise binary with explicit version and sha256 inputs."
   } >&2
 fi
 

--- a/scripts/test-release-docs.sh
+++ b/scripts/test-release-docs.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 readme="$project_root/README.md"
+release_process="$project_root/docs/release-process.md"
 threat_model="$project_root/docs/threat-model.md"
 
 fail() {
@@ -24,6 +25,14 @@ reject_text() {
 
   if grep -F -- "$needle" "$readme" >/dev/null; then
     fail "README.md still contains stale release documentation: $needle"
+  fi
+}
+
+require_release_process_text() {
+  local needle="$1"
+
+  if ! grep -F -- "$needle" "$release_process" >/dev/null; then
+    fail "docs/release-process.md is missing expected release documentation: $needle"
   fi
 }
 
@@ -55,6 +64,10 @@ require_text "--require-production-signing"
 require_text "Tag-triggered GitHub releases require production"
 reject_text "Local and CI builds are ad-hoc signed by default"
 reject_text "Developer ID signing and notarization are opt-in release settings"
+
+require_release_process_text "## Toolchain Pin Maintenance"
+require_release_process_text "AGENT_SECRET_MISE_VERSION"
+require_release_process_text "scripts/test-workflow-actions-pinned.sh"
 
 require_threat_model_text "## Review Finding Ledger"
 require_threat_model_text "Current open findings live in GitHub issues named"

--- a/scripts/test-workflow-actions-pinned.sh
+++ b/scripts/test-workflow-actions-pinned.sh
@@ -36,6 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
+        with:
+          version: "2026.4.28"
+          sha256: f0f5fa48643a00442c8cc066f8350285896561f2491bcbbee93b1a9a8249816d
       - uses: ./.github/actions/local-action
 YAML
 "$check_script" "$tmp_dir/pinned.yml"
@@ -72,5 +76,31 @@ jobs:
       - uses: actions/checkout@34e1148
 YAML
 expect_failure "actions/checkout@34e1148" "$check_script" "$tmp_dir/short-sha.yml"
+
+cat >"$tmp_dir/mise-no-version.yml" <<'YAML'
+name: mise-no-version
+on: push
+jobs:
+  mise-no-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
+        with:
+          sha256: f0f5fa48643a00442c8cc066f8350285896561f2491bcbbee93b1a9a8249816d
+YAML
+expect_failure "jdx/mise-action must pin mise version and sha256" "$check_script" "$tmp_dir/mise-no-version.yml"
+
+cat >"$tmp_dir/mise-no-sha.yml" <<'YAML'
+name: mise-no-sha
+on: push
+jobs:
+  mise-no-sha:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
+        with:
+          version: "2026.4.28"
+YAML
+expect_failure "jdx/mise-action must pin mise version and sha256" "$check_script" "$tmp_dir/mise-no-sha.yml"
 
 echo "test-workflow-actions-pinned: ok"


### PR DESCRIPTION
## Summary
- pin the mise runtime version and per-runner binary checksums in GitHub Actions
- teach the workflow pinning check to require `version` and `sha256` on every `jdx/mise-action` step
- document the maintainer process for rotating the mise binary pins

Fixes #141

## Verification
- `AGENT_SECRET_IN_MISE=1 scripts/test-workflow-actions-pinned.sh`
- `mise exec -- actionlint .github/workflows/ci.yml`
- `AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh`
- `mise run lint:shell`
- `npx --no-install markdownlint docs/release-process.md`
- `mise run test:smoke`
- `git diff --check`
- `mise run lint:smart`