### PR TITLE
ASR-051: Align expired denial semantics

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalPromptExpiration.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPromptExpiration.swift
@@ -12,7 +12,7 @@ struct ApprovalPromptExpiration: Equatable {
     }
 
     func guardDecision(_ decision: ApprovalDecisionKind, at now: Date) -> ApprovalDecisionKind {
-        if decision.requiresUnexpiredRequest, isExpired(at: now) {
+        if isExpired(at: now) {
             return .timeout
         }
         return decision

--- a/approver/Tests/AgentSecretApproverTests/ApprovalPromptExpirationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalPromptExpirationTests.swift
@@ -12,7 +12,7 @@ final class ApprovalPromptExpirationTests: XCTestCase {
         XCTAssertEqual(expiration.timeoutDecision(at: expiresAt.addingTimeInterval(1)), .timeout)
     }
 
-    func testLateApprovalActionsBecomeTimeoutsButDenialRemainsDenial() {
+    func testLateDecisionsBecomeTimeouts() {
         let expiresAt = Date(timeIntervalSince1970: 1_800_000_000)
         let expiration = ApprovalPromptExpiration(expiresAt: expiresAt)
 
@@ -22,7 +22,7 @@ final class ApprovalPromptExpirationTests: XCTestCase {
         )
         XCTAssertEqual(expiration.guardDecision(.approveOnce, at: expiresAt), .timeout)
         XCTAssertEqual(expiration.guardDecision(.approveReusable, at: expiresAt.addingTimeInterval(1)), .timeout)
-        XCTAssertEqual(expiration.guardDecision(.deny, at: expiresAt.addingTimeInterval(1)), .deny)
+        XCTAssertEqual(expiration.guardDecision(.deny, at: expiresAt.addingTimeInterval(1)), .timeout)
         XCTAssertEqual(expiration.guardDecision(.timeout, at: expiresAt.addingTimeInterval(1)), .timeout)
     }
 

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -378,6 +378,46 @@ func TestSocketApproverRejectsInvalidDecision(t *testing.T) {
 	}
 }
 
+func TestSocketApproverTreatsExpiredDenialAsTimeout(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	now := time.Date(2026, 4, 28, 15, 0, 0, 0, time.UTC)
+	var nowMu sync.Mutex
+	nowFn := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return now
+	}
+	setNow := func(value time.Time) {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		now = value
+	}
+	launcher := &recordingLauncher{expected: ExpectedApprover{PID: os.Getpid(), ExecutablePath: exe}}
+	approver := newSocketApproverForTest(t, launcher, nowFn)
+	req := approvalTestRequest(t, now.Add(time.Minute))
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := approver.ApproveExec(context.Background(), "req_1", "nonce_1", req)
+		errCh <- err
+	}()
+	waitForPending(t, approver)
+
+	setNow(req.ExpiresAt)
+	err := approver.SubmitDecision(context.Background(), peerInfoForTest(t, os.Getpid(), exe), ApprovalDecisionPayload{
+		RequestID: "req_1",
+		Nonce:     "nonce_1",
+		Decision:  "deny",
+	})
+	if err != nil {
+		t.Fatalf("expired denial decision returned error: %v", err)
+	}
+	if err := <-errCh; !errors.Is(err, ErrRequestExpired) {
+		t.Fatalf("ApproveExec error = %v, want expired", err)
+	}
+}
+
 func TestProcessApproverLauncherExecutablePath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- treat every post-expiry Swift approval decision as `timeout`, including denials
- add a daemon contract test that expired deny submissions resolve the pending approval as `ErrRequestExpired`

Fixes #154

## Verification
- `mise exec -- go test ./internal/daemon -run TestSocketApproverTreatsExpiredDenialAsTimeout -count=1`
- `swift test --filter ApprovalPromptExpirationTests`
- `mise run lint:go`
- `mise run lint:swift`
- `mise exec -- go test ./internal/daemon -count=1`
- `mise exec -- go test -race ./internal/daemon -count=1`
- `git diff --check`
- `swift test` (passed after rerunning known `DaemonPeerValidationTests.testPathTransportCanTrustCurrentExecutableForLocalPeer` socket flake)
- `mise run lint:smart`

Note: `mise run test` cleared Go on rerun but hit the existing Swift peer socket flake (`read failed: errno 22`) during the Swift phase; standalone full `swift test` passed immediately afterward.