### PR TITLE
ASR-050: Keep timeout audit contexts alive

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -578,6 +578,10 @@ func (b *Broker) recordRequiredAudit(ctx context.Context, event audit.Event) err
 	return nil
 }
 
+func terminalAuditContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+}
+
 func (b *Broker) recordApprovalError(
 	ctx context.Context,
 	requestID string,
@@ -590,7 +594,9 @@ func (b *Broker) recordApprovalError(
 	case errors.Is(err, ErrRequestExpired):
 		event := audit.FromExecRequest(audit.EventApprovalTimedOut, requestID, req)
 		event.ErrorCode = "request_expired"
-		return b.recordRequiredAudit(ctx, event)
+		auditCtx, cancel := terminalAuditContext(ctx)
+		defer cancel()
+		return b.recordRequiredAudit(auditCtx, event)
 	default:
 		return nil
 	}
@@ -615,7 +621,9 @@ func (b *Broker) recordSecretFetchFailed(
 		SecretRefs: auditRefsForIdentity(secrets, identity),
 		ErrorCode:  secretFetchErrorCode(err),
 	}
-	return b.recordRequiredAudit(ctx, event)
+	auditCtx, cancel := terminalAuditContext(ctx)
+	defer cancel()
+	return b.recordRequiredAudit(auditCtx, event)
 }
 
 func secretFetchErrorCode(err error) string {

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -72,6 +72,21 @@ func (s *sleepingApprover) ApproveExec(
 	return s.decision, nil
 }
 
+type contextExpiringApprover struct {
+	done chan struct{}
+}
+
+func (a *contextExpiringApprover) ApproveExec(
+	ctx context.Context,
+	_ string,
+	_ string,
+	_ request.ExecRequest,
+) (ApprovalDecision, error) {
+	<-ctx.Done()
+	close(a.done)
+	return ApprovalDecision{}, ErrRequestExpired
+}
+
 type mockResolver struct {
 	mu     sync.Mutex
 	values map[string]string
@@ -216,6 +231,17 @@ func (m *memoryAudit) Record(_ context.Context, event audit.Event) error {
 	return nil
 }
 
+type contextCheckingAudit struct {
+	memoryAudit
+}
+
+func (m *contextCheckingAudit) Record(ctx context.Context, event audit.Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return m.memoryAudit.Record(ctx, event)
+}
+
 func (m *memoryAudit) ApprovalReused(_ context.Context, event policy.ReuseAuditEvent) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -301,6 +327,46 @@ func TestBrokerApprovalTimeoutAuditsOutcomeWithoutResolveOrCommandStart(t *testi
 		eventType: audit.EventApprovalTimedOut,
 		errorCode: "request_expired",
 	})
+}
+
+func TestBrokerApprovalTimeoutAuditIgnoresExpiredRequestContext(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	now := time.Now()
+	req := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req.TTL = 25 * time.Millisecond
+	req.ExpiresAt = req.ReceivedAt.Add(req.TTL)
+	approver := &contextExpiringApprover{done: make(chan struct{})}
+	resolver := &mockResolver{values: map[string]string{ref: "value"}}
+	aud := &contextCheckingAudit{}
+	broker, err := NewBroker(BrokerOptions{
+		Now:      time.Now,
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    aud,
+	})
+	if err != nil {
+		t.Fatalf("NewBroker returned error: %v", err)
+	}
+
+	_, err = broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if !errors.Is(err, ErrRequestExpired) {
+		t.Fatalf("expected request expiry, got %v", err)
+	}
+	receiveBrokerSignal(t, approver.done, "approver did not observe request deadline")
+	if calls := resolver.Calls(); len(calls) != 0 {
+		t.Fatalf("resolver was called after approval timeout: %v", calls)
+	}
+
+	events := aud.Events()
+	want := []audit.EventType{audit.EventApprovalRequested, audit.EventApprovalTimedOut}
+	if got := auditEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+	if events[1].ErrorCode != "request_expired" {
+		t.Fatalf("approval timeout error code = %q", events[1].ErrorCode)
+	}
 }
 
 type approvalFailureAuditCase struct {
@@ -498,7 +564,7 @@ func TestBrokerRequestDeadlineCancelsSlowSecretFetch(t *testing.T) {
 	req.TTL = 50 * time.Millisecond
 	req.ExpiresAt = req.ReceivedAt.Add(req.TTL)
 	resolver := &deadlineObservingResolver{done: make(chan struct{})}
-	aud := &memoryAudit{}
+	aud := &contextCheckingAudit{}
 	broker, err := NewBroker(BrokerOptions{
 		Now:      time.Now,
 		Approver: &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true}},
@@ -515,6 +581,19 @@ func TestBrokerRequestDeadlineCancelsSlowSecretFetch(t *testing.T) {
 		t.Fatalf("expected request expiry while resolving, got %v", err)
 	}
 	receiveBrokerSignal(t, resolver.done, "resolver did not observe request deadline")
+	events := aud.Events()
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventSecretFetchFailed,
+	}
+	if got := auditEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+	if events[len(events)-1].ErrorCode != "context_deadline_exceeded" {
+		t.Fatalf("fetch failure error code = %q", events[len(events)-1].ErrorCode)
+	}
 	if containsAuditEvent(aud.Events(), audit.EventCommandStarting) {
 		t.Fatal("command_starting was audited after request deadline expired during fetch")
 	}


### PR DESCRIPTION
Fixes #153

## Summary
- record terminal approval timeout and secret fetch failure audit events with a bounded context that survives request cancellation
- preserve required-audit failure semantics by still returning `ErrAuditRequired` when the writer fails
- add regression coverage using an audit sink that rejects canceled contexts for approval timeout and fetch deadline paths

## Verification
- mise exec -- go test ./internal/daemon -run 'TestBrokerApprovalTimeoutAuditIgnoresExpiredRequestContext|TestBrokerRequestDeadlineCancelsSlowSecretFetch' -count=1\n- mise exec -- go test ./internal/daemon ./internal/audit -count=1\n- mise exec -- go test -race ./internal/daemon -count=1\n- mise run lint:go\n- git diff --check\n- swift test (from approver/)\n- mise run lint:smart\n\nNote: aggregate `mise run test` passed all Go packages, then hit the known transient Swift socket test; standalone Swift rerun passed.