### PR TITLE
ASR-065: Sanitize approval metadata display

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalDisplayTextSanitizer.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalDisplayTextSanitizer.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+enum ApprovalDisplayTextSanitizer {
+    private enum ScalarCode {
+        static let backspace: UInt32 = 8
+        static let bell: UInt32 = 7
+        static let carriageReturn: UInt32 = 13
+        static let controlDelete: UInt32 = 127
+        static let horizontalTab: UInt32 = 9
+        static let lineFeed: UInt32 = 10
+        static let maxByteEscapeScalar: UInt32 = 0xFF
+        static let maxFourDigitEscapeScalar: UInt32 = 0xFFFF
+        static let printablePrefixStart: UInt32 = 32
+    }
+
+    static func sanitize(_ value: String) -> String {
+        value.unicodeScalars.map(sanitizedScalar).joined()
+    }
+
+    private static func sanitizedScalar(_ scalar: Unicode.Scalar) -> String {
+        switch scalar.value {
+        case ScalarCode.bell:
+            return "\\a"
+
+        case ScalarCode.backspace:
+            return "\\b"
+
+        case ScalarCode.horizontalTab:
+            return "\\t"
+
+        case ScalarCode.lineFeed:
+            return "\\n"
+
+        case ScalarCode.carriageReturn:
+            return "\\r"
+
+        default:
+            if shouldEscape(scalar) {
+                return unicodeEscape(scalar)
+            }
+            return String(scalar)
+        }
+    }
+
+    private static func shouldEscape(_ scalar: Unicode.Scalar) -> Bool {
+        if scalar.value < ScalarCode.printablePrefixStart || scalar.value == ScalarCode.controlDelete {
+            return true
+        }
+        return switch scalar.properties.generalCategory {
+        case .control, .format, .lineSeparator, .paragraphSeparator, .privateUse, .surrogate, .unassigned:
+            true
+
+        default:
+            false
+        }
+    }
+
+    private static func unicodeEscape(_ scalar: Unicode.Scalar) -> String {
+        if scalar.value <= ScalarCode.maxByteEscapeScalar {
+            return String(format: "\\x%02X", scalar.value)
+        }
+        if scalar.value <= ScalarCode.maxFourDigitEscapeScalar {
+            return String(format: "\\u%04X", scalar.value)
+        }
+        return String(format: "\\U%08X", scalar.value)
+    }
+}

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Caution.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Caution.swift
@@ -34,7 +34,8 @@ extension ApprovalRequestViewModel {
         guard request.overrideEnv, !request.overriddenAliases.isEmpty else {
             return nil
         }
-        return "Will replace existing variables: \(request.overriddenAliases.joined(separator: ", "))"
+        let aliases: [String] = request.overriddenAliases.map(Self.sanitizedDisplayText)
+        return "Will replace existing variables: \(aliases.joined(separator: ", "))"
     }
 
     private static func mutableExecutableWarning(for request: ApprovalRequest) -> String? {

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
@@ -92,15 +92,15 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
     /// Builds a prompt view model without including raw secret values.
     public init(request: ApprovalRequest, now: Date = Date()) {
         title = "Secret Access Request"
-        reason = request.reason
-        executable = Self.executableName(request.resolvedExecutable ?? request.command.first)
+        reason = Self.sanitizedDisplayText(request.reason)
+        executable = Self.sanitizedDisplayText(Self.executableName(request.resolvedExecutable ?? request.command.first))
         commandArguments = Self.commandArguments(request.command)
         command = Self.commandDisplay(commandArguments)
         commandNeedsInspector = Self.commandNeedsInspector(command, arguments: commandArguments)
         commandInspectionText = Self.commandInspectionText(commandArguments)
-        cwd = request.cwd
-        projectFolder = Self.displayPath(request.cwd)
-        resolvedExecutable = request.resolvedExecutable
+        cwd = Self.sanitizedDisplayText(request.cwd)
+        projectFolder = Self.sanitizedDisplayText(Self.displayPath(request.cwd))
+        resolvedExecutable = request.resolvedExecutable.map(Self.sanitizedDisplayText)
         let secretPresentation: SecretPresentation = Self.secretPresentation(for: request.secrets)
         requestedSecrets = secretPresentation.rows
         secretRows = secretPresentation.rowText
@@ -254,6 +254,10 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
             return "~" + path.dropFirst(home.count)
         }
         return path
+    }
+
+    static func sanitizedDisplayText(_ value: String) -> String {
+        ApprovalDisplayTextSanitizer.sanitize(value)
     }
 
     private static func formatRemaining(_ interval: TimeInterval) -> String {

--- a/approver/Sources/AgentSecretApprover/RequestedSecretRowViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/RequestedSecretRowViewModel.swift
@@ -33,18 +33,18 @@ public struct RequestedSecretRowViewModel: Equatable, Sendable {
         } else {
             normalizedAccount = nil
         }
-        self.alias = alias
-        self.ref = ref
-        self.account = normalizedAccount
-        accountLabel = normalizedAccount.map { account in "Account: \(account)" }
-        vaultName = parts.first ?? "Unknown vault"
-        if let normalizedAccount {
-            vaultScopeName = "\(normalizedAccount) / \(vaultName)"
+        self.alias = Self.sanitizedDisplayText(alias)
+        self.ref = Self.sanitizedDisplayText(ref)
+        self.account = normalizedAccount.map(Self.sanitizedDisplayText)
+        accountLabel = self.account.map { account in "Account: \(account)" }
+        vaultName = Self.sanitizedDisplayText(parts.first ?? "Unknown vault")
+        if let account = self.account {
+            vaultScopeName = "\(account) / \(vaultName)"
         } else {
             vaultScopeName = vaultName
         }
-        itemName = parts.dropFirst().first
-        fieldName = parts.dropFirst().dropFirst().first
+        itemName = parts.dropFirst().first.map(Self.sanitizedDisplayText)
+        fieldName = parts.dropFirst().dropFirst().first.map(Self.sanitizedDisplayText)
         symbolName = Self.symbolName(alias: alias, ref: ref)
     }
 
@@ -66,5 +66,9 @@ public struct RequestedSecretRowViewModel: Equatable, Sendable {
             return "person"
         }
         return "key"
+    }
+
+    private static func sanitizedDisplayText(_ value: String) -> String {
+        ApprovalDisplayTextSanitizer.sanitize(value)
     }
 }

--- a/approver/Tests/AgentSecretApproverTests/ApprovalMetadataSanitizationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalMetadataSanitizationTests.swift
@@ -1,0 +1,108 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class ApprovalMetadataSanitizationTests: XCTestCase {
+    private static let sampleExpiration: TimeInterval = 1_800_000_000
+    private static let viewModelNow: TimeInterval = 1_799_999_880
+
+    func testNonCommandMetadataEscapesSpoofingScalars() throws {
+        let request = ApprovalRequest(
+            requestID: "req_metadata_spoof",
+            nonce: "nonce_metadata_spoof",
+            reason: "Deploy\nAccount: Work\u{202E}\t",
+            command: ["/bin/echo", "safe\u{202E}txt"],
+            cwd: "/tmp/project\rspoof\u{200D}",
+            expiresAt: Date(timeIntervalSince1970: Self.sampleExpiration),
+            secrets: [
+                RequestedSecret(
+                    alias: "DEPLOY_TOKEN",
+                    ref: "op://Shared\nInjected/Item\u{202E}/token",
+                    account: "Work\u{202E}\nAdmin"
+                )
+            ],
+            resolvedExecutable: "/tmp/bin/tool\u{202E}txt",
+            overrideEnv: true,
+            overriddenAliases: ["DEPLOY_TOKEN\nROOT", "API\u{202E}KEY"]
+        )
+
+        let viewModel = ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: Self.viewModelNow)
+        )
+
+        try assertSpoofingMetadataEscaped(viewModel)
+    }
+
+    private func assertSpoofingMetadataEscaped(
+        _ viewModel: ApprovalRequestViewModel,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let secret = try XCTUnwrap(viewModel.requestedSecrets.first, file: file, line: line)
+        XCTAssertEqual(viewModel.reason, "Deploy\\nAccount: Work\\u202E\\t")
+        XCTAssertEqual(viewModel.cwd, "/tmp/project\\rspoof\\u200D")
+        XCTAssertEqual(viewModel.projectFolder, "/tmp/project\\rspoof\\u200D")
+        XCTAssertEqual(viewModel.executable, "tool\\u202Etxt")
+        XCTAssertEqual(viewModel.resolvedExecutable, "/tmp/bin/tool\\u202Etxt")
+        XCTAssertEqual(secret.ref, "op://Shared\\nInjected/Item\\u202E/token")
+        XCTAssertEqual(secret.account, "Work\\u202E\\nAdmin")
+        XCTAssertEqual(secret.accountLabel, "Account: Work\\u202E\\nAdmin")
+        XCTAssertEqual(secret.vaultName, "Shared\\nInjected")
+        XCTAssertEqual(secret.vaultScopeName, "Work\\u202E\\nAdmin / Shared\\nInjected")
+        XCTAssertEqual(
+            viewModel.secretRows,
+            [
+                "DEPLOY_TOKEN [Account: Work\\u202E\\nAdmin] -> " +
+                    "op://Shared\\nInjected/Item\\u202E/token"
+            ]
+        )
+        XCTAssertEqual(
+            viewModel.overrideWarning,
+            "Will replace existing variables: DEPLOY_TOKEN\\nROOT, API\\u202EKEY"
+        )
+        XCTAssertEqual(viewModel.command, "'/bin/echo' $'safe\\u202Etxt'")
+        XCTAssertFalse(viewModel.renderedText.contains("\u{202E}"))
+        XCTAssertFalse(viewModel.renderedText.contains("\u{200D}"))
+        XCTAssertFalse(viewModel.renderedText.contains("\r"))
+        XCTAssertFalse(viewModel.renderedText.contains("\t"))
+        XCTAssertTrue(viewModel.renderedText.contains("Reason: Deploy\\nAccount: Work\\u202E\\t"))
+        XCTAssertTrue(
+            viewModel.renderedText.contains(
+                "DEPLOY_TOKEN [Account: Work\\u202E\\nAdmin] -> " +
+                    "op://Shared\\nInjected/Item\\u202E/token"
+            )
+        )
+    }
+
+    func testPrintableMetadataRemainsReadable() throws {
+        let request = ApprovalRequest(
+            requestID: "req_metadata_readable",
+            nonce: "nonce_metadata_readable",
+            reason: "Deploy café service 🚀",
+            command: ["/usr/bin/env", "deploy"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: Self.sampleExpiration),
+            secrets: [
+                RequestedSecret(alias: "DEPLOY_TOKEN", ref: "op://Shared/Deploy/token", account: "Work")
+            ],
+            resolvedExecutable: "/usr/bin/env"
+        )
+
+        let viewModel = ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: Self.viewModelNow)
+        )
+        let secret = try XCTUnwrap(viewModel.requestedSecrets.first)
+
+        XCTAssertEqual(viewModel.reason, "Deploy café service 🚀")
+        XCTAssertEqual(viewModel.cwd, "/tmp/project")
+        XCTAssertEqual(viewModel.resolvedExecutable, "/usr/bin/env")
+        XCTAssertEqual(secret.accountLabel, "Account: Work")
+        XCTAssertEqual(secret.ref, "op://Shared/Deploy/token")
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared Swift display sanitizer for approval metadata
- escape control characters, newlines, tabs, and unsafe Unicode categories in reason, cwd, executable paths, secret refs, account labels, vault grouping, and override warnings
- keep existing argv shell escaping intact, with regression coverage to guard against double-sanitizing command display

Closes #185.

## Verification
- `mise exec -- swift test --package-path approver --filter ApprovalMetadataSanitizationTests`
- `mise exec -- swift test --package-path approver`
- `mise run lint:swift`
- `mise run build`
- `mise run test:smoke`
- `mise run test` (initial run hit known `TestProcessApproverLauncherHealthCheck` timeout; rerun passed)
- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5`
- `mise exec -- go test ./internal/daemon -coverprofile=/tmp/asr065-daemon.cover`
- `mise run lint` (rerun passed after the same health-check flake)
- `mise run lint:smart`
