### PR TITLE
ASR-059: Enforce reusable approval expiry through delivery

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -68,15 +68,17 @@ type ExecGrant struct {
 	SecretAliases      []string
 	ApprovalID         string
 	reusableMutationID string
+	approvalExpiresAt  time.Time
 }
 
 type activeExec struct {
-	nonce            string
-	req              request.ExecRequest
-	approvalID       string
-	payloadDelivered bool
-	started          bool
-	childPID         *int
+	nonce             string
+	req               request.ExecRequest
+	approvalID        string
+	payloadDelivered  bool
+	started           bool
+	childPID          *int
+	approvalExpiresAt time.Time
 }
 
 type BrokerOptions struct {
@@ -160,6 +162,9 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 		b.rollbackReusableApproval(grant.reusableMutationID)
 		return ExecGrant{}, err
 	}
+	if err := b.reusableApprovalActive(grant.ApprovalID, grant.approvalExpiresAt); err != nil {
+		return ExecGrant{}, err
+	}
 
 	event := audit.FromExecRequest(audit.EventCommandStarting, requestID, req)
 	if err := b.recordRequiredAudit(execCtx, event); err != nil {
@@ -170,12 +175,16 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 		b.rollbackReusableApproval(grant.reusableMutationID)
 		return ExecGrant{}, err
 	}
+	if err := b.reusableApprovalActive(grant.ApprovalID, grant.approvalExpiresAt); err != nil {
+		return ExecGrant{}, err
+	}
 
 	b.mu.Lock()
 	b.active[requestID] = &activeExec{
-		nonce:      nonce,
-		req:        req,
-		approvalID: grant.ApprovalID,
+		nonce:             nonce,
+		req:               req,
+		approvalID:        grant.ApprovalID,
+		approvalExpiresAt: grant.approvalExpiresAt,
 	}
 	b.mu.Unlock()
 
@@ -216,21 +225,44 @@ func (b *Broker) requestError(ctx context.Context, req request.ExecRequest, err 
 func (b *Broker) MarkPayloadDelivered(requestID string) error {
 	b.mu.Lock()
 	active, ok := b.active[requestID]
-	if ok {
-		active.payloadDelivered = true
-	}
 	b.mu.Unlock()
 	if !ok {
 		return ErrUnknownRequest
 	}
 	if active.approvalID == "" {
+		b.mu.Lock()
+		if current := b.active[requestID]; current != nil {
+			current.payloadDelivered = true
+		}
+		b.mu.Unlock()
 		return nil
 	}
+	if err := b.reusableApprovalActive(active.approvalID, active.approvalExpiresAt); err != nil {
+		b.mu.Lock()
+		delete(b.active, requestID)
+		b.mu.Unlock()
+		return err
+	}
 	approval, err := b.store.FinishReusableAttempt(active.approvalID, policy.DeliveryPayloadDelivered)
-	if err == nil && approval.Uses >= approval.MaxUses {
+	if err != nil {
+		b.clearReusableCacheScope(active.approvalID)
+		if errors.Is(err, policy.ErrExpired) {
+			b.mu.Lock()
+			delete(b.active, requestID)
+			b.mu.Unlock()
+			return ErrRequestExpired
+		}
+		return err
+	}
+	if approval.Uses >= approval.MaxUses {
 		b.clearReusableCacheScope(approval.ID)
 	}
-	return err
+	b.mu.Lock()
+	if current := b.active[requestID]; current != nil {
+		current.payloadDelivered = true
+	}
+	b.mu.Unlock()
+	return nil
 }
 
 func (b *Broker) ReportStarted(ctx context.Context, requestID string, nonce string, childPID int) error {
@@ -336,12 +368,18 @@ func (b *Broker) reusableGrant(ctx context.Context, req request.ExecRequest) (Ex
 	var values map[string]string
 	var valueErr error
 	if req.ForceRefresh {
-		values, valueErr = b.refreshedReusableValues(ctx, approval.ID, req)
+		values, valueErr = b.refreshedReusableValues(ctx, approval, req)
 	} else {
+		if err := b.reusableApprovalActive(approval.ID, approval.ExpiresAt); err != nil {
+			return ExecGrant{}, err
+		}
 		values, valueErr = b.cachedValues(approval.ID, req.Secrets)
 	}
 	if valueErr != nil {
 		return ExecGrant{}, valueErr
+	}
+	if err := b.reusableApprovalActive(approval.ID, approval.ExpiresAt); err != nil {
+		return ExecGrant{}, err
 	}
 
 	return ExecGrant{
@@ -349,6 +387,7 @@ func (b *Broker) reusableGrant(ctx context.Context, req request.ExecRequest) (Ex
 		SecretAliases:      aliases(req.Secrets),
 		ApprovalID:         approval.ID,
 		reusableMutationID: reusableMutationID(req.ForceRefresh, approval.ID),
+		approvalExpiresAt:  approval.ExpiresAt,
 	}, nil
 }
 
@@ -407,13 +446,15 @@ func (b *Broker) freshGrant(
 	values := fanoutValues(req.Secrets, refValues)
 
 	approvalID := ""
+	approvalExpiresAt := time.Time{}
 	if decision.Reusable {
 		approval, err := b.store.AddReusable(req, "", "")
 		if err != nil {
 			return ExecGrant{}, err
 		}
 		approvalID = approval.ID
-		if err := b.cacheResolvedValues(approvalID, refValues); err != nil {
+		approvalExpiresAt = approval.ExpiresAt
+		if err := b.cacheResolvedValues(approvalID, approval.ExpiresAt, refValues); err != nil {
 			b.rollbackReusableApproval(approvalID)
 			return ExecGrant{}, err
 		}
@@ -425,6 +466,7 @@ func (b *Broker) freshGrant(
 		SecretAliases:      aliases(req.Secrets),
 		ApprovalID:         approvalID,
 		reusableMutationID: approvalID,
+		approvalExpiresAt:  approvalExpiresAt,
 	}, nil
 }
 
@@ -441,6 +483,17 @@ func (b *Broker) rollbackReusableApproval(approvalID string) {
 	}
 	b.store.RemoveReusable(approvalID)
 	b.clearReusableCacheScope(approvalID)
+}
+
+func (b *Broker) reusableApprovalActive(approvalID string, expiresAt time.Time) error {
+	if approvalID == "" || expiresAt.IsZero() {
+		return nil
+	}
+	if b.now().Before(expiresAt) {
+		return nil
+	}
+	b.rollbackReusableApproval(approvalID)
+	return ErrRequestExpired
 }
 
 func (b *Broker) scheduleReusableExpiry(approvalID string, expiresAt time.Time) {
@@ -543,7 +596,7 @@ func (b *Broker) resolveUniqueRefs(ctx context.Context, requestID string, req re
 
 func (b *Broker) refreshedReusableValues(
 	ctx context.Context,
-	approvalID string,
+	approval policy.ReusableApproval,
 	req request.ExecRequest,
 ) (map[string]string, error) {
 	refValues, err := b.resolveUniqueRefs(ctx, "", req)
@@ -553,19 +606,25 @@ func (b *Broker) refreshedReusableValues(
 	if err := b.requestActive(ctx, req); err != nil {
 		return nil, err
 	}
+	if err := b.reusableApprovalActive(approval.ID, approval.ExpiresAt); err != nil {
+		return nil, err
+	}
 	values := fanoutValues(req.Secrets, refValues)
-	if err := b.cacheResolvedValues(approvalID, refValues); err != nil {
-		b.rollbackReusableApproval(approvalID)
+	if err := b.cacheResolvedValues(approval.ID, approval.ExpiresAt, refValues); err != nil {
+		b.rollbackReusableApproval(approval.ID)
 		return nil, err
 	}
 	event := audit.FromExecRequest(audit.EventApprovalRefreshed, "", req)
-	event.ApprovalID = approvalID
+	event.ApprovalID = approval.ID
 	if err := b.recordRequiredAudit(ctx, event); err != nil {
-		b.rollbackReusableApproval(approvalID)
+		b.rollbackReusableApproval(approval.ID)
 		return nil, err
 	}
 	if err := b.requestActive(ctx, req); err != nil {
-		b.rollbackReusableApproval(approvalID)
+		b.rollbackReusableApproval(approval.ID)
+		return nil, err
+	}
+	if err := b.reusableApprovalActive(approval.ID, approval.ExpiresAt); err != nil {
 		return nil, err
 	}
 	return values, nil
@@ -654,11 +713,21 @@ func auditRefsForIdentity(secrets []request.Secret, identity secretIdentity) []a
 	return refs
 }
 
-func (b *Broker) cacheResolvedValues(approvalID string, refValues map[secretIdentity]string) error {
+func (b *Broker) cacheResolvedValues(
+	approvalID string,
+	expiresAt time.Time,
+	refValues map[secretIdentity]string,
+) error {
 	for identity, value := range refValues {
+		if err := b.reusableApprovalActive(approvalID, expiresAt); err != nil {
+			return err
+		}
 		if err := b.cache.Put(approvalID, identity.ref, identity.account, value); err != nil {
 			return fmt.Errorf("cache approved secret in locked memory: %w", err)
 		}
+	}
+	if err := b.reusableApprovalActive(approvalID, expiresAt); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -799,6 +799,102 @@ func TestBrokerClearsReusableCacheOnExpiry(t *testing.T) {
 	}
 }
 
+func TestBrokerRejectsReusableApprovalThatExpiresDuringForceRefresh(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
+	ref := "op://Example/Item/token"
+	cache := policy.NewSecretCache()
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true}}
+	broker, err := NewBroker(BrokerOptions{
+		Now:      func() time.Time { return now },
+		Cache:    cache,
+		Approver: approver,
+		Resolver: &mockResolver{values: map[string]string{ref: "first"}},
+		Audit:    &memoryAudit{},
+	})
+	if err != nil {
+		t.Fatalf("NewBroker returned error: %v", err)
+	}
+	req := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+
+	first, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if err != nil {
+		t.Fatalf("first HandleExec returned error: %v", err)
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); err != nil {
+		t.Fatalf("MarkPayloadDelivered returned error: %v", err)
+	}
+	if _, ok := cache.Get(first.ApprovalID, ref, ""); !ok {
+		t.Fatal("expected reusable value in cache before force refresh")
+	}
+
+	now = req.ExpiresAt.Add(-time.Millisecond)
+	broker.resolver = &advancingResolver{
+		value: "second",
+		advance: func() {
+			now = req.ExpiresAt.Add(time.Second)
+		},
+	}
+	force := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	force.ForceRefresh = true
+
+	_, err = broker.HandleExec(context.Background(), "req_2", "nonce_2", force)
+	if !errors.Is(err, ErrRequestExpired) {
+		t.Fatalf("expected expired reusable approval during refresh, got %v", err)
+	}
+	if _, ok := cache.Get(first.ApprovalID, ref, ""); ok {
+		t.Fatal("expired reusable approval cache scope remained after force refresh")
+	}
+	if _, err := broker.store.FindReusable(context.Background(), req, nil); !errors.Is(err, policy.ErrMismatch) {
+		t.Fatalf("expired reusable approval remained in store: %v", err)
+	}
+}
+
+func TestBrokerRejectsReusableApprovalThatExpiresBeforePayloadDelivery(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
+	ref := "op://Example/Item/token"
+	cache := policy.NewSecretCache()
+	broker, err := NewBroker(BrokerOptions{
+		Now:      func() time.Time { return now },
+		Cache:    cache,
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true}},
+		Resolver: &mockResolver{values: map[string]string{ref: "first"}},
+		Audit:    &memoryAudit{},
+	})
+	if err != nil {
+		t.Fatalf("NewBroker returned error: %v", err)
+	}
+	req := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+
+	first, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if err != nil {
+		t.Fatalf("first HandleExec returned error: %v", err)
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); err != nil {
+		t.Fatalf("MarkPayloadDelivered returned error: %v", err)
+	}
+
+	now = req.ExpiresAt.Add(-time.Millisecond)
+	reuse := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	if _, err := broker.HandleExec(context.Background(), "req_2", "nonce_2", reuse); err != nil {
+		t.Fatalf("reuse HandleExec returned error before payload delivery: %v", err)
+	}
+
+	now = req.ExpiresAt.Add(time.Second)
+	if err := broker.MarkPayloadDelivered("req_2"); !errors.Is(err, ErrRequestExpired) {
+		t.Fatalf("expected reusable approval expiry before payload delivery, got %v", err)
+	}
+	if _, ok := cache.Get(first.ApprovalID, ref, ""); ok {
+		t.Fatal("expired reusable approval cache scope remained before payload delivery")
+	}
+	if err := broker.MarkPayloadDelivered("req_2"); !errors.Is(err, ErrUnknownRequest) {
+		t.Fatalf("expired request should no longer accept payload delivery, got %v", err)
+	}
+}
+
 func TestBrokerReusableCacheExpiresWithoutMatchingRequest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -279,13 +279,14 @@ func (s *Server) handleRequestExec(
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
 		return ""
 	}
-	err = writeOK(encoder, env.RequestID, env.Nonce, ExecResponsePayload{
+	if err := s.broker.MarkPayloadDelivered(env.RequestID); err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return ""
+	}
+	_ = writeOK(encoder, env.RequestID, env.Nonce, ExecResponsePayload{
 		Env:           grant.Env,
 		SecretAliases: grant.SecretAliases,
 	})
-	if err == nil {
-		_ = s.broker.MarkPayloadDelivered(env.RequestID)
-	}
 	return env.RequestID
 }
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -193,6 +193,10 @@ func (s *Store) FinishReusableAttempt(id string, result DeliveryResult) (Reusabl
 	if !ok {
 		return ReusableApproval{}, ErrMismatch
 	}
+	if !s.now().Before(approval.ExpiresAt) {
+		delete(s.approvals, id)
+		return *approval, ErrExpired
+	}
 	if consumesUse(result) {
 		approval.Uses++
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -193,6 +193,30 @@ func TestReusableApprovalExpiresAndExhaustsUses(t *testing.T) {
 	}
 }
 
+func TestFinishReusableAttemptRejectsExpiredApproval(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	store := NewStore(func() time.Time { return now })
+	req := testRequest(t, now)
+	approval, err := store.AddReusable(req, "appr_1", "nonce_1")
+	if err != nil {
+		t.Fatalf("AddReusable returned error: %v", err)
+	}
+
+	now = req.ExpiresAt
+	expired, err := store.FinishReusableAttempt(approval.ID, DeliveryPayloadDelivered)
+	if !errors.Is(err, ErrExpired) {
+		t.Fatalf("expected expired approval at payload delivery, got %v", err)
+	}
+	if expired.Uses != 0 {
+		t.Fatalf("expired approval consumed use: %d", expired.Uses)
+	}
+	if _, err := store.FindReusable(context.Background(), req, nil); !errors.Is(err, ErrMismatch) {
+		t.Fatalf("expected expired approval to be removed, got %v", err)
+	}
+}
+
 func TestReusableApprovalAuditFailureFailsClosed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #170.

## Summary
- carry reusable approval expiry into active exec grants and re-check it after cache refresh, before command-starting audit, and at payload delivery
- consume reusable approval uses before the daemon writes the secret-bearing exec response
- make policy finish reject expired approvals so delivery cannot bypass expiry in the store layer
- add daemon and policy regressions for force-refresh expiry and expiry at payload delivery

## Verification
- mise exec -- go test ./internal/daemon -run 'TestBrokerRejectsReusableApprovalThatExpires|TestBrokerReusableApprovalUsesCacheAndForceRefreshRefetches|TestBrokerClearsReusableCacheOnExpiry|TestBrokerClearsReusableCacheOnUseExhaustion|TestBrokerReportLifecycleValidatesNonceAndAudits'\n- mise exec -- go test ./internal/policy -run 'TestFinishReusableAttemptRejectsExpiredApproval|TestReusableApproval'\n- mise exec -- go test ./internal/daemon\n- mise exec -- go test ./internal/policy\n- mise run lint:smart\n- mise run lint:go\n- mise run test\n- mise run test:smoke\n- mise run test:race