### PR TITLE
ASR-054: Document immutable installer bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,28 @@ Human install flow:
    agent-secret doctor
    ```
 
-Unattended install and upgrade use the same script:
+Unattended install and upgrade use the same script. Pin the bootstrap script to
+the same immutable release tag as `AGENT_SECRET_VERSION`:
 
 ```bash
-curl -fsSL \
-  https://raw.githubusercontent.com/kovyrin/agent-secret/main/install.sh | sh
+version="v0.3.1"
+base_url="https://raw.githubusercontent.com/kovyrin/agent-secret"
+curl -fsSL "$base_url/${version}/install.sh" |
+  AGENT_SECRET_VERSION="$version" sh
+```
+
+For a latest-release install, resolve the release tag first and fetch
+`install.sh` from that tag, not from `main`:
+
+```bash
+version="$(
+  curl -fsSL https://api.github.com/repos/kovyrin/agent-secret/releases/latest |
+    awk -F'"' '/"tag_name":/ { print $4; exit }'
+)"
+test -n "$version"
+base_url="https://raw.githubusercontent.com/kovyrin/agent-secret"
+curl -fsSL "$base_url/${version}/install.sh" |
+  AGENT_SECRET_VERSION="$version" sh
 ```
 
 Useful installer environment variables:

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -81,11 +81,14 @@ agent-secret skill-install
 
 ### Unattended Install
 
-Agents and setup scripts use:
+Agents and setup scripts pin the bootstrap script to the same immutable release
+tag as `AGENT_SECRET_VERSION`:
 
 ```bash
-curl -fsSL \
-  https://raw.githubusercontent.com/kovyrin/agent-secret/main/install.sh | sh
+version="v0.3.1"
+base_url="https://raw.githubusercontent.com/kovyrin/agent-secret"
+curl -fsSL "$base_url/${version}/install.sh" |
+  AGENT_SECRET_VERSION="$version" sh
 ```
 
 The installer should:
@@ -125,11 +128,19 @@ relative, broad, or symlinked.
 
 ### Upgrade
 
-The upgrade path is intentionally the same as install:
+The upgrade path is intentionally the same as install. Latest-release upgrades
+resolve the release tag first and fetch `install.sh` from that tag, not from
+`main`:
 
 ```bash
-curl -fsSL \
-  https://raw.githubusercontent.com/kovyrin/agent-secret/main/install.sh | sh
+version="$(
+  curl -fsSL https://api.github.com/repos/kovyrin/agent-secret/releases/latest |
+    awk -F'"' '/"tag_name":/ { print $4; exit }'
+)"
+test -n "$version"
+base_url="https://raw.githubusercontent.com/kovyrin/agent-secret"
+curl -fsSL "$base_url/${version}/install.sh" |
+  AGENT_SECRET_VERSION="$version" sh
 ```
 
 The installer replaces the app bundle atomically enough for a user-level tool:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -157,6 +157,13 @@ Do not print, commit, paste, or attach `.p8`, `.p12`, private key, or password
 material. If a notary API key must be recreated, use an App Store Connect Team
 Key and store the downloaded `.p8` directly in GitHub Secrets.
 
+## Installer Bootstrap Documentation
+
+Unattended install examples must fetch `install.sh` from an immutable release
+tag. Pinned installs set `AGENT_SECRET_VERSION` to that same tag. Latest
+installs resolve the latest release tag first, then fetch `install.sh` from that
+tag. Do not pipe `main/install.sh` into a shell.
+
 ## Toolchain Pin Maintenance
 
 The GitHub workflow pins both `jdx/mise-action` and the `mise` binary that the

--- a/scripts/test-release-docs.sh
+++ b/scripts/test-release-docs.sh
@@ -5,6 +5,7 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 readme="$project_root/README.md"
 release_process="$project_root/docs/release-process.md"
+macos_distribution_plan="$project_root/docs/macos-distribution-plan.md"
 threat_model="$project_root/docs/threat-model.md"
 
 fail() {
@@ -25,6 +26,14 @@ reject_text() {
 
   if grep -F -- "$needle" "$readme" >/dev/null; then
     fail "README.md still contains stale release documentation: $needle"
+  fi
+}
+
+reject_macos_distribution_text() {
+  local needle="$1"
+
+  if grep -F -- "$needle" "$macos_distribution_plan" >/dev/null; then
+    fail "docs/macos-distribution-plan.md still contains stale release documentation: $needle"
   fi
 }
 
@@ -66,10 +75,17 @@ require_text "--require-production-signing"
 require_text "Tag-triggered GitHub releases require production"
 reject_text "Local and CI builds are ad-hoc signed by default"
 reject_text "Developer ID signing and notarization are opt-in release settings"
+reject_text "raw.githubusercontent.com/kovyrin/agent-secret/main/install.sh"
+reject_macos_distribution_text "raw.githubusercontent.com/kovyrin/agent-secret/main/install.sh"
+require_text "raw.githubusercontent.com/kovyrin/agent-secret"
+require_text "\$base_url/\${version}/install.sh"
+require_text "AGENT_SECRET_VERSION=\"\$version\" sh"
 
 require_release_process_text "## Toolchain Pin Maintenance"
+require_release_process_text "## Installer Bootstrap Documentation"
 require_release_process_text "reachable from \`origin/main\`"
 require_release_process_text "refuses to replace assets on a published release"
+require_release_process_text "Do not pipe \`main/install.sh\` into a shell."
 require_release_process_text "AGENT_SECRET_MISE_VERSION"
 require_release_process_text "scripts/test-workflow-actions-pinned.sh"
 


### PR DESCRIPTION
## Summary
- replace mutable `main/install.sh` unattended install examples with release-tagged bootstrap commands
- document the latest-release flow as: resolve latest tag first, then fetch `install.sh` from that tag
- update the macOS distribution plan and release process with the same immutable bootstrap contract
- extend release-docs smoke coverage to reject raw `main/install.sh` examples

Fixes #157

## Verification
- `AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh`
- `npx --yes markdownlint-cli README.md docs/release-process.md docs/macos-distribution-plan.md`
- `npx --no-install markdownlint-cli README.md docs/release-process.md docs/macos-distribution-plan.md`
- `mise run lint:shell`
- `git diff --check`
- `mise run test:smoke`
- `mise run lint:smart`

Note: `npx --no-install markdownlint README.md docs/release-process.md docs/macos-distribution-plan.md` fails locally because the executable is `markdownlint-cli`, not `markdownlint`; the no-install `markdownlint-cli` invocation passed.