### PR TITLE
ASR-052: Guard tag releases by main ancestry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Verify release tag ancestry
+        run: scripts/check-release-ancestry.sh "$GITHUB_REF_NAME"
+
       - name: Install mise
         uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:

--- a/README.md
+++ b/README.md
@@ -87,12 +87,14 @@ scripts/build-app-bundle.sh
 ```
 
 `mise run test:smoke` runs the non-secret install, uninstall, release
-configuration, release version, release docs, and approver smoke checks:
+configuration, release ancestry, release version, release docs, and approver
+smoke checks:
 
 ```bash
 AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-release-ancestry.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-workflow-actions-pinned.sh

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -60,6 +60,10 @@ release target. Do not publish a release whose changelog section is empty.
    git push origin "v$version"
    ```
 
+   The tag-triggered workflow rejects `v*` tags whose target commit is not
+   reachable from `origin/main` before validating signing secrets or building
+   release artifacts.
+
 7. Watch the tag-triggered CI run until `Draft Release Artifacts` passes.
    The job should create or update a draft GitHub Release with:
 

--- a/mise.toml
+++ b/mise.toml
@@ -79,6 +79,7 @@ run = """
 AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh
+AGENT_SECRET_IN_MISE=1 scripts/test-release-ancestry.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh
 AGENT_SECRET_IN_MISE=1 scripts/test-workflow-actions-pinned.sh

--- a/scripts/check-release-ancestry.sh
+++ b/scripts/check-release-ancestry.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote="${AGENT_SECRET_RELEASE_ANCESTRY_REMOTE:-origin}"
+main_branch="${AGENT_SECRET_RELEASE_ANCESTRY_MAIN_BRANCH:-main}"
+release_ref="${1:-${GITHUB_REF_NAME:-}}"
+
+fail() {
+  echo "release ancestry: $*" >&2
+  exit 1
+}
+
+if [[ -z "$release_ref" ]]; then
+  fail "release tag is required"
+fi
+
+case "$release_ref" in
+  refs/tags/v*)
+    tag_name="${release_ref#refs/tags/}"
+    ;;
+  v*)
+    tag_name="$release_ref"
+    ;;
+  *)
+    fail "release ref must be a v* tag, got $release_ref"
+    ;;
+esac
+
+tag_ref="refs/tags/$tag_name"
+if ! release_commit="$(git rev-parse --verify -q "${tag_ref}^{commit}")"; then
+  git fetch --no-tags "$remote" "+refs/tags/${tag_name}:refs/tags/${tag_name}" >/dev/null ||
+    fail "could not fetch tag $tag_name from $remote"
+  release_commit="$(git rev-parse --verify -q "${tag_ref}^{commit}")" ||
+    fail "could not resolve tag $tag_name to a commit"
+fi
+
+main_ref="refs/remotes/${remote}/${main_branch}"
+if [[ "$(git rev-parse --is-shallow-repository 2>/dev/null || printf 'false')" == "true" ]]; then
+  git fetch --unshallow --no-tags "$remote" "+refs/heads/${main_branch}:${main_ref}" >/dev/null ||
+    fail "could not fetch $remote/$main_branch"
+else
+  git fetch --no-tags "$remote" "+refs/heads/${main_branch}:${main_ref}" >/dev/null ||
+    fail "could not fetch $remote/$main_branch"
+fi
+
+main_commit="$(git rev-parse --verify -q "${main_ref}^{commit}")" ||
+  fail "could not resolve $remote/$main_branch"
+
+if ! git merge-base --is-ancestor "$release_commit" "$main_commit"; then
+  fail "tag $tag_name targets commit $release_commit, which is not reachable from $remote/$main_branch"
+fi
+
+echo "release ancestry: tag $tag_name targets commit $release_commit reachable from $remote/$main_branch"

--- a/scripts/test-release-ancestry.sh
+++ b/scripts/test-release-ancestry.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd -- "$script_dir/.." && pwd)"
+check_script="$project_root/scripts/check-release-ancestry.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-release-ancestry-test.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "test-release-ancestry: $*" >&2
+  exit 1
+}
+
+expect_failure() {
+  local want="$1"
+  shift
+
+  if "$@" >"$tmp_dir/stdout" 2>"$tmp_dir/stderr"; then
+    fail "expected failure containing $want"
+  fi
+  if ! grep -F "$want" "$tmp_dir/stderr" >/dev/null; then
+    fail "stderr did not contain $want: $(cat "$tmp_dir/stderr")"
+  fi
+}
+
+origin="$tmp_dir/origin.git"
+repo="$tmp_dir/repo"
+
+git init --bare "$origin" >/dev/null
+git init "$repo" >/dev/null
+git -C "$repo" config user.email agent-secret@example.invalid
+git -C "$repo" config user.name "Agent Secret Test"
+git -C "$repo" remote add origin "$origin"
+
+printf 'base\n' >"$repo/file.txt"
+git -C "$repo" add file.txt
+git -C "$repo" commit -m "base" >/dev/null
+git -C "$repo" branch -M main
+git -C "$repo" push -u origin main >/dev/null
+
+git -C "$repo" tag v1.0.0
+(
+  cd "$repo"
+  "$check_script" v1.0.0 >/dev/null
+)
+
+printf 'reviewed\n' >>"$repo/file.txt"
+git -C "$repo" commit -am "reviewed" >/dev/null
+git -C "$repo" push origin main >/dev/null
+git -C "$repo" tag -a v1.0.1 -m "v1.0.1"
+(
+  cd "$repo"
+  "$check_script" refs/tags/v1.0.1 >/dev/null
+)
+
+git -C "$repo" switch -c unreviewed >/dev/null
+printf 'unreviewed\n' >>"$repo/file.txt"
+git -C "$repo" commit -am "unreviewed" >/dev/null
+git -C "$repo" tag v1.0.2
+expect_failure "tag v1.0.2 targets commit" bash -c "cd '$repo' && '$check_script' v1.0.2"
+
+expect_failure "release ref must be a v* tag" bash -c "cd '$repo' && '$check_script' main"
+
+echo "test-release-ancestry: ok"

--- a/scripts/test-release-docs.sh
+++ b/scripts/test-release-docs.sh
@@ -55,6 +55,7 @@ reject_threat_model_text() {
 require_text "AGENT_SECRET_IN_MISE=1 scripts/test-install.sh"
 require_text "AGENT_SECRET_IN_MISE=1 scripts/test-uninstall.sh"
 require_text "AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh"
+require_text "AGENT_SECRET_IN_MISE=1 scripts/test-release-ancestry.sh"
 require_text "AGENT_SECRET_IN_MISE=1 scripts/test-release-version.sh"
 require_text "AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh"
 require_text "AGENT_SECRET_IN_MISE=1 scripts/test-workflow-actions-pinned.sh"
@@ -66,6 +67,7 @@ reject_text "Local and CI builds are ad-hoc signed by default"
 reject_text "Developer ID signing and notarization are opt-in release settings"
 
 require_release_process_text "## Toolchain Pin Maintenance"
+require_release_process_text "reachable from \`origin/main\`"
 require_release_process_text "AGENT_SECRET_MISE_VERSION"
 require_release_process_text "scripts/test-workflow-actions-pinned.sh"
 


### PR DESCRIPTION
## Summary
- add a release ancestry guard that resolves lightweight and annotated `v*` tags to commits and fails unless the target is reachable from `origin/main`
- run the guard in the tag-only release artifact job before signing-secret validation or certificate import
- add smoke coverage for reviewed lightweight tags, reviewed annotated tags, off-main tags, and non-tag refs
- document the release ancestry contract in README/release process docs

Fixes #155

## Verification
- `AGENT_SECRET_IN_MISE=1 scripts/test-release-ancestry.sh`
- `AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh`
- `mise exec -- actionlint .github/workflows/ci.yml`
- `mise run lint:shell`
- `mise run lint:toml`
- `npx --yes markdownlint-cli README.md docs/release-process.md`
- `mise run test:smoke`
- `git diff --check`
- `mise run lint:smart`
- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=1` after the known daemon health-check timeout flaked in `mise run lint`
- `swift test --filter DaemonPeerValidationTests/testPathTransportCanTrustCurrentExecutableForLocalPeer` and `swift test` after the known Swift peer socket flake (`write failed: errno 22`) flaked in `mise run lint`

Note: `mise run lint` cleared the Go lint/test/race/coverage/vuln/secrets/language-lint phases on rerun, then hit the existing Swift peer socket flake. The full Swift suite passed immediately afterward.