### PR TITLE
ASR-060: Honor cancellation in approval waits

### DIFF
--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -95,6 +95,8 @@ type SocketApprover struct {
 
 type approvalJob struct {
 	payload       ApprovalRequestPayload
+	done          chan struct{}
+	doneOnce      sync.Once
 	expected      ExpectedApprover
 	expectedReady bool
 	result        chan approvalResult
@@ -132,6 +134,7 @@ func (a *SocketApprover) ApproveExec(
 ) (ApprovalDecision, error) {
 	job := &approvalJob{
 		payload: approvalPayload(requestID, nonce, req),
+		done:    make(chan struct{}),
 		result:  make(chan approvalResult, 1),
 	}
 
@@ -163,13 +166,11 @@ func (a *SocketApprover) ApproveExec(
 	}
 }
 
-func (a *SocketApprover) FetchPending(_ context.Context, peer peercred.Info) (ApprovalRequestPayload, error) {
-	a.mu.Lock()
-	for a.active != nil && !a.active.expectedReady {
-		a.cond.Wait()
+func (a *SocketApprover) FetchPending(ctx context.Context, peer peercred.Info) (ApprovalRequestPayload, error) {
+	job, err := a.activeWhenExpectedReady(ctx)
+	if err != nil {
+		return ApprovalRequestPayload{}, err
 	}
-	job := a.active
-	a.mu.Unlock()
 	if job == nil {
 		return ApprovalRequestPayload{}, ErrNoPendingApproval
 	}
@@ -184,16 +185,14 @@ func (a *SocketApprover) FetchPending(_ context.Context, peer peercred.Info) (Ap
 }
 
 func (a *SocketApprover) SubmitDecision(
-	_ context.Context,
+	ctx context.Context,
 	peer peercred.Info,
 	decision ApprovalDecisionPayload,
 ) error {
-	a.mu.Lock()
-	for a.active != nil && !a.active.expectedReady {
-		a.cond.Wait()
+	job, err := a.activeWhenExpectedReady(ctx)
+	if err != nil {
+		return err
 	}
-	job := a.active
-	a.mu.Unlock()
 	if job == nil {
 		return ErrNoPendingApproval
 	}
@@ -361,8 +360,14 @@ func (a *SocketApprover) promoteNext() {
 		a.complete(job, approvalResult{err: ErrRequestExpired})
 		return
 	}
-	expected, err := a.launcher.Launch(context.Background(), a.socketPath, job.payload)
+	launchCtx, cancelLaunch := job.launchContext()
+	defer cancelLaunch()
+	expected, err := a.launcher.Launch(launchCtx, a.socketPath, job.payload)
 	if err != nil {
+		if job.canceled() {
+			a.cancel(job, context.Canceled)
+			return
+		}
 		a.complete(job, approvalResult{err: fmt.Errorf("%w: %w", ErrApproverLaunchFailed, err)})
 		return
 	}
@@ -377,6 +382,7 @@ func (a *SocketApprover) promoteNext() {
 }
 
 func (a *SocketApprover) complete(job *approvalJob, result approvalResult) {
+	job.cancel()
 	a.mu.Lock()
 	if a.active == job {
 		a.active = nil
@@ -392,6 +398,7 @@ func (a *SocketApprover) complete(job *approvalJob, result approvalResult) {
 }
 
 func (a *SocketApprover) cancel(job *approvalJob, err error) {
+	job.cancel()
 	a.mu.Lock()
 	for i, queued := range a.queue {
 		if queued == job {
@@ -411,6 +418,62 @@ func (a *SocketApprover) cancel(job *approvalJob, err error) {
 	default:
 	}
 	go a.promoteNext()
+}
+
+func (j *approvalJob) cancel() {
+	j.doneOnce.Do(func() {
+		close(j.done)
+	})
+}
+
+func (j *approvalJob) canceled() bool {
+	select {
+	case <-j.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (j *approvalJob) launchContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := make(chan struct{})
+	go func() {
+		select {
+		case <-j.done:
+			cancel()
+		case <-stop:
+		}
+	}()
+	return ctx, func() {
+		close(stop)
+		cancel()
+	}
+}
+
+func (a *SocketApprover) activeWhenExpectedReady(ctx context.Context) (*approvalJob, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	stop := context.AfterFunc(ctx, func() {
+		a.mu.Lock()
+		a.cond.Broadcast()
+		a.mu.Unlock()
+	})
+	defer stop()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for a.active != nil && !a.active.expectedReady {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		a.cond.Wait()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return a.active, nil
 }
 
 func validateApproverPeer(expected ExpectedApprover, got peercred.Info) error {

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -25,6 +25,10 @@ type recordingLauncher struct {
 	err      error
 }
 
+type blockingLauncher struct {
+	started chan struct{}
+}
+
 type allowApproverIdentityPolicy struct{}
 
 func (allowApproverIdentityPolicy) ValidateApproverExecutable(path string) (ApproverIdentity, error) {
@@ -57,6 +61,18 @@ func (l *recordingLauncher) Count() int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return len(l.launched)
+}
+
+func newBlockingLauncher() *blockingLauncher {
+	return &blockingLauncher{
+		started: make(chan struct{}),
+	}
+}
+
+func (l *blockingLauncher) Launch(ctx context.Context, _ string, _ ApprovalRequestPayload) (ExpectedApprover, error) {
+	close(l.started)
+	<-ctx.Done()
+	return ExpectedApprover{}, ctx.Err()
 }
 
 func TestApprovalFixturesDecodeInGo(t *testing.T) {
@@ -329,6 +345,79 @@ func TestSocketApproverExpiresActiveRequestWithoutDecision(t *testing.T) {
 	_, err := approver.ApproveExec(context.Background(), "req_1", "nonce_1", req)
 	if !errors.Is(err, ErrRequestExpired) {
 		t.Fatalf("ApproveExec error = %v, want expired", err)
+	}
+}
+
+func TestSocketApproverFetchPendingHonorsContextWhileApproverLaunchIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	launcher := newBlockingLauncher()
+	approver := newSocketApproverForTest(t, launcher, time.Now)
+	req := approvalTestRequest(t, time.Now().Add(time.Minute))
+	approveCtx, cancelApprove := context.WithCancel(context.Background())
+	defer cancelApprove()
+	approveErr := make(chan error, 1)
+	go func() {
+		_, err := approver.ApproveExec(approveCtx, "req_1", "nonce_1", req)
+		approveErr <- err
+	}()
+	receiveApprovalSignal(t, launcher.started, "approver launch did not start")
+
+	fetchCtx, cancelFetch := context.WithCancel(context.Background())
+	fetchErr := make(chan error, 1)
+	go func() {
+		_, err := approver.FetchPending(fetchCtx, peerInfoForTest(t, os.Getpid(), exe))
+		fetchErr <- err
+	}()
+	cancelFetch()
+	if err := receiveApprovalError(t, fetchErr, "FetchPending did not observe context cancellation"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("FetchPending error = %v, want context cancellation", err)
+	}
+
+	cancelApprove()
+	if err := receiveApprovalError(t, approveErr, "ApproveExec did not observe context cancellation"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ApproveExec error = %v, want context cancellation", err)
+	}
+}
+
+func TestSocketApproverSubmitDecisionHonorsContextWhileApproverLaunchIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	launcher := newBlockingLauncher()
+	approver := newSocketApproverForTest(t, launcher, time.Now)
+	req := approvalTestRequest(t, time.Now().Add(time.Minute))
+	approveCtx, cancelApprove := context.WithCancel(context.Background())
+	defer cancelApprove()
+	approveErr := make(chan error, 1)
+	go func() {
+		_, err := approver.ApproveExec(approveCtx, "req_1", "nonce_1", req)
+		approveErr <- err
+	}()
+	receiveApprovalSignal(t, launcher.started, "approver launch did not start")
+
+	decisionCtx, cancelDecision := context.WithCancel(context.Background())
+	decisionErr := make(chan error, 1)
+	go func() {
+		decisionErr <- approver.SubmitDecision(
+			decisionCtx,
+			peerInfoForTest(t, os.Getpid(), exe),
+			ApprovalDecisionPayload{
+				RequestID: "req_1",
+				Nonce:     "nonce_1",
+				Decision:  "approve_once",
+			},
+		)
+	}()
+	cancelDecision()
+	if err := receiveApprovalError(t, decisionErr, "SubmitDecision did not observe context cancellation"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SubmitDecision error = %v, want context cancellation", err)
+	}
+
+	cancelApprove()
+	if err := receiveApprovalError(t, approveErr, "ApproveExec did not observe context cancellation"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ApproveExec error = %v, want context cancellation", err)
 	}
 }
 
@@ -866,4 +955,24 @@ func waitForPending(t *testing.T, approver *SocketApprover) {
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatal("timed out waiting for pending approval")
+}
+
+func receiveApprovalSignal(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
+}
+
+func receiveApprovalError(t *testing.T, ch <-chan error, message string) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal(message)
+		return nil
+	}
 }


### PR DESCRIPTION
Closes #171.

## Summary
- make approval socket waits on expected approver identity return when their caller context is canceled
- propagate approval cancellation into the native approver launch path without storing context on the job struct
- add blocked-launch regressions for both FetchPending and SubmitDecision

## Verification
- mise exec -- go test ./internal/daemon -run 'TestSocketApprover(FetchPending|SubmitDecision)HonorsContextWhileApproverLaunchIsBlocked'\n- mise exec -- go test ./internal/daemon -run 'TestSocketApprover'\n- mise exec -- go test -race ./internal/daemon -run 'TestSocketApprover'\n- mise exec -- go test ./internal/daemon\n- mise run lint:smart\n- mise run lint:go\n- mise run test\n- mise run test:smoke\n- mise run test:race