### PR TITLE
ASR-055: Trust existing CLI before daemon stop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -345,17 +345,15 @@ stop_existing_daemon() {
   fi
 
   target_app="$app_dir/Agent Secret.app"
-  existing=""
-  if [ -x "$target_app/Contents/Resources/bin/agent-secret" ]; then
-    existing="$target_app/Contents/Resources/bin/agent-secret"
-  elif [ -x "$bin_dir/agent-secret" ]; then
-    existing="$bin_dir/agent-secret"
-  elif command -v agent-secret >/dev/null 2>&1; then
-    existing="$(command -v agent-secret)"
+  existing="$target_app/Contents/Resources/bin/agent-secret"
+  if [ ! -d "$target_app" ]; then
+    return
   fi
 
-  if [ -n "$existing" ]; then
+  if (verify_app_identity "$target_app") >/dev/null 2>&1; then
     "$existing" daemon stop >/dev/null 2>&1 || true
+  else
+    echo "agent-secret install: skipping daemon stop because existing Agent Secret.app could not be verified" >&2
   fi
 }
 

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -79,6 +79,16 @@ printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
 exit "${AGENT_SECRET_INSTALL_TEST_XCRUN_STATUS:-0}"
 SCRIPT
 
+  cat >"$fake_bin/agent-secret" <<'SCRIPT'
+#!/bin/sh
+printf 'fake-path-agent-secret' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+exit 0
+SCRIPT
+
   cat >"$fake_bin/ditto" <<'SCRIPT'
 #!/bin/sh
 printf 'ditto %s %s\n' "$1" "$2" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
@@ -175,6 +185,7 @@ exit 64
 SCRIPT
 
   chmod 755 "$fake_bin/codesign" "$fake_bin/spctl" "$fake_bin/xcrun" \
+    "$fake_bin/agent-secret" \
     "$fake_bin/ditto" "$fake_bin/hdiutil"
 }
 
@@ -199,6 +210,17 @@ run_installer() {
 
   make_fixture "$run_dir"
   write_fake_tools "$fake_bin"
+  mkdir -p "$run_dir/bin-dir"
+  cat >"$run_dir/bin-dir/agent-secret" <<'SCRIPT'
+#!/bin/sh
+printf 'fake-bin-dir-agent-secret' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+exit 0
+SCRIPT
+  chmod 755 "$run_dir/bin-dir/agent-secret"
   : >"$log"
 
   env \
@@ -352,6 +374,17 @@ test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts() {
   fi
 }
 
+test_untrusted_existing_cli_is_not_used_for_daemon_stop() {
+  run_installer untrusted-existing-cli AGENT_SECRET_NO_STOP_DAEMON=0
+  log="$tmp_dir/untrusted-existing-cli/tools.log"
+
+  if grep -E '^fake-(bin-dir|path)-agent-secret daemon stop$' "$log" >/dev/null; then
+    echo "---- tool log ----" >&2
+    cat "$log" >&2
+    fail "installer executed an untrusted existing agent-secret during daemon stop"
+  fi
+}
+
 test_identity_checks_run
 test_identity_failure_stops_install
 test_wrong_team_id_stops_install
@@ -362,5 +395,6 @@ test_destination_overrides_require_guard
 test_destination_validation_rejects_bad_paths
 test_destination_validation_rejects_symlinked_parent_dirs
 test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts
+test_untrusted_existing_cli_is_not_used_for_daemon_stop
 
 echo "test-install: ok"

--- a/scripts/test-uninstall.sh
+++ b/scripts/test-uninstall.sh
@@ -237,6 +237,58 @@ safe_custom_paths_remove_only_known_files() {
   done
 }
 
+untrusted_existing_cli_is_not_used_for_daemon_stop() {
+  local run_dir="$tmp_dir/untrusted-existing-cli"
+  local home="$run_dir/home"
+  local app_dir="$run_dir/apps"
+  local bin_dir="$run_dir/bin"
+  local skills_dir="$run_dir/skills"
+  local support="$run_dir/support/agent-secret"
+  local path_bin="$run_dir/path"
+  local log="$run_dir/stop.log"
+
+  mkdir -p "$home" "$app_dir" "$bin_dir" "$skills_dir" "$support" "$path_bin"
+  : >"$log"
+
+  cat >"$bin_dir/agent-secret" <<'SCRIPT'
+#!/bin/sh
+printf 'fake-bin-dir-agent-secret' >>"$AGENT_SECRET_UNINSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_UNINSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_UNINSTALL_TEST_LOG"
+exit 0
+SCRIPT
+  chmod 755 "$bin_dir/agent-secret"
+
+  cat >"$path_bin/agent-secret" <<'SCRIPT'
+#!/bin/sh
+printf 'fake-path-agent-secret' >>"$AGENT_SECRET_UNINSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_UNINSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_UNINSTALL_TEST_LOG"
+exit 0
+SCRIPT
+  chmod 755 "$path_bin/agent-secret"
+
+  run_uninstall \
+    untrusted-existing-cli \
+    HOME="$home" \
+    PATH="$path_bin:$PATH" \
+    AGENT_SECRET_NO_STOP_DAEMON=0 \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_APP_DIR="$app_dir" \
+    AGENT_SECRET_BIN_DIR="$bin_dir" \
+    AGENT_SECRET_SKILLS_DIR="$skills_dir" \
+    AGENT_SECRET_SUPPORT_DIR="$support" \
+    AGENT_SECRET_UNINSTALL_TEST_LOG="$log"
+
+  if grep -E '^fake-(bin-dir|path)-agent-secret daemon stop$' "$log" >/dev/null; then
+    fail "uninstaller executed an untrusted existing agent-secret during daemon stop"
+  fi
+}
+
 custom_guard_rejects_override
 custom_destination_guard_rejects_override
 dangerous_paths_are_rejected_even_with_guard
@@ -244,5 +296,6 @@ dangerous_destination_paths_are_rejected_even_with_guard
 symlinked_parent_dirs_are_rejected
 symlinked_dirs_are_rejected
 safe_custom_paths_remove_only_known_files
+untrusted_existing_cli_is_not_used_for_daemon_stop
 
 echo "test-uninstall: ok"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -10,6 +10,9 @@ skills_dir="${AGENT_SECRET_SKILLS_DIR:-$default_skills_dir}"
 remove_audit_logs="${AGENT_SECRET_REMOVE_AUDIT_LOGS:-0}"
 no_stop_daemon="${AGENT_SECRET_NO_STOP_DAEMON:-0}"
 allow_custom_uninstall_paths="${AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS:-0}"
+expected_team_id="B6L7QLWTZW"
+expected_app_bundle_id="com.kovyrin.agent-secret"
+expected_daemon_bundle_id="com.kovyrin.agent-secret.daemon"
 default_support_dir="$HOME/Library/Application Support/agent-secret"
 default_audit_dir="$HOME/Library/Logs/agent-secret"
 
@@ -21,22 +24,68 @@ fail() {
   exit 1
 }
 
+plist_value() {
+  plist="$1"
+  key="$2"
+
+  /usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2>/dev/null
+}
+
+bundle_identifier_matches() {
+  bundle="$1"
+  expected="$2"
+  plist="$bundle/Contents/Info.plist"
+
+  [ -f "$plist" ] || return 1
+  got="$(plist_value "$plist" CFBundleIdentifier)" || return 1
+  [ "$got" = "$expected" ]
+}
+
+codesign_team_id() {
+  path="$1"
+
+  details="$(codesign -dv --verbose=4 "$path" 2>&1)" || return 1
+  printf '%s\n' "$details" |
+    awk -F= '$1 == "TeamIdentifier" { print $2; found = 1; exit } END { if (!found) exit 1 }'
+}
+
+team_id_matches() {
+  path="$1"
+
+  team_id="$(codesign_team_id "$path")" || return 1
+  [ "$team_id" = "$expected_team_id" ]
+}
+
+existing_app_is_trusted_for_stop() {
+  daemon_app="$target_app/Contents/Library/Helpers/AgentSecretDaemon.app"
+  cli="$target_app/Contents/Resources/bin/agent-secret"
+
+  [ -x "$cli" ] || return 1
+  command -v /usr/libexec/PlistBuddy >/dev/null 2>&1 || return 1
+  command -v codesign >/dev/null 2>&1 || return 1
+  bundle_identifier_matches "$target_app" "$expected_app_bundle_id" || return 1
+  [ -d "$daemon_app" ] || return 1
+  bundle_identifier_matches "$daemon_app" "$expected_daemon_bundle_id" || return 1
+  codesign --verify --deep --strict "$target_app" >/dev/null 2>&1 || return 1
+  team_id_matches "$target_app" || return 1
+  team_id_matches "$daemon_app" || return 1
+  team_id_matches "$cli" || return 1
+}
+
 stop_existing_daemon() {
   if [ "$no_stop_daemon" = "1" ]; then
     return
   fi
 
-  existing=""
-  if [ -x "$cli_link" ]; then
-    existing="$cli_link"
-  elif [ -x "$target_app/Contents/Resources/bin/agent-secret" ]; then
-    existing="$target_app/Contents/Resources/bin/agent-secret"
-  elif command -v agent-secret >/dev/null 2>&1; then
-    existing="$(command -v agent-secret)"
+  existing="$target_app/Contents/Resources/bin/agent-secret"
+  if [ ! -d "$target_app" ]; then
+    return
   fi
 
-  if [ -n "$existing" ]; then
+  if existing_app_is_trusted_for_stop; then
     "$existing" daemon stop >/dev/null 2>&1 || true
+  else
+    echo "agent-secret uninstall: skipping daemon stop because existing Agent Secret.app could not be verified" >&2
   fi
 }
 


### PR DESCRIPTION
## Summary
- remove bin-dir and PATH fallbacks from installer/uninstaller daemon stop
- verify the installed app-bundled CLI before using it to stop an existing daemon
- add installer and uninstaller smoke tests proving fake existing CLIs are not executed

Closes #166

## Verification
- bash scripts/test-install.sh
- bash scripts/test-uninstall.sh
- git diff --check
- mise run lint:shell
- mise run test:smoke
- mise run lint:smart