### PR TITLE
ASR-064: Bind reusable approvals to environment fingerprints

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -212,6 +212,9 @@ NEXT=op://Example/Next/token
 	if got := lookupTestEnv(req.Env, "REMOVED"); got != "plain-now" {
 		t.Fatalf("REMOVED = %q, want plain-now", got)
 	}
+	if req.EnvironmentFingerprint != request.EnvironmentFingerprint(req.Env) {
+		t.Fatalf("environment fingerprint = %q, want fingerprint of effective env", req.EnvironmentFingerprint)
+	}
 }
 
 func TestParseExecEnvFileDoesNotLoadDefaultProfile(t *testing.T) {

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -1036,11 +1036,15 @@ func approvalTestRequest(t *testing.T, expiresAt time.Time) request.ExecRequest 
 		ResolvedExecutable: "/opt/homebrew/bin/terraform",
 		ExecutableIdentity: fileidentity.Identity{Device: 1, Inode: 1, Mode: 0o755},
 		CWD:                "/tmp/project",
-		Secrets:            []request.Secret{{Alias: "TOKEN", Ref: ref, Account: "Work"}},
-		ReceivedAt:         expiresAt.Add(-request.DefaultExecTTL),
-		ExpiresAt:          expiresAt,
-		TTL:                request.DefaultExecTTL,
-		DeliveryMode:       request.DeliveryEnvExec,
+		EnvironmentFingerprint: request.EnvironmentFingerprint([]string{
+			"PATH=/opt/homebrew/bin",
+			"NODE_OPTIONS=--require ./safe.js",
+		}),
+		Secrets:      []request.Secret{{Alias: "TOKEN", Ref: ref, Account: "Work"}},
+		ReceivedAt:   expiresAt.Add(-request.DefaultExecTTL),
+		ExpiresAt:    expiresAt,
+		TTL:          request.DefaultExecTTL,
+		DeliveryMode: request.DeliveryEnvExec,
 	}
 }
 

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -750,6 +750,56 @@ func TestBrokerReusableApprovalUsesCacheAndForceRefreshRefetches(t *testing.T) {
 	}
 }
 
+func TestBrokerReusableApprovalMissesWhenEnvironmentFingerprintChanges(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true}}
+	resolver := &mockResolver{values: map[string]string{ref: "first"}}
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    aud,
+		Cache:    policy.NewSecretCache(),
+	})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+
+	first, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if err != nil {
+		t.Fatalf("first HandleExec returned error: %v", err)
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); err != nil {
+		t.Fatalf("MarkPayloadDelivered returned error: %v", err)
+	}
+
+	resolver.values[ref] = "second"
+	changed := req
+	changed.EnvironmentFingerprint = request.EnvironmentFingerprint([]string{
+		"PATH=/opt/homebrew/bin",
+		"NODE_OPTIONS=--require ./changed.js",
+	})
+	second, err := broker.HandleExec(context.Background(), "req_2", "nonce_2", changed)
+	if err != nil {
+		t.Fatalf("second HandleExec returned error: %v", err)
+	}
+	if second.ApprovalID == first.ApprovalID {
+		t.Fatalf("changed environment reused approval %q", first.ApprovalID)
+	}
+	if second.Env["TOKEN"] != "second" {
+		t.Fatalf("changed environment used cached value from old approval: %+v", second.Env)
+	}
+	if approver.calls != 2 {
+		t.Fatalf("approver calls = %d, want fresh approval after env fingerprint change", approver.calls)
+	}
+	if len(resolver.Calls()) != 2 {
+		t.Fatalf("resolver calls = %v, want refetch after env fingerprint change", resolver.Calls())
+	}
+	if reuses := aud.Reuses(); len(reuses) != 0 {
+		t.Fatalf("changed environment emitted reuse audit: %+v", reuses)
+	}
+}
+
 func TestBrokerClearsReusableCacheOnExpiry(t *testing.T) {
 	t.Parallel()
 
@@ -1311,11 +1361,15 @@ func testExecRequestAt(t *testing.T, now time.Time, secrets []request.SecretSpec
 		ResolvedExecutable: "/opt/homebrew/bin/terraform",
 		ExecutableIdentity: fileidentity.Identity{Device: 1, Inode: 1, Mode: 0o755},
 		CWD:                "/tmp/project",
-		Secrets:            reqSecrets,
-		TTL:                request.DefaultExecTTL,
-		ReceivedAt:         now,
-		ExpiresAt:          now.Add(request.DefaultExecTTL),
-		DeliveryMode:       request.DeliveryEnvExec,
+		EnvironmentFingerprint: request.EnvironmentFingerprint([]string{
+			"PATH=/opt/homebrew/bin",
+			"NODE_OPTIONS=--require ./safe.js",
+		}),
+		Secrets:      reqSecrets,
+		TTL:          request.DefaultExecTTL,
+		ReceivedAt:   now,
+		ExpiresAt:    now.Add(request.DefaultExecTTL),
+		DeliveryMode: request.DeliveryEnvExec,
 	}
 }
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -61,6 +61,7 @@ type ReuseKey struct {
 	ResolvedExecutable     string
 	ExecutableIdentity     fileidentity.Identity
 	CWD                    string
+	EnvironmentFingerprint string
 	Secrets                []SecretGrant
 	DeliveryMode           request.DeliveryMode
 	TTL                    time.Duration
@@ -344,6 +345,7 @@ func NewReuseKey(req request.ExecRequest) ReuseKey {
 		ResolvedExecutable:     req.ResolvedExecutable,
 		ExecutableIdentity:     req.ExecutableIdentity,
 		CWD:                    req.CWD,
+		EnvironmentFingerprint: req.EnvironmentFingerprint,
 		Secrets:                secrets,
 		DeliveryMode:           req.DeliveryMode,
 		TTL:                    req.TTL,
@@ -359,6 +361,7 @@ func (k ReuseKey) Equal(other ReuseKey) bool {
 		k.ResolvedExecutable == other.ResolvedExecutable &&
 		k.ExecutableIdentity == other.ExecutableIdentity &&
 		k.CWD == other.CWD &&
+		k.EnvironmentFingerprint == other.EnvironmentFingerprint &&
 		slices.Equal(k.Secrets, other.Secrets) &&
 		k.DeliveryMode == other.DeliveryMode &&
 		k.TTL == other.TTL &&

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -79,6 +79,12 @@ func TestReusableApprovalMissesOnPolicyChanges(t *testing.T) {
 		{name: "resolved executable", mutate: func(r *request.ExecRequest) { r.ResolvedExecutable = "/different/tool" }},
 		{name: "executable identity", mutate: func(r *request.ExecRequest) { r.ExecutableIdentity.Inode++ }},
 		{name: "cwd", mutate: func(r *request.ExecRequest) { r.CWD = "/tmp/other" }},
+		{name: "environment fingerprint", mutate: func(r *request.ExecRequest) {
+			r.EnvironmentFingerprint = request.EnvironmentFingerprint([]string{
+				"PATH=/opt/homebrew/bin",
+				"NODE_OPTIONS=--require ./changed.js",
+			})
+		}},
 		{name: "ref", mutate: func(r *request.ExecRequest) { r.Secrets[0].Ref.Raw = "op://Example Vault/Other/token" }},
 		{name: "account", mutate: func(r *request.ExecRequest) { r.Secrets[0].Account = "Fixture" }},
 		{name: "delivery mode", mutate: func(r *request.ExecRequest) { r.DeliveryMode = request.DeliverySessionSocket }},
@@ -570,11 +576,15 @@ func testRequest(t *testing.T, now time.Time) request.ExecRequest {
 		ResolvedExecutable: "/opt/homebrew/bin/terraform",
 		ExecutableIdentity: fileidentity.Identity{Device: 1, Inode: 1, Mode: 0o755},
 		CWD:                "/tmp/project",
-		Secrets:            []request.Secret{{Alias: "TOKEN", Ref: ref}},
-		TTL:                2 * time.Minute,
-		ReceivedAt:         now,
-		ExpiresAt:          now.Add(2 * time.Minute),
-		DeliveryMode:       request.DeliveryEnvExec,
+		EnvironmentFingerprint: request.EnvironmentFingerprint([]string{
+			"PATH=/opt/homebrew/bin",
+			"NODE_OPTIONS=--require ./safe.js",
+		}),
+		Secrets:      []request.Secret{{Alias: "TOKEN", Ref: ref}},
+		TTL:          2 * time.Minute,
+		ReceivedAt:   now,
+		ExpiresAt:    now.Add(2 * time.Minute),
+		DeliveryMode: request.DeliveryEnvExec,
 	}
 }
 

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -1,6 +1,8 @@
 package request
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -83,6 +85,7 @@ type ExecRequest struct {
 	ExecutableIdentity     fileidentity.Identity
 	CWD                    string
 	Env                    []string `json:"-"`
+	EnvironmentFingerprint string
 	Secrets                []Secret
 	TTL                    time.Duration
 	ReceivedAt             time.Time
@@ -136,6 +139,9 @@ func (r ExecRequest) ValidateForDaemon() error {
 	}
 	if r.ExecutableIdentity.IsZero() {
 		return fmt.Errorf("%w: executable identity is required", ErrInvalidRequest)
+	}
+	if err := validateEnvironmentFingerprint(r.EnvironmentFingerprint); err != nil {
+		return err
 	}
 	if len(r.Command) == 0 || r.Command[0] == "" {
 		return fmt.Errorf("%w: argv is required", ErrInvalidCommand)
@@ -218,6 +224,7 @@ func NewExec(opts ExecOptions) (ExecRequest, error) {
 		ExecutableIdentity:     executableIdentity,
 		CWD:                    cwd,
 		Env:                    env,
+		EnvironmentFingerprint: EnvironmentFingerprint(env),
 		Secrets:                secrets,
 		TTL:                    ttl,
 		ReceivedAt:             receivedAt,
@@ -229,6 +236,16 @@ func NewExec(opts ExecOptions) (ExecRequest, error) {
 		ForceRefresh:           opts.ForceRefresh,
 		AllowMutableExecutable: opts.AllowMutableExecutable,
 	}, nil
+}
+
+func EnvironmentFingerprint(env []string) string {
+	canonical := canonicalEnv(env)
+	sum := sha256.New()
+	for _, entry := range canonical {
+		sum.Write([]byte(entry))
+		sum.Write([]byte{0})
+	}
+	return "env-v1:" + hex.EncodeToString(sum.Sum(nil))
 }
 
 func ParseSecretRef(ref string) (SecretRef, error) {
@@ -499,6 +516,48 @@ func lookupEnv(env []string, key string) string {
 		}
 	}
 	return ""
+}
+
+func validateEnvironmentFingerprint(value string) error {
+	const prefix = "env-v1:"
+	if !strings.HasPrefix(value, prefix) {
+		return fmt.Errorf("%w: environment fingerprint is required", ErrInvalidRequest)
+	}
+	raw := strings.TrimPrefix(value, prefix)
+	decoded, err := hex.DecodeString(raw)
+	if err != nil || len(decoded) != sha256.Size {
+		return fmt.Errorf("%w: invalid environment fingerprint", ErrInvalidRequest)
+	}
+	return nil
+}
+
+func canonicalEnv(env []string) []string {
+	values := make(map[string]string, len(env))
+	malformed := make([]string, 0)
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			malformed = append(malformed, entry)
+			continue
+		}
+		values[key] = value
+	}
+
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	out := make([]string, 0, len(keys)+len(malformed))
+	for _, key := range keys {
+		out = append(out, key+"="+values[key])
+	}
+	slices.Sort(malformed)
+	for _, entry := range malformed {
+		out = append(out, "malformed:"+entry)
+	}
+	return out
 }
 
 func evalPath(path string) string {

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -52,6 +53,12 @@ func TestNewExecValidatesAndNormalizesRequest(t *testing.T) {
 	}
 	if req.ExecutableIdentity.IsZero() {
 		t.Fatal("executable identity was not captured")
+	}
+	if req.EnvironmentFingerprint == "" {
+		t.Fatal("environment fingerprint was not captured")
+	}
+	if req.EnvironmentFingerprint != EnvironmentFingerprint(req.Env) {
+		t.Fatalf("environment fingerprint = %q, want fingerprint of request env", req.EnvironmentFingerprint)
 	}
 	if len(req.Secrets) != 2 || req.Secrets[0].Ref.Raw != req.Secrets[1].Ref.Raw {
 		t.Fatalf("duplicate refs with different aliases should be preserved: %+v", req.Secrets)
@@ -202,6 +209,60 @@ func TestNewExecRecordsOverrideAliases(t *testing.T) {
 	}
 }
 
+func TestEnvironmentFingerprintBindsEffectiveEnvWithoutRawValues(t *testing.T) {
+	t.Parallel()
+
+	base := []string{
+		"PATH=/usr/bin",
+		"NODE_OPTIONS=--require ./safe.js",
+		"DUP=first",
+		"DUP=last",
+	}
+	reordered := []string{
+		"DUP=first",
+		"NODE_OPTIONS=--require ./safe.js",
+		"PATH=/usr/bin",
+		"DUP=last",
+	}
+	if EnvironmentFingerprint(base) != EnvironmentFingerprint(reordered) {
+		t.Fatal("same effective environment produced different fingerprints")
+	}
+
+	changedValue := []string{"PATH=/usr/bin", "NODE_OPTIONS=--require ./evil.js", "DUP=last"}
+	if EnvironmentFingerprint(base) == EnvironmentFingerprint(changedValue) {
+		t.Fatal("changed environment value did not change fingerprint")
+	}
+
+	addedVariable := append(slices.Clone(base), "AWS_PROFILE=prod")
+	if EnvironmentFingerprint(base) == EnvironmentFingerprint(addedVariable) {
+		t.Fatal("added environment variable did not change fingerprint")
+	}
+}
+
+func TestExecRequestJSONOmitsRawEnvironmentValues(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeExecutable(t, dir)
+	req, err := NewExec(mutate(baseOptions(dir, "reason"), func(o *ExecOptions) {
+		o.Env = append(o.Env, "CANARY_SECRET_ENV=do-not-serialize")
+	}))
+	if err != nil {
+		t.Fatalf("NewExec returned error: %v", err)
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(raw), "CANARY_SECRET_ENV") || strings.Contains(string(raw), "do-not-serialize") {
+		t.Fatalf("request JSON included raw environment data: %s", raw)
+	}
+	if !strings.Contains(string(raw), req.EnvironmentFingerprint) {
+		t.Fatalf("request JSON omitted environment fingerprint: %s", raw)
+	}
+}
+
 func TestExecRequestValidateForDaemonAcceptsClientNormalizedRequest(t *testing.T) {
 	t.Parallel()
 
@@ -243,6 +304,8 @@ func TestExecRequestValidateForDaemonRejectsFabricatedMetadata(t *testing.T) {
 		{name: "relative cwd", mutate: func(r *ExecRequest) { r.CWD = "project" }, want: ErrInvalidRequest},
 		{name: "relative resolved executable", mutate: func(r *ExecRequest) { r.ResolvedExecutable = "tool" }, want: ErrInvalidRequest},
 		{name: "missing executable identity", mutate: func(r *ExecRequest) { r.ExecutableIdentity = fileidentity.Identity{} }, want: ErrInvalidRequest},
+		{name: "missing environment fingerprint", mutate: func(r *ExecRequest) { r.EnvironmentFingerprint = "" }, want: ErrInvalidRequest},
+		{name: "malformed environment fingerprint", mutate: func(r *ExecRequest) { r.EnvironmentFingerprint = "env-v1:not-hex" }, want: ErrInvalidRequest},
 		{name: "missing command", mutate: func(r *ExecRequest) { r.Command = nil }, want: ErrInvalidCommand},
 		{name: "session socket delivery", mutate: func(r *ExecRequest) {
 			r.DeliveryMode = DeliverySessionSocket


### PR DESCRIPTION
## Summary
- add a value-free fingerprint of the effective child environment to exec requests
- bind reusable approval cache keys to that fingerprint so environment changes require fresh approval
- keep raw environment values out of JSON protocol payloads and tests

Closes #184.

## Verification
- `mise exec -- go test ./internal/request ./internal/policy ./internal/daemon ./internal/cli`
- `mise exec -- go test -race ./internal/request ./internal/policy ./internal/daemon ./internal/cli`
- `mise run lint:go`
- `mise run test`
- `mise run test:smoke`
- `mise run test:race`
- `mise run build`
- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5`
- `mise exec -- go test ./internal/daemon -coverprofile=/tmp/asr064-daemon.cover`
- `mise run lint`
- `mise run lint:smart`
