### PR TITLE
ASR-061: Bound Swift codesign validation

### DIFF
--- a/approver/Sources/AgentSecretApprover/CodeSignatureProcessResult.swift
+++ b/approver/Sources/AgentSecretApprover/CodeSignatureProcessResult.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+#if canImport(Darwin)
+    struct CodeSignatureProcessResult {
+        let output: String
+        let terminationStatus: Int32
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/CodeSignatureProcessRunning.swift
+++ b/approver/Sources/AgentSecretApprover/CodeSignatureProcessRunning.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+#if canImport(Darwin)
+    protocol CodeSignatureProcessRunning {
+        func run(executableURL: URL, arguments: [String], timeout: TimeInterval) throws -> CodeSignatureProcessResult
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/FoundationCodeSignatureProcessRunner.swift
+++ b/approver/Sources/AgentSecretApprover/FoundationCodeSignatureProcessRunner.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+#if canImport(Darwin)
+    import Darwin
+
+    struct FoundationCodeSignatureProcessRunner: CodeSignatureProcessRunning {
+        private final class ProcessOutputBuffer: @unchecked Sendable {
+            private let lock = NSLock()
+            private var data = Data()
+
+            func append(_ chunk: Data) {
+                lock.lock()
+                data.append(chunk)
+                lock.unlock()
+            }
+
+            func text() -> String {
+                lock.lock()
+                defer { lock.unlock() }
+                return String(data: data, encoding: .utf8) ?? ""
+            }
+
+            deinit {
+                /* Required by SwiftLint. */
+            }
+        }
+
+        private static let minimumTimeout: TimeInterval = 0.001
+        private static let millisecondsPerSecond: TimeInterval = 1e3
+        private static let outputDrainTimeout: TimeInterval = 1
+        private static let shutdownTimeout: TimeInterval = 0.2
+
+        private static func readOutput(from pipe: Pipe) -> (done: DispatchSemaphore, text: () -> String) {
+            let done = DispatchSemaphore(value: 0)
+            let output = ProcessOutputBuffer()
+            DispatchQueue.global(qos: .utility).async {
+                while true {
+                    let data = pipe.fileHandleForReading.availableData
+                    if data.isEmpty {
+                        break
+                    }
+                    output.append(data)
+                }
+                done.signal()
+            }
+            return (
+                done,
+                {
+                    output.text()
+                }
+            )
+        }
+
+        private static func stopTimedOutProcess(_ process: Process, termination: DispatchSemaphore) {
+            process.terminate()
+            if termination.wait(timeout: deadline(after: shutdownTimeout)) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = termination.wait(timeout: deadline(after: shutdownTimeout))
+            }
+        }
+
+        private static func deadline(after seconds: TimeInterval) -> DispatchTime {
+            let boundedSeconds = max(seconds, minimumTimeout)
+            let milliseconds = max(1, Int((boundedSeconds * millisecondsPerSecond).rounded(.up)))
+            return .now() + .milliseconds(milliseconds)
+        }
+
+        func run(executableURL: URL, arguments: [String], timeout: TimeInterval) throws -> CodeSignatureProcessResult {
+            let process = Process()
+            process.executableURL = executableURL
+            process.arguments = arguments
+            let output = Pipe()
+            process.standardOutput = output
+            process.standardError = output
+
+            let termination = DispatchSemaphore(value: 0)
+            process.terminationHandler = { _ in
+                termination.signal()
+            }
+
+            do {
+                try process.run()
+            } catch {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "launch daemon process code signature validation failed: \(error)"
+                )
+            }
+
+            let outputReader = Self.readOutput(from: output)
+            guard termination.wait(timeout: Self.deadline(after: timeout)) == .success else {
+                Self.stopTimedOutProcess(process, termination: termination)
+                _ = outputReader.done.wait(timeout: Self.deadline(after: Self.outputDrainTimeout))
+                throw SocketDaemonClientError.untrustedDaemon("daemon process code signature validation timed out")
+            }
+
+            _ = outputReader.done.wait(timeout: Self.deadline(after: Self.outputDrainTimeout))
+            return CodeSignatureProcessResult(
+                output: outputReader.text(),
+                terminationStatus: process.terminationStatus
+            )
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/SecurityDaemonCodeSignatureChecker.swift
+++ b/approver/Sources/AgentSecretApprover/SecurityDaemonCodeSignatureChecker.swift
@@ -1,33 +1,18 @@
 import Foundation
 
 #if canImport(Darwin)
-    import Darwin
     import Security
 
     struct SecurityDaemonCodeSignatureChecker: DaemonCodeSignatureChecking {
-        private static func runCodesign(arguments: [String]) throws -> String {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
-            process.arguments = arguments
-            let output = Pipe()
-            process.standardOutput = output
-            process.standardError = output
-            do {
-                try process.run()
-            } catch {
-                throw SocketDaemonClientError.untrustedDaemon(
-                    "launch daemon process code signature validation failed: \(error)"
-                )
-            }
-            process.waitUntilExit()
-            let data = output.fileHandleForReading.readDataToEndOfFile()
-            let text = String(data: data, encoding: .utf8) ?? ""
-            guard process.terminationStatus == 0 else {
-                throw SocketDaemonClientError.untrustedDaemon(
-                    "daemon process code signature validation failed with status \(process.terminationStatus)"
-                )
-            }
-            return text
+        private let codesignRunner: CodeSignatureProcessRunning
+        private let codesignTimeout: TimeInterval
+
+        init(
+            codesignRunner: CodeSignatureProcessRunning = FoundationCodeSignatureProcessRunner(),
+            codesignTimeout: TimeInterval = 2
+        ) {
+            self.codesignRunner = codesignRunner
+            self.codesignTimeout = codesignTimeout
         }
 
         private static func teamID(forStaticCode code: SecStaticCode) throws -> String {
@@ -49,6 +34,20 @@ import Foundation
                 throw SocketDaemonClientError.untrustedDaemon("daemon code signature has no Team ID")
             }
             return teamID
+        }
+
+        private func runCodesign(arguments: [String]) throws -> String {
+            let result = try codesignRunner.run(
+                executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
+                arguments: arguments,
+                timeout: codesignTimeout
+            )
+            guard result.terminationStatus == 0 else {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "daemon process code signature validation failed with status \(result.terminationStatus)"
+                )
+            }
+            return result.output
         }
 
         func staticCodeTeamID(for path: String) throws -> String {
@@ -80,8 +79,8 @@ import Foundation
 
         func processTeamID(for pid: pid_t) throws -> String {
             let target = "+\(pid)"
-            _ = try Self.runCodesign(arguments: ["--verify", "--strict", "--deep", target])
-            let output = try Self.runCodesign(arguments: ["-dv", "--verbose=4", target])
+            _ = try runCodesign(arguments: ["--verify", "--strict", "--deep", target])
+            let output = try runCodesign(arguments: ["-dv", "--verbose=4", target])
             for line in output.components(separatedBy: .newlines) {
                 let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
                 if trimmedLine.hasPrefix("TeamIdentifier=") {

--- a/approver/Tests/AgentSecretApproverTests/SecurityDaemonCodeSignatureCheckerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/SecurityDaemonCodeSignatureCheckerTests.swift
@@ -1,0 +1,142 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+#if canImport(Darwin)
+    final class SecurityDaemonCodeSignatureCheckerTests: XCTestCase {
+        private struct ProcessRunnerCall: Equatable {
+            let executableURL: URL
+            let arguments: [String]
+            let timeout: TimeInterval
+        }
+
+        private final class FakeCodeSignatureProcessRunner: CodeSignatureProcessRunning {
+            private var results: [Result<CodeSignatureProcessResult, Error>]
+            private(set) var calls: [ProcessRunnerCall] = []
+
+            init(results: [Result<CodeSignatureProcessResult, Error>]) {
+                self.results = results
+            }
+
+            func run(
+                executableURL: URL,
+                arguments: [String],
+                timeout: TimeInterval
+            ) throws -> CodeSignatureProcessResult {
+                calls.append(ProcessRunnerCall(executableURL: executableURL, arguments: arguments, timeout: timeout))
+                return try results.removeFirst().get()
+            }
+
+            deinit {
+                /* Required by SwiftLint. */
+            }
+        }
+
+        private static let largeOutputByteCount = 200_000
+        private static let minimumLargeOutputBytes = 100_000
+
+        func testProcessTeamIDVerifiesAndParsesCodesignOutput() throws {
+            let runner = FakeCodeSignatureProcessRunner(results: [
+                .success(CodeSignatureProcessResult(output: "", terminationStatus: 0)),
+                .success(
+                    CodeSignatureProcessResult(
+                        output: "Authority=Example\nTeamIdentifier=TEAMID\n",
+                        terminationStatus: 0
+                    )
+                )
+            ])
+            let checker = SecurityDaemonCodeSignatureChecker(codesignRunner: runner, codesignTimeout: 0.25)
+            let pid: pid_t = 123
+
+            XCTAssertEqual(try checker.processTeamID(for: pid), "TEAMID")
+            XCTAssertEqual(runner.calls, [
+                .init(
+                    executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
+                    arguments: ["--verify", "--strict", "--deep", "+123"],
+                    timeout: 0.25
+                ),
+                .init(
+                    executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
+                    arguments: ["-dv", "--verbose=4", "+123"],
+                    timeout: 0.25
+                )
+            ])
+        }
+
+        func testProcessTeamIDRejectsNonZeroCodesignStatus() {
+            let runner = FakeCodeSignatureProcessRunner(results: [
+                .success(CodeSignatureProcessResult(output: "bad signature", terminationStatus: 1))
+            ])
+            let checker = SecurityDaemonCodeSignatureChecker(codesignRunner: runner, codesignTimeout: 0.25)
+
+            XCTAssertThrowsError(try checker.processTeamID(for: 123)) { error in
+                XCTAssertEqual(
+                    error as? SocketDaemonClientError,
+                    .untrustedDaemon("daemon process code signature validation failed with status 1")
+                )
+            }
+        }
+
+        func testFoundationRunnerReturnsOutputAndStatus() throws {
+            let runner = FoundationCodeSignatureProcessRunner()
+
+            let result = try runner.run(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "printf hello"],
+                timeout: 1
+            )
+
+            XCTAssertEqual(result.output, "hello")
+            XCTAssertEqual(result.terminationStatus, 0)
+        }
+
+        func testFoundationRunnerReturnsNonZeroStatusWithoutThrowing() throws {
+            let runner = FoundationCodeSignatureProcessRunner()
+
+            let result = try runner.run(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "printf nope; exit 7"],
+                timeout: 1
+            )
+
+            XCTAssertEqual(result.output, "nope")
+            XCTAssertEqual(result.terminationStatus, 7)
+        }
+
+        func testFoundationRunnerDrainsLargeOutput() throws {
+            let runner = FoundationCodeSignatureProcessRunner()
+
+            let result = try runner.run(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "yes agent-secret | head -c \(Self.largeOutputByteCount)"],
+                timeout: 1
+            )
+
+            XCTAssertGreaterThan(result.output.count, Self.minimumLargeOutputBytes)
+            XCTAssertEqual(result.terminationStatus, 0)
+        }
+
+        func testFoundationRunnerTimesOutHungProcess() {
+            let runner = FoundationCodeSignatureProcessRunner()
+            let startedAt = Date()
+
+            XCTAssertThrowsError(
+                try runner.run(
+                    executableURL: URL(fileURLWithPath: "/bin/sleep"),
+                    arguments: ["5"],
+                    timeout: 0.05
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? SocketDaemonClientError,
+                    .untrustedDaemon("daemon process code signature validation timed out")
+                )
+            }
+            XCTAssertLessThan(Date().timeIntervalSince(startedAt), 2)
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif


### PR DESCRIPTION
Closes #172.

## Summary
- replace unbounded Swift `codesign` waits with an injectable process runner that enforces a timeout
- drain combined stdout/stderr concurrently so noisy signature checks cannot block on a full pipe
- fail closed on timeout and keep non-zero status handling in the signature checker
- add Swift regressions for parsed Team ID output, non-zero status, large output draining, and hung process timeout

## Verification
- mise exec -- swift test --package-path approver --filter SecurityDaemonCodeSignatureCheckerTests
- mise run lint:swift
- mise run lint:smart
- mise run lint:go
- mise run test
- mise run test:smoke
- mise run test:race