### PR TITLE
ASR-062: Detect early approver process exit

### DIFF
--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -81,6 +81,7 @@ type ExpectedApprover struct {
 	ExpectedTeamID    string
 	VerifySignature   bool
 	signatureVerifier codeSignatureVerifier
+	exited            <-chan error
 }
 
 type SocketApprover struct {
@@ -99,6 +100,7 @@ type approvalJob struct {
 	doneOnce      sync.Once
 	expected      ExpectedApprover
 	expectedReady bool
+	expectedUsed  bool
 	result        chan approvalResult
 }
 
@@ -180,6 +182,9 @@ func (a *SocketApprover) FetchPending(ctx context.Context, peer peercred.Info) (
 	}
 	if err := validateApproverPeer(job.expected, peer); err != nil {
 		return ApprovalRequestPayload{}, err
+	}
+	if !a.markExpectedUsed(job) {
+		return ApprovalRequestPayload{}, ErrNoPendingApproval
 	}
 	return job.payload, nil
 }
@@ -272,8 +277,11 @@ func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string, 
 	}
 	executable = identity.ExecutablePath
 
-	//nolint:gosec // G204: executable was canonicalized and validated by the approver identity policy above.
-	cmd := exec.CommandContext(ctx, executable, "--socket", socketPath)
+	if err := ctx.Err(); err != nil {
+		return ExpectedApprover{}, err
+	}
+	//nolint:gosec,noctx // G204: executable was canonicalized and validated above; CommandContext would kill a successfully launched approver when the approval job completes.
+	cmd := exec.Command(executable, "--socket", socketPath)
 	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
 	if err != nil {
 		return ExpectedApprover{}, fmt.Errorf("%w: open /dev/null: %w", ErrApproverLaunchFailed, err)
@@ -285,6 +293,13 @@ func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string, 
 	if err := cmd.Start(); err != nil {
 		return ExpectedApprover{}, fmt.Errorf("%w: %w", ErrApproverLaunchFailed, err)
 	}
+	select {
+	case <-ctx.Done():
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return ExpectedApprover{}, ctx.Err()
+	default:
+	}
 	expected := ExpectedApprover{
 		PID:               cmd.Process.Pid,
 		ExecutablePath:    executable,
@@ -292,9 +307,12 @@ func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string, 
 		VerifySignature:   identity.VerifySignature,
 		signatureVerifier: codesignSignatureVerifier{},
 	}
-	if err := cmd.Process.Release(); err != nil {
-		return ExpectedApprover{}, fmt.Errorf("%w: release process: %w", ErrApproverLaunchFailed, err)
-	}
+	exited := make(chan error, 1)
+	expected.exited = exited
+	go func() {
+		exited <- cmd.Wait()
+		close(exited)
+	}()
 	return expected, nil
 }
 
@@ -360,8 +378,7 @@ func (a *SocketApprover) promoteNext() {
 		a.complete(job, approvalResult{err: ErrRequestExpired})
 		return
 	}
-	launchCtx, cancelLaunch := job.launchContext()
-	defer cancelLaunch()
+	launchCtx := job.launchContext()
 	expected, err := a.launcher.Launch(launchCtx, a.socketPath, job.payload)
 	if err != nil {
 		if job.canceled() {
@@ -379,6 +396,9 @@ func (a *SocketApprover) promoteNext() {
 		a.cond.Broadcast()
 	}
 	a.mu.Unlock()
+	if expected.exited != nil {
+		go a.monitorExpectedApprover(job, expected.exited)
+	}
 }
 
 func (a *SocketApprover) complete(job *approvalJob, result approvalResult) {
@@ -435,20 +455,44 @@ func (j *approvalJob) canceled() bool {
 	}
 }
 
-func (j *approvalJob) launchContext() (context.Context, context.CancelFunc) {
+func (j *approvalJob) launchContext() context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
-	stop := make(chan struct{})
 	go func() {
-		select {
-		case <-j.done:
-			cancel()
-		case <-stop:
-		}
-	}()
-	return ctx, func() {
-		close(stop)
+		<-j.done
 		cancel()
+	}()
+	return ctx
+}
+
+func (a *SocketApprover) markExpectedUsed(job *approvalJob) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.active != job {
+		return false
 	}
+	job.expectedUsed = true
+	return true
+}
+
+func (a *SocketApprover) monitorExpectedApprover(job *approvalJob, exited <-chan error) {
+	select {
+	case err := <-exited:
+		if !a.expectedApproverExitShouldFail(job) {
+			return
+		}
+		message := "approver exited before fetching pending approval"
+		if err != nil {
+			message = fmt.Sprintf("%s: %v", message, err)
+		}
+		a.complete(job, approvalResult{err: fmt.Errorf("%w: %s", ErrApproverLaunchFailed, message)})
+	case <-job.done:
+	}
+}
+
+func (a *SocketApprover) expectedApproverExitShouldFail(job *approvalJob) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.active == job && job.expectedReady && !job.expectedUsed
 }
 
 func (a *SocketApprover) activeWhenExpectedReady(ctx context.Context) (*approvalJob, error) {

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -29,6 +29,16 @@ type blockingLauncher struct {
 	started chan struct{}
 }
 
+type exitingLauncher struct {
+	expected ExpectedApprover
+	exited   chan error
+}
+
+type contextObservingLauncher struct {
+	expected ExpectedApprover
+	canceled chan struct{}
+}
+
 type allowApproverIdentityPolicy struct{}
 
 func (allowApproverIdentityPolicy) ValidateApproverExecutable(path string) (ApproverIdentity, error) {
@@ -73,6 +83,20 @@ func (l *blockingLauncher) Launch(ctx context.Context, _ string, _ ApprovalReque
 	close(l.started)
 	<-ctx.Done()
 	return ExpectedApprover{}, ctx.Err()
+}
+
+func (l *exitingLauncher) Launch(_ context.Context, _ string, _ ApprovalRequestPayload) (ExpectedApprover, error) {
+	expected := l.expected
+	expected.exited = l.exited
+	return expected, nil
+}
+
+func (l *contextObservingLauncher) Launch(ctx context.Context, _ string, _ ApprovalRequestPayload) (ExpectedApprover, error) {
+	go func() {
+		<-ctx.Done()
+		close(l.canceled)
+	}()
+	return l.expected, nil
 }
 
 func TestApprovalFixturesDecodeInGo(t *testing.T) {
@@ -346,6 +370,124 @@ func TestSocketApproverExpiresActiveRequestWithoutDecision(t *testing.T) {
 	if !errors.Is(err, ErrRequestExpired) {
 		t.Fatalf("ApproveExec error = %v, want expired", err)
 	}
+}
+
+func TestSocketApproverFailsWhenExpectedApproverExitsBeforeFetch(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	exited := make(chan error, 1)
+	launcher := &exitingLauncher{
+		expected: ExpectedApprover{PID: os.Getpid(), ExecutablePath: exe},
+		exited:   exited,
+	}
+	approver := newSocketApproverForTest(t, launcher, time.Now)
+	req := approvalTestRequest(t, time.Now().Add(time.Minute))
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := approver.ApproveExec(context.Background(), "req_1", "nonce_1", req)
+		errCh <- err
+	}()
+	waitForPending(t, approver)
+
+	exited <- errors.New("exit status 64")
+	close(exited)
+
+	if err := receiveApprovalError(t, errCh, "ApproveExec did not observe early approver exit"); !errors.Is(err, ErrApproverLaunchFailed) {
+		t.Fatalf("ApproveExec error = %v, want launch failure", err)
+	}
+	if _, err := approver.FetchPending(context.Background(), peerInfoForTest(t, os.Getpid(), exe)); !errors.Is(err, ErrNoPendingApproval) {
+		t.Fatalf("FetchPending after early exit = %v, want no pending approval", err)
+	}
+}
+
+func TestSocketApproverIgnoresExpectedApproverExitAfterFetch(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	exited := make(chan error, 1)
+	launcher := &exitingLauncher{
+		expected: ExpectedApprover{PID: os.Getpid(), ExecutablePath: exe},
+		exited:   exited,
+	}
+	approver := newSocketApproverForTest(t, launcher, time.Now)
+	req := approvalTestRequest(t, time.Now().Add(time.Minute))
+	resultCh := make(chan ApprovalDecision, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		decision, err := approver.ApproveExec(context.Background(), "req_1", "nonce_1", req)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		resultCh <- decision
+	}()
+	waitForPending(t, approver)
+
+	if _, err := approver.FetchPending(context.Background(), peerInfoForTest(t, os.Getpid(), exe)); err != nil {
+		t.Fatalf("FetchPending returned error: %v", err)
+	}
+	exited <- errors.New("exit status 64")
+	close(exited)
+
+	err := approver.SubmitDecision(context.Background(), peerInfoForTest(t, os.Getpid(), exe), ApprovalDecisionPayload{
+		RequestID: "req_1",
+		Nonce:     "nonce_1",
+		Decision:  "approve_once",
+	})
+	if err != nil {
+		t.Fatalf("SubmitDecision returned error: %v", err)
+	}
+	select {
+	case decision := <-resultCh:
+		if !decision.Approved {
+			t.Fatalf("unexpected approval result: %+v", decision)
+		}
+	case err := <-errCh:
+		t.Fatalf("ApproveExec returned error after fetch: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for approval result")
+	}
+}
+
+func TestSocketApproverLaunchContextLivesUntilApprovalCompletes(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	launcher := &contextObservingLauncher{
+		expected: ExpectedApprover{PID: os.Getpid(), ExecutablePath: exe},
+		canceled: make(chan struct{}),
+	}
+	approver := newSocketApproverForTest(t, launcher, time.Now)
+	req := approvalTestRequest(t, time.Now().Add(time.Minute))
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := approver.ApproveExec(context.Background(), "req_1", "nonce_1", req)
+		errCh <- err
+	}()
+	waitForPending(t, approver)
+
+	select {
+	case <-launcher.canceled:
+		t.Fatal("launch context was canceled before approval completed")
+	default:
+	}
+
+	if _, err := approver.FetchPending(context.Background(), peerInfoForTest(t, os.Getpid(), exe)); err != nil {
+		t.Fatalf("FetchPending returned error: %v", err)
+	}
+	err := approver.SubmitDecision(context.Background(), peerInfoForTest(t, os.Getpid(), exe), ApprovalDecisionPayload{
+		RequestID: "req_1",
+		Nonce:     "nonce_1",
+		Decision:  "approve_once",
+	})
+	if err != nil {
+		t.Fatalf("SubmitDecision returned error: %v", err)
+	}
+	if err := receiveApprovalError(t, errCh, "ApproveExec did not complete"); err != nil {
+		t.Fatalf("ApproveExec returned error: %v", err)
+	}
+	receiveApprovalSignal(t, launcher.canceled, "launch context was not canceled after approval completed")
 }
 
 func TestSocketApproverFetchPendingHonorsContextWhileApproverLaunchIsBlocked(t *testing.T) {
@@ -646,6 +788,38 @@ func TestProcessApproverLauncherLaunchesBinary(t *testing.T) {
 	}
 	if expected.ExecutablePath != helper {
 		t.Fatalf("expected executable path = %q, want %q", expected.ExecutablePath, helper)
+	}
+}
+
+func TestProcessApproverLauncherExposesEarlyProcessExit(t *testing.T) {
+	t.Parallel()
+
+	helper := filepath.Join(t.TempDir(), "approver-helper")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexit 42\n"), 0o755); err != nil { //nolint:gosec // G306: launcher tests need runnable helper executables.
+		t.Fatalf("write helper: %v", err)
+	}
+
+	expected, err := (ProcessApproverLauncher{
+		AppPath:        helper,
+		IdentityPolicy: allowApproverIdentityPolicy{},
+	}).Launch(
+		context.Background(),
+		"/tmp/agent-secret-test.sock",
+		ApprovalRequestPayload{},
+	)
+	if err != nil {
+		t.Fatalf("Launch returned error: %v", err)
+	}
+	if expected.exited == nil {
+		t.Fatal("expected process exit monitor channel")
+	}
+	select {
+	case err := <-expected.exited:
+		if err == nil {
+			t.Fatal("expected non-zero helper exit error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for helper process exit")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #173.

Detects a native approver process that exits after launch but before it consumes the pending approval request. The daemon now fails the active approval immediately in that case, records the launcher failure path, and promotes queued requests instead of waiting for the full request TTL.

## Changes

- Keeps a process wait handle for the launched approver instead of releasing it immediately.
- Marks expected approvers as consumed only after the daemon validates the peer and fetches the pending request.
- Fails the job with `ErrApproverLaunchFailed` when the launched approver exits before fetching its request.
- Leaves post-fetch exits alone so normal approval/denial response delivery is not interrupted.
- Keeps the launcher context alive until the approval completes so ASR-060 cancellation semantics do not kill a successfully launched approver prematurely.

## Verification

- `mise exec -- go test ./internal/daemon -run 'TestSocketApprover(FailsWhenExpectedApproverExitsBeforeFetch|IgnoresExpectedApproverExitAfterFetch|LaunchContextLivesUntilApprovalCompletes)|TestProcessApproverLauncher(ExposesEarlyProcessExit|LaunchesBinary|CarriesSignaturePolicy)'`
- `mise exec -- go test -race ./internal/daemon -run TestProcessApproverLauncherExposesEarlyProcessExit -count=5`
- `mise exec -- go test ./internal/daemon`
- `mise exec -- go test -race ./internal/daemon -run 'TestSocketApprover|TestProcessApproverLauncher'`
- `mise run lint:smart`
- `mise run lint:go`
- `mise run test`
- `mise run test:smoke`
- `mise run test:race`
