### PR TITLE
ASR-049: Disable SIGPIPE on Swift socket transport

### DIFF
--- a/approver/Sources/AgentSecretApprover/UnixSocketLineTransport+SocketOptions.swift
+++ b/approver/Sources/AgentSecretApprover/UnixSocketLineTransport+SocketOptions.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+#if canImport(Darwin)
+    import Darwin
+
+    extension UnixSocketLineTransport {
+        static func configureSocket(
+            for descriptor: Int32,
+            ioTimeout: TimeInterval
+        ) throws {
+            try configureTimeout(
+                for: descriptor,
+                option: SO_RCVTIMEO,
+                timeout: ioTimeout,
+                error: SocketDaemonClientError.readFailed
+            )
+            try configureTimeout(
+                for: descriptor,
+                option: SO_SNDTIMEO,
+                timeout: ioTimeout,
+                error: SocketDaemonClientError.writeFailed
+            )
+            try configureNoSigPipe(for: descriptor)
+        }
+
+        static func isTimeout(_ errnoValue: Int32) -> Bool {
+            errnoValue == EAGAIN || errnoValue == EWOULDBLOCK
+        }
+
+        private static func configureTimeout(
+            for descriptor: Int32,
+            option: Int32,
+            timeout: TimeInterval,
+            error: (Int32) -> SocketDaemonClientError
+        ) throws {
+            var value = socketTimeval(from: timeout)
+            let status: Int32 = withUnsafePointer(to: &value) { pointer in
+                pointer.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<timeval>.size) { rawPointer in
+                    setsockopt(
+                        descriptor,
+                        SOL_SOCKET,
+                        option,
+                        rawPointer,
+                        socklen_t(MemoryLayout<timeval>.size)
+                    )
+                }
+            }
+            guard status == 0 else {
+                throw error(errno)
+            }
+        }
+
+        private static func configureNoSigPipe(for descriptor: Int32) throws {
+            var value: Int32 = 1
+            let status: Int32 = withUnsafePointer(to: &value) { pointer in
+                pointer.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<Int32>.size) { rawPointer in
+                    setsockopt(
+                        descriptor,
+                        SOL_SOCKET,
+                        SO_NOSIGPIPE,
+                        rawPointer,
+                        socklen_t(MemoryLayout<Int32>.size)
+                    )
+                }
+            }
+            guard status == 0 else {
+                throw SocketDaemonClientError.writeFailed(errno)
+            }
+        }
+
+        private static func socketTimeval(from timeout: TimeInterval) -> timeval {
+            let microsecondsPerSecond = 1_000_000
+            let totalMicroseconds = max(
+                1,
+                Int(timeout * TimeInterval(microsecondsPerSecond))
+            )
+            return Darwin.timeval(
+                tv_sec: totalMicroseconds / microsecondsPerSecond,
+                tv_usec: Int32(totalMicroseconds % microsecondsPerSecond)
+            )
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/UnixSocketLineTransport.swift
+++ b/approver/Sources/AgentSecretApprover/UnixSocketLineTransport.swift
@@ -12,7 +12,6 @@ final class UnixSocketLineTransport: LineTransport {
         private static let pathTerminatorByte: UInt8 = 0
         private static let readChunkBytes: Int = 0x1000
         private static let singleAddressCapacity: Int = 1
-        private static let timevalMicrosecondsPerSecond: Int = 1_000_000
 
         private let maxFrameBytes: Int
         private let socketFileDescriptor: Int32
@@ -37,7 +36,7 @@ final class UnixSocketLineTransport: LineTransport {
         ) throws {
             try Self.validate(maxFrameBytes: maxFrameBytes)
             do {
-                try Self.configureTimeouts(
+                try Self.configureSocket(
                     for: descriptor,
                     ioTimeout: ioTimeout
                 )
@@ -91,7 +90,7 @@ final class UnixSocketLineTransport: LineTransport {
                 throw SocketDaemonClientError.connectFailed(errnoValue)
             }
             do {
-                try Self.configureTimeouts(
+                try Self.configureSocket(
                     for: descriptor,
                     ioTimeout: ioTimeout
                 )
@@ -119,62 +118,6 @@ final class UnixSocketLineTransport: LineTransport {
             guard maxFrameBytes > 0 else {
                 throw SocketDaemonClientError.invalidResponse("invalid maximum frame size")
             }
-        }
-
-        private static func configureTimeouts(
-            for descriptor: Int32,
-            ioTimeout: TimeInterval
-        ) throws {
-            try configureTimeout(
-                for: descriptor,
-                option: SO_RCVTIMEO,
-                timeout: ioTimeout,
-                error: SocketDaemonClientError.readFailed
-            )
-            try configureTimeout(
-                for: descriptor,
-                option: SO_SNDTIMEO,
-                timeout: ioTimeout,
-                error: SocketDaemonClientError.writeFailed
-            )
-        }
-
-        private static func configureTimeout(
-            for descriptor: Int32,
-            option: Int32,
-            timeout: TimeInterval,
-            error: (Int32) -> SocketDaemonClientError
-        ) throws {
-            var value = socketTimeval(from: timeout)
-            let status: Int32 = withUnsafePointer(to: &value) { pointer in
-                pointer.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<timeval>.size) { rawPointer in
-                    setsockopt(
-                        descriptor,
-                        SOL_SOCKET,
-                        option,
-                        rawPointer,
-                        socklen_t(MemoryLayout<timeval>.size)
-                    )
-                }
-            }
-            guard status == 0 else {
-                throw error(errno)
-            }
-        }
-
-        private static func socketTimeval(from timeout: TimeInterval) -> timeval {
-            let totalMicroseconds = max(
-                1,
-                Int(timeout * TimeInterval(Self.timevalMicrosecondsPerSecond))
-            )
-            return Darwin.timeval(
-                tv_sec: totalMicroseconds / Self.timevalMicrosecondsPerSecond,
-                tv_usec: Int32(totalMicroseconds % Self.timevalMicrosecondsPerSecond)
-            )
-        }
-
-        private static func isTimeout(_ errnoValue: Int32) -> Bool {
-            errnoValue == EAGAIN || errnoValue == EWOULDBLOCK
         }
 
     #endif

--- a/approver/Tests/AgentSecretApproverTests/UnixSocketLineTransportTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/UnixSocketLineTransportTests.swift
@@ -130,6 +130,15 @@ import XCTest
             XCTAssertEqual(try Self.readString(from: pair.peer), "hello\n")
         }
 
+        func testWriteLineToClosedPeerReturnsErrorWithoutSignal() throws {
+            let pair = try makeTransportPair()
+            close(pair.peer)
+
+            assertTransportError(.writeFailed(EPIPE)) {
+                try pair.transport.writeLine(Data("hello".utf8))
+            }
+        }
+
         func testWriteLineRejectsOversizedFrame() throws {
             let pair = try makeTransportPair(maxFrameBytes: Self.smallFrameBytes)
             defer {


### PR DESCRIPTION
Fixes #152

## Summary
- configure Swift Unix socket descriptors with `SO_NOSIGPIPE` before protocol use
- move socket option setup into a focused transport extension to keep the transport class within SwiftLint limits
- add a regression test that closes the peer before `writeLine` and asserts a controlled `.writeFailed(EPIPE)` error instead of process termination

## Verification
- swift test --filter UnixSocketLineTransportTests (from approver/)
- mise run lint:swift
- swift test (from approver/)
- git diff --check
- mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=1
- mise run lint:smart

Note: aggregate `mise run test` attempts hit existing transient local flakes in `TestProcessApproverLauncherHealthCheck` and Swift `DaemonPeerValidationTests`; focused reruns passed, and the final full Swift suite passed.