### PR TITLE
ASR-047: Validate Swift daemon peer process identity

### DIFF
--- a/approver/Sources/AgentSecretApprover/DaemonCodeSignatureChecking.swift
+++ b/approver/Sources/AgentSecretApprover/DaemonCodeSignatureChecking.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+#if canImport(Darwin)
+    import Darwin
+
+    protocol DaemonCodeSignatureChecking {
+        func staticCodeTeamID(for path: String) throws -> String
+        func processTeamID(for pid: pid_t) throws -> String
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/SecurityDaemonCodeSignatureChecker.swift
+++ b/approver/Sources/AgentSecretApprover/SecurityDaemonCodeSignatureChecker.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+#if canImport(Darwin)
+    import Darwin
+    import Security
+
+    struct SecurityDaemonCodeSignatureChecker: DaemonCodeSignatureChecking {
+        private static func runCodesign(arguments: [String]) throws -> String {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+            process.arguments = arguments
+            let output = Pipe()
+            process.standardOutput = output
+            process.standardError = output
+            do {
+                try process.run()
+            } catch {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "launch daemon process code signature validation failed: \(error)"
+                )
+            }
+            process.waitUntilExit()
+            let data = output.fileHandleForReading.readDataToEndOfFile()
+            let text = String(data: data, encoding: .utf8) ?? ""
+            guard process.terminationStatus == 0 else {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "daemon process code signature validation failed with status \(process.terminationStatus)"
+                )
+            }
+            return text
+        }
+
+        private static func teamID(forStaticCode code: SecStaticCode) throws -> String {
+            var information: CFDictionary?
+            let copyStatus = SecCodeCopySigningInformation(
+                code,
+                SecCSFlags(rawValue: kSecCSSigningInformation),
+                &information
+            )
+            guard copyStatus == errSecSuccess, let dictionary = information as? [String: Any] else {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "read daemon code signature failed with status \(copyStatus)"
+                )
+            }
+            guard let teamID = dictionary[kSecCodeInfoTeamIdentifier as String] as? String else {
+                throw SocketDaemonClientError.untrustedDaemon("daemon code signature has no Team ID")
+            }
+            guard !teamID.isEmpty else {
+                throw SocketDaemonClientError.untrustedDaemon("daemon code signature has no Team ID")
+            }
+            return teamID
+        }
+
+        func staticCodeTeamID(for path: String) throws -> String {
+            var staticCode: SecStaticCode?
+            let createStatus = SecStaticCodeCreateWithPath(
+                URL(fileURLWithPath: path) as CFURL,
+                SecCSFlags(),
+                &staticCode
+            )
+            guard createStatus == errSecSuccess, let code = staticCode else {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "load daemon code signature failed with status \(createStatus)"
+                )
+            }
+
+            let checkStatus = SecStaticCodeCheckValidity(
+                code,
+                SecCSFlags(rawValue: kSecCSStrictValidate),
+                nil
+            )
+            guard checkStatus == errSecSuccess else {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "daemon code signature validation failed with status \(checkStatus)"
+                )
+            }
+
+            return try Self.teamID(forStaticCode: code)
+        }
+
+        func processTeamID(for pid: pid_t) throws -> String {
+            let target = "+\(pid)"
+            _ = try Self.runCodesign(arguments: ["--verify", "--strict", "--deep", target])
+            let output = try Self.runCodesign(arguments: ["-dv", "--verbose=4", target])
+            for line in output.components(separatedBy: .newlines) {
+                let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmedLine.hasPrefix("TeamIdentifier=") {
+                    let teamID = String(trimmedLine.dropFirst("TeamIdentifier=".count))
+                    guard !teamID.isEmpty else {
+                        throw SocketDaemonClientError.untrustedDaemon("daemon code signature has no Team ID")
+                    }
+                    return teamID
+                }
+            }
+            throw SocketDaemonClientError.untrustedDaemon("daemon code signature has no Team ID")
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/TrustedDaemonPeerValidator.swift
+++ b/approver/Sources/AgentSecretApprover/TrustedDaemonPeerValidator.swift
@@ -2,7 +2,6 @@ import Foundation
 
 #if canImport(Darwin)
     import Darwin
-    import Security
 
     struct TrustedDaemonPeerValidator: DaemonPeerValidator {
         private struct TrustedExecutable {
@@ -57,10 +56,16 @@ import Foundation
         private static let expectedTeamIDKey: String = "AgentSecretExpectedTeamID"
 
         private let expectedTeamID: String
+        private let signatureChecker: DaemonCodeSignatureChecking
         private let trustedExecutables: [TrustedExecutable]
 
-        init(expectedExecutablePaths: [String], expectedTeamID: String = Self.configuredExpectedTeamID()) {
+        init(
+            expectedExecutablePaths: [String],
+            expectedTeamID: String = Self.configuredExpectedTeamID(),
+            signatureChecker: DaemonCodeSignatureChecking = SecurityDaemonCodeSignatureChecker()
+        ) {
             self.expectedTeamID = expectedTeamID.trimmingCharacters(in: .whitespacesAndNewlines)
+            self.signatureChecker = signatureChecker
 
             var seen = Set<String>()
             trustedExecutables = expectedExecutablePaths.compactMap { path in
@@ -147,51 +152,20 @@ import Foundation
             return value.trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
-        private static func codeSignatureTeamID(for path: String) throws -> String {
-            var staticCode: SecStaticCode?
-            let createStatus = SecStaticCodeCreateWithPath(
-                URL(fileURLWithPath: path) as CFURL,
-                SecCSFlags(),
-                &staticCode
-            )
-            guard createStatus == errSecSuccess, let code = staticCode else {
-                throw SocketDaemonClientError.untrustedDaemon(
-                    "load daemon code signature failed with status \(createStatus)"
-                )
+        private static func validatePeerCredentials(_ info: DaemonPeerInfo) throws {
+            guard info.uid == getuid() else {
+                throw SocketDaemonClientError.untrustedDaemon("daemon uid does not match current user")
             }
-
-            let checkStatus = SecStaticCodeCheckValidity(
-                code,
-                SecCSFlags(rawValue: kSecCSStrictValidate),
-                nil
-            )
-            guard checkStatus == errSecSuccess else {
-                throw SocketDaemonClientError.untrustedDaemon(
-                    "daemon code signature validation failed with status \(checkStatus)"
-                )
+            guard info.gid == getgid() else {
+                throw SocketDaemonClientError.untrustedDaemon("daemon gid does not match current user")
             }
-
-            var information: CFDictionary?
-            let copyStatus = SecCodeCopySigningInformation(
-                code,
-                SecCSFlags(rawValue: kSecCSSigningInformation),
-                &information
-            )
-            guard copyStatus == errSecSuccess, let dictionary = information as? [String: Any] else {
-                throw SocketDaemonClientError.untrustedDaemon(
-                    "read daemon code signature failed with status \(copyStatus)"
-                )
+            guard info.pid > 0 else {
+                throw SocketDaemonClientError.untrustedDaemon("daemon pid is unavailable")
             }
-            guard let teamID = dictionary[kSecCodeInfoTeamIdentifier as String] as? String else {
-                throw SocketDaemonClientError.untrustedDaemon("daemon code signature has no Team ID")
-            }
-            guard !teamID.isEmpty else {
-                throw SocketDaemonClientError.untrustedDaemon("daemon code signature has no Team ID")
-            }
-            return teamID
         }
 
         func validateDaemonPeer(_ info: DaemonPeerInfo) throws {
+            try Self.validatePeerCredentials(info)
             let got = Self.comparablePath(info.executablePath)
             guard !got.isEmpty else {
                 throw SocketDaemonClientError.untrustedDaemon("daemon executable path is unavailable")
@@ -205,9 +179,13 @@ import Foundation
 
             try trusted.validateCurrentFile()
             if !expectedTeamID.isEmpty {
-                let teamID = try Self.codeSignatureTeamID(for: trusted.path)
-                guard teamID == expectedTeamID else {
+                let staticTeamID = try signatureChecker.staticCodeTeamID(for: trusted.path)
+                guard staticTeamID == expectedTeamID else {
                     throw SocketDaemonClientError.untrustedDaemon("daemon Team ID does not match")
+                }
+                let processTeamID = try signatureChecker.processTeamID(for: info.pid)
+                guard processTeamID == expectedTeamID else {
+                    throw SocketDaemonClientError.untrustedDaemon("daemon process Team ID does not match")
                 }
             }
         }

--- a/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTests.swift
@@ -6,6 +6,25 @@ import XCTest
     import Darwin
 
     final class DaemonPeerValidationTests: XCTestCase {
+        private final class FakeSignatureChecker: DaemonCodeSignatureChecking {
+            var staticTeamIDResult: Result<String, Error> = .success("TEAMID")
+            var processTeamIDResult: Result<String, Error> = .success("TEAMID")
+            private(set) var processPIDs: [pid_t] = []
+
+            func staticCodeTeamID(for _: String) throws -> String {
+                try staticTeamIDResult.get()
+            }
+
+            func processTeamID(for pid: pid_t) throws -> String {
+                processPIDs.append(pid)
+                return try processTeamIDResult.get()
+            }
+
+            deinit {
+                /* Required by SwiftLint. */
+            }
+        }
+
         private final class UnixSocketServer: @unchecked Sendable {
             let path: String
             private let descriptor: Int32
@@ -61,6 +80,19 @@ import XCTest
             try XCTUnwrap(Bundle.main.executableURL?.path)
         }
 
+        private static func currentPeerInfo(
+            uid: uid_t = getuid(),
+            gid: gid_t = getgid(),
+            pid: pid_t = getpid()
+        ) throws -> DaemonPeerInfo {
+            try DaemonPeerInfo(
+                uid: uid,
+                gid: gid,
+                pid: pid,
+                executablePath: currentExecutablePath()
+            )
+        }
+
         private static func makeServer(testCase: XCTestCase) throws -> UnixSocketServer {
             let directory = URL(fileURLWithPath: "/tmp")
                 .appendingPathComponent("agent-secret-swift-tests-\(UUID().uuidString)")
@@ -89,6 +121,48 @@ import XCTest
             XCTAssertNoThrow(try validator.validateDaemonPeer(info))
         }
 
+        func testTrustedDaemonValidatorRejectsDifferentUID() throws {
+            let validator = try TrustedDaemonPeerValidator(
+                expectedExecutablePaths: [Self.currentExecutablePath()]
+            )
+            let info = try Self.currentPeerInfo(uid: getuid() + 1)
+
+            XCTAssertThrowsError(try validator.validateDaemonPeer(info)) { error in
+                XCTAssertEqual(
+                    error as? SocketDaemonClientError,
+                    .untrustedDaemon("daemon uid does not match current user")
+                )
+            }
+        }
+
+        func testTrustedDaemonValidatorRejectsDifferentGID() throws {
+            let validator = try TrustedDaemonPeerValidator(
+                expectedExecutablePaths: [Self.currentExecutablePath()]
+            )
+            let info = try Self.currentPeerInfo(gid: getgid() + 1)
+
+            XCTAssertThrowsError(try validator.validateDaemonPeer(info)) { error in
+                XCTAssertEqual(
+                    error as? SocketDaemonClientError,
+                    .untrustedDaemon("daemon gid does not match current user")
+                )
+            }
+        }
+
+        func testTrustedDaemonValidatorRejectsMissingPID() throws {
+            let validator = try TrustedDaemonPeerValidator(
+                expectedExecutablePaths: [Self.currentExecutablePath()]
+            )
+            let info = try Self.currentPeerInfo(pid: 0)
+
+            XCTAssertThrowsError(try validator.validateDaemonPeer(info)) { error in
+                XCTAssertEqual(
+                    error as? SocketDaemonClientError,
+                    .untrustedDaemon("daemon pid is unavailable")
+                )
+            }
+        }
+
         func testTrustedDaemonValidatorRejectsUnexpectedExecutablePeer() throws {
             var descriptors = [Int32](repeating: -1, count: 2)
             XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
@@ -106,6 +180,38 @@ import XCTest
                     .untrustedDaemon("daemon executable is not trusted")
                 )
             }
+        }
+
+        func testTrustedDaemonValidatorChecksProcessTeamIDWhenExpected() throws {
+            let checker = FakeSignatureChecker()
+            let validator = try TrustedDaemonPeerValidator(
+                expectedExecutablePaths: [Self.currentExecutablePath()],
+                expectedTeamID: "TEAMID",
+                signatureChecker: checker
+            )
+            let info = try Self.currentPeerInfo()
+
+            XCTAssertNoThrow(try validator.validateDaemonPeer(info))
+            XCTAssertEqual(checker.processPIDs, [getpid()])
+        }
+
+        func testTrustedDaemonValidatorRejectsMismatchedProcessTeamID() throws {
+            let checker = FakeSignatureChecker()
+            checker.processTeamIDResult = .success("OTHERTEAM")
+            let validator = try TrustedDaemonPeerValidator(
+                expectedExecutablePaths: [Self.currentExecutablePath()],
+                expectedTeamID: "TEAMID",
+                signatureChecker: checker
+            )
+            let info = try Self.currentPeerInfo()
+
+            XCTAssertThrowsError(try validator.validateDaemonPeer(info)) { error in
+                XCTAssertEqual(
+                    error as? SocketDaemonClientError,
+                    .untrustedDaemon("daemon process Team ID does not match")
+                )
+            }
+            XCTAssertEqual(checker.processPIDs, [getpid()])
         }
 
         func testPathTransportRejectsSocketBeforeProtocolWhenPeerIsUntrusted() throws {


### PR DESCRIPTION
Fixes #150

## Summary
- require the Swift approver to validate peer UID, GID, and PID before trusting a socket peer
- validate both the daemon executable on disk and the connected daemon process Team ID when production Team ID metadata is configured
- add daemon peer validation tests for UID/GID/PID rejection and mismatched process Team ID rejection

## Verification
- mise run lint:swift
- swift test --filter DaemonPeerValidationTests (from approver/)
- swift test (from approver/)
- /usr/bin/codesign -dv --verbose=4 +$$
- /usr/bin/codesign --verify --strict --deep +$$
- mise run lint:smart
- mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=1
- mise run test

Note: the first repo-level `mise run test` attempt hit the known transient `TestProcessApproverLauncherHealthCheck` timeout; the focused rerun and full rerun both passed.