### PR TITLE
ASR-057: Require release tags to match current main

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -60,8 +60,8 @@ release target. Do not publish a release whose changelog section is empty.
    git push origin "v$version"
    ```
 
-   The tag-triggered workflow rejects `v*` tags whose target commit is not
-   reachable from `origin/main` before validating signing secrets or building
+   The tag-triggered workflow rejects `v*` tags whose target commit is not the
+   current `origin/main` commit before validating signing secrets or building
    release artifacts.
 
 7. Watch the tag-triggered CI run until `Draft Release Artifacts` passes.

--- a/scripts/check-release-ancestry.sh
+++ b/scripts/check-release-ancestry.sh
@@ -46,8 +46,11 @@ fi
 main_commit="$(git rev-parse --verify -q "${main_ref}^{commit}")" ||
   fail "could not resolve $remote/$main_branch"
 
-if ! git merge-base --is-ancestor "$release_commit" "$main_commit"; then
+if [[ "$release_commit" != "$main_commit" ]]; then
+  if git merge-base --is-ancestor "$release_commit" "$main_commit"; then
+    fail "tag $tag_name targets stale commit $release_commit, expected current $remote/$main_branch commit $main_commit"
+  fi
   fail "tag $tag_name targets commit $release_commit, which is not reachable from $remote/$main_branch"
 fi
 
-echo "release ancestry: tag $tag_name targets commit $release_commit reachable from $remote/$main_branch"
+echo "release ancestry: tag $tag_name targets current $remote/$main_branch commit $main_commit"

--- a/scripts/test-release-ancestry.sh
+++ b/scripts/test-release-ancestry.sh
@@ -58,6 +58,8 @@ git -C "$repo" tag -a v1.0.1 -m "v1.0.1"
   "$check_script" refs/tags/v1.0.1 >/dev/null
 )
 
+expect_failure "tag v1.0.0 targets stale commit" bash -c "cd '$repo' && '$check_script' v1.0.0"
+
 git -C "$repo" switch -c unreviewed >/dev/null
 printf 'unreviewed\n' >>"$repo/file.txt"
 git -C "$repo" commit -am "unreviewed" >/dev/null

--- a/scripts/test-release-docs.sh
+++ b/scripts/test-release-docs.sh
@@ -86,7 +86,7 @@ require_text "AGENT_SECRET_VERSION=\"\$version\" sh"
 
 require_release_process_text "## Toolchain Pin Maintenance"
 require_release_process_text "## Installer Bootstrap Documentation"
-require_release_process_text "reachable from \`origin/main\`"
+require_release_process_text "current \`origin/main\` commit"
 require_release_process_text "refuses to replace assets on a published release"
 require_release_process_text "Do not pipe"
 require_release_process_text "\`main/install.sh\` or \`main/uninstall.sh\`"


### PR DESCRIPTION
## Summary
- make the release ancestry guard require tag commits to equal fetched origin/main
- preserve the separate failure for tags not reachable from main
- add smoke coverage for stale ancestor tags after main advances

Closes #168

## Verification
- bash scripts/test-release-ancestry.sh
- AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh
- npx --yes markdownlint-cli docs/release-process.md
- git diff --check
- mise run lint:shell
- mise run test:smoke
- mise run lint:smart