### PR TITLE
ASR-048: Validate approver process identity

### DIFF
--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -67,15 +67,20 @@ type ApproverIdentityPolicy interface {
 }
 
 type ApproverIdentity struct {
-	ExecutablePath string
-	BundlePath     string
-	BundleID       string
-	TeamID         string
+	ExecutablePath  string
+	BundlePath      string
+	BundleID        string
+	TeamID          string
+	ExpectedTeamID  string
+	VerifySignature bool
 }
 
 type ExpectedApprover struct {
-	PID            int
-	ExecutablePath string
+	PID               int
+	ExecutablePath    string
+	ExpectedTeamID    string
+	VerifySignature   bool
+	signatureVerifier codeSignatureVerifier
 }
 
 type SocketApprover struct {
@@ -282,8 +287,11 @@ func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string, 
 		return ExpectedApprover{}, fmt.Errorf("%w: %w", ErrApproverLaunchFailed, err)
 	}
 	expected := ExpectedApprover{
-		PID:            cmd.Process.Pid,
-		ExecutablePath: executable,
+		PID:               cmd.Process.Pid,
+		ExecutablePath:    executable,
+		ExpectedTeamID:    identity.ExpectedTeamID,
+		VerifySignature:   identity.VerifySignature,
+		signatureVerifier: codesignSignatureVerifier{},
 	}
 	if err := cmd.Process.Release(); err != nil {
 		return ExpectedApprover{}, fmt.Errorf("%w: release process: %w", ErrApproverLaunchFailed, err)
@@ -410,6 +418,9 @@ func validateApproverPeer(expected ExpectedApprover, got peercred.Info) error {
 		return fmt.Errorf("%w: pid %d != %d", ErrApproverPeerMismatch, got.PID, expected.PID)
 	}
 	if expected.ExecutablePath == "" {
+		if expected.VerifySignature && strings.TrimSpace(expected.ExpectedTeamID) != "" {
+			return fmt.Errorf("%w: executable path is unavailable for signature validation", ErrApproverPeerMismatch)
+		}
 		return nil
 	}
 	expectedPath, err := comparableApproverPath(expected.ExecutablePath)
@@ -422,6 +433,20 @@ func validateApproverPeer(expected ExpectedApprover, got peercred.Info) error {
 	}
 	if gotPath != expectedPath {
 		return fmt.Errorf("%w: executable %q != %q", ErrApproverPeerMismatch, gotPath, expectedPath)
+	}
+	if expected.VerifySignature {
+		expectedTeamID := strings.TrimSpace(expected.ExpectedTeamID)
+		if expectedTeamID != "" {
+			if err := validatePeerSignature(
+				got,
+				expectedPath,
+				expectedTeamID,
+				expected.signatureVerifier,
+				ErrApproverPeerMismatch,
+			); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -31,6 +31,18 @@ func (allowApproverIdentityPolicy) ValidateApproverExecutable(path string) (Appr
 	return ApproverIdentity{ExecutablePath: path}, nil
 }
 
+type staticApproverIdentityPolicy struct {
+	identity ApproverIdentity
+}
+
+func (p staticApproverIdentityPolicy) ValidateApproverExecutable(path string) (ApproverIdentity, error) {
+	identity := p.identity
+	if identity.ExecutablePath == "" {
+		identity.ExecutablePath = path
+	}
+	return identity, nil
+}
+
 func (l *recordingLauncher) Launch(_ context.Context, _ string, payload ApprovalRequestPayload) (ExpectedApprover, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -166,6 +178,96 @@ func TestSocketApproverRejectsWrongPeerAndStaleNonce(t *testing.T) {
 	}
 	if err := <-errCh; !errors.Is(err, ErrApprovalDenied) {
 		t.Fatalf("ApproveExec error = %v, want denial", err)
+	}
+}
+
+func TestSocketApproverRejectsFetchFromWrongApproverProcessSignature(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	verifier := &recordingSignatureVerifier{
+		pathTeamID:    "TEAMID",
+		processTeamID: "OTHERTEAM",
+	}
+	launcher := &recordingLauncher{
+		expected: ExpectedApprover{
+			PID:               os.Getpid(),
+			ExecutablePath:    exe,
+			ExpectedTeamID:    "TEAMID",
+			VerifySignature:   true,
+			signatureVerifier: verifier,
+		},
+	}
+	approver := newSocketApproverForTest(t, launcher, time.Now)
+	req := approvalTestRequest(t, time.Now().Add(time.Minute))
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := approver.ApproveExec(ctx, "req_1", "nonce_1", req)
+		errCh <- err
+	}()
+	waitForPending(t, approver)
+
+	_, err := approver.FetchPending(context.Background(), peerInfoForTest(t, os.Getpid(), exe))
+	if !errors.Is(err, ErrApproverPeerMismatch) {
+		t.Fatalf("expected approver peer mismatch, got %v", err)
+	}
+	if !slices.Equal(verifier.pids, []int{os.Getpid()}) {
+		t.Fatalf("verified pids = %v, want [%d]", verifier.pids, os.Getpid())
+	}
+
+	cancel()
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("ApproveExec error = %v, want context cancellation", err)
+	}
+}
+
+func TestSocketApproverRejectsDecisionFromWrongApproverProcessSignature(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	verifier := &recordingSignatureVerifier{
+		pathTeamID:    "TEAMID",
+		processTeamID: "TEAMID",
+	}
+	launcher := &recordingLauncher{
+		expected: ExpectedApprover{
+			PID:               os.Getpid(),
+			ExecutablePath:    exe,
+			ExpectedTeamID:    "TEAMID",
+			VerifySignature:   true,
+			signatureVerifier: verifier,
+		},
+	}
+	approver := newSocketApproverForTest(t, launcher, time.Now)
+	req := approvalTestRequest(t, time.Now().Add(time.Minute))
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := approver.ApproveExec(ctx, "req_1", "nonce_1", req)
+		errCh <- err
+	}()
+	waitForPending(t, approver)
+
+	if _, err := approver.FetchPending(context.Background(), peerInfoForTest(t, os.Getpid(), exe)); err != nil {
+		t.Fatalf("FetchPending returned error: %v", err)
+	}
+	verifier.processTeamID = "OTHERTEAM"
+	err := approver.SubmitDecision(context.Background(), peerInfoForTest(t, os.Getpid(), exe), ApprovalDecisionPayload{
+		RequestID: "req_1",
+		Nonce:     "nonce_1",
+		Decision:  "approve_once",
+	})
+	if !errors.Is(err, ErrApproverPeerMismatch) {
+		t.Fatalf("expected approver peer mismatch, got %v", err)
+	}
+	if !slices.Equal(verifier.pids, []int{os.Getpid(), os.Getpid()}) {
+		t.Fatalf("verified pids = %v, want [%d %d]", verifier.pids, os.Getpid(), os.Getpid())
+	}
+
+	cancel()
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("ApproveExec error = %v, want context cancellation", err)
 	}
 }
 
@@ -415,6 +517,39 @@ func TestProcessApproverLauncherLaunchesBinary(t *testing.T) {
 	}
 	if expected.ExecutablePath != helper {
 		t.Fatalf("expected executable path = %q, want %q", expected.ExecutablePath, helper)
+	}
+}
+
+func TestProcessApproverLauncherCarriesSignaturePolicyToExpectedPeer(t *testing.T) {
+	t.Parallel()
+
+	helper := filepath.Join(t.TempDir(), "approver-helper")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: launcher tests need runnable helper executables.
+		t.Fatalf("write helper: %v", err)
+	}
+
+	expected, err := (ProcessApproverLauncher{
+		AppPath: helper,
+		IdentityPolicy: staticApproverIdentityPolicy{identity: ApproverIdentity{
+			ExpectedTeamID:  "TEAMID",
+			VerifySignature: true,
+		}},
+	}).Launch(
+		context.Background(),
+		"/tmp/agent-secret-test.sock",
+		ApprovalRequestPayload{},
+	)
+	if err != nil {
+		t.Fatalf("Launch returned error: %v", err)
+	}
+	if expected.ExpectedTeamID != "TEAMID" {
+		t.Fatalf("ExpectedTeamID = %q, want TEAMID", expected.ExpectedTeamID)
+	}
+	if !expected.VerifySignature {
+		t.Fatal("VerifySignature = false, want true")
+	}
+	if expected.signatureVerifier == nil {
+		t.Fatal("signatureVerifier is nil")
 	}
 }
 

--- a/internal/daemon/approver_identity.go
+++ b/internal/daemon/approver_identity.go
@@ -111,10 +111,12 @@ func (p BundleApproverIdentityPolicy) ValidateApproverExecutable(path string) (A
 	}
 
 	return ApproverIdentity{
-		ExecutablePath: path,
-		BundlePath:     bundlePath,
-		BundleID:       bundleID,
-		TeamID:         teamID,
+		ExecutablePath:  path,
+		BundlePath:      bundlePath,
+		BundleID:        bundleID,
+		TeamID:          teamID,
+		ExpectedTeamID:  p.ExpectedTeamID,
+		VerifySignature: p.VerifySignature,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes #151

## Summary
- carry the approver signature policy from launch validation into the expected peer record
- require approver fetch and decision peers to pass process signature validation when a production Team ID is configured
- add daemon tests for fetch-time and submit-time process Team ID mismatch rejection

## Verification
- mise exec -- go test ./internal/daemon -run 'TestSocketApproverRejects(Fetch|Decision)FromWrongApproverProcessSignature|TestProcessApproverLauncherCarriesSignaturePolicyToExpectedPeer' -count=1\n- mise exec -- go test ./internal/daemon -count=1\n- mise exec -- go test -race ./internal/daemon -count=1\n- mise run lint:go\n- git diff --check\n- mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=1\n- swift test (from approver/)\n- mise run test\n- mise run lint:smart\n\nNote: earlier aggregate attempts hit known transient local flakes in `TestProcessApproverLauncherHealthCheck` and Swift `DaemonPeerValidationTests`; focused reruns and the final aggregate run passed.