### PR TITLE
ASR-063: Stabilize Swift peer validation tests

### DIFF
--- a/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTests.swift
@@ -63,9 +63,12 @@ import XCTest
                 }
             }
 
-            func acceptOneConnection() {
+            func acceptOneConnection(holdOpenUntil release: DispatchSemaphore? = nil) {
                 let client = accept(descriptor, nil, nil)
                 if client >= 0 {
+                    if let release {
+                        _ = release.wait(timeout: .now() + 5)
+                    }
                     close(client)
                 }
             }
@@ -216,10 +219,12 @@ import XCTest
 
         func testPathTransportRejectsSocketBeforeProtocolWhenPeerIsUntrusted() throws {
             let server = try Self.makeServer(testCase: self)
+            let releaseConnection = DispatchSemaphore(value: 0)
             let acceptThread = Thread {
-                server.acceptOneConnection()
+                server.acceptOneConnection(holdOpenUntil: releaseConnection)
             }
             acceptThread.start()
+            defer { releaseConnection.signal() }
 
             XCTAssertThrowsError(try UnixSocketLineTransport(path: server.path)) { error in
                 guard case .untrustedDaemon = error as? SocketDaemonClientError else {
@@ -230,10 +235,12 @@ import XCTest
 
         func testPathTransportCanTrustCurrentExecutableForLocalPeer() throws {
             let server = try Self.makeServer(testCase: self)
+            let releaseConnection = DispatchSemaphore(value: 0)
             let acceptThread = Thread {
-                server.acceptOneConnection()
+                server.acceptOneConnection(holdOpenUntil: releaseConnection)
             }
             acceptThread.start()
+            defer { releaseConnection.signal() }
 
             let validator = try TrustedDaemonPeerValidator(
                 expectedExecutablePaths: [Self.currentExecutablePath()]
@@ -244,6 +251,7 @@ import XCTest
                 ioTimeout: 0.05,
                 peerValidator: validator
             )
+            releaseConnection.signal()
 
             XCTAssertThrowsError(try transport.readLine()) { error in
                 XCTAssertEqual(error as? SocketDaemonClientError, .disconnected)


### PR DESCRIPTION
## Summary
- keep accepted test sockets open until peer validation completes
- close the held socket only after transport initialization so disconnected-read assertions still run
- prevent LOCAL_PEERPID/proc_pidpath races from failing unrelated PRs

Closes #174

## Verification
- cd approver && swift test --filter DaemonPeerValidationTests
- 25x repeated cd approver && swift test --filter DaemonPeerValidationTests
- mise run lint:swift
- git diff --check
- mise run test:smoke
- mise run test (passed on rerun after known Go health-check timeout)
- mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=3
- mise run lint:smart