### PR TITLE
ASR-066: Pin installer trust tools

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,44 @@ require_custom_install_path_guard() {
   die "$label path override requires AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1: $path"
 }
 
+require_tool() {
+  name="$1"
+  path="$2"
+  if [ ! -x "$path" ]; then
+    die "required command not found or not executable: $name ($path)"
+  fi
+}
+
+configure_tool_paths() {
+  tool_curl="/usr/bin/curl"
+  tool_hdiutil="/usr/bin/hdiutil"
+  tool_shasum="/usr/bin/shasum"
+  tool_ditto="/usr/bin/ditto"
+  tool_codesign="/usr/bin/codesign"
+  tool_spctl="/usr/sbin/spctl"
+  tool_xcrun="/usr/bin/xcrun"
+  tool_plistbuddy="/usr/libexec/PlistBuddy"
+
+  if [ -z "$install_tool_dir" ]; then
+    return
+  fi
+
+  case "$install_tool_dir" in
+    /*) ;;
+    *)
+      die "AGENT_SECRET_INSTALL_TOOL_DIR must be absolute: $install_tool_dir"
+      ;;
+  esac
+
+  tool_curl="$install_tool_dir/curl"
+  tool_hdiutil="$install_tool_dir/hdiutil"
+  tool_shasum="$install_tool_dir/shasum"
+  tool_ditto="$install_tool_dir/ditto"
+  tool_codesign="$install_tool_dir/codesign"
+  tool_spctl="$install_tool_dir/spctl"
+  tool_xcrun="$install_tool_dir/xcrun"
+}
+
 is_system_root_alias() {
   case "$1" in
     /etc | /tmp | /var)
@@ -153,6 +191,7 @@ if [ "$install_dev_mode" != "1" ]; then
   require_dev_mode_for_env AGENT_SECRET_EXPECTED_TEAM_ID
   require_dev_mode_for_env AGENT_SECRET_EXPECTED_APP_BUNDLE_ID
   require_dev_mode_for_env AGENT_SECRET_EXPECTED_DAEMON_BUNDLE_ID
+  require_dev_mode_for_env AGENT_SECRET_INSTALL_TOOL_DIR
 else
   repo="${AGENT_SECRET_REPO:-$production_repo}"
   github_url="${AGENT_SECRET_GITHUB_URL:-$production_github_url}"
@@ -172,6 +211,8 @@ local_dmg="${AGENT_SECRET_DMG:-}"
 local_checksums="${AGENT_SECRET_CHECKSUMS_FILE:-}"
 no_stop_daemon="${AGENT_SECRET_NO_STOP_DAEMON:-0}"
 allow_custom_install_paths="${AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS:-0}"
+install_tool_dir="${AGENT_SECRET_INSTALL_TOOL_DIR:-}"
+configure_tool_paths
 
 case "$allow_custom_install_paths" in
   0 | 1) ;;
@@ -194,17 +235,11 @@ mounted=0
 
 cleanup() {
   if [ "$mounted" -eq 1 ]; then
-    hdiutil detach "$mount_dir" >/dev/null 2>&1 || true
+    "$tool_hdiutil" detach "$mount_dir" >/dev/null 2>&1 || true
   fi
   rm -rf "$tmp_dir"
 }
 trap cleanup EXIT HUP INT TERM
-
-require_command() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    die "required command not found: $1"
-  fi
-}
 
 detect_arch() {
   case "$(uname -m)" in
@@ -221,7 +256,7 @@ detect_arch() {
 }
 
 latest_version() {
-  json="$(curl -fsSL "$github_api/repos/$repo/releases/latest")" || die "could not fetch latest GitHub release"
+  json="$("$tool_curl" -fsSL "$github_api/repos/$repo/releases/latest")" || die "could not fetch latest GitHub release"
   tag="$(printf '%s\n' "$json" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
   if [ -z "$tag" ]; then
     die "could not find tag_name in latest release response"
@@ -234,7 +269,7 @@ download_release_file() {
   destination="$2"
   url="$github_url/$repo/releases/download/$version/$file_name"
   echo "Downloading $url"
-  curl -fL --progress-bar "$url" -o "$destination"
+  "$tool_curl" -fL --progress-bar "$url" -o "$destination"
 }
 
 verify_checksum() {
@@ -244,7 +279,7 @@ verify_checksum() {
 
   expected="$(awk -v file="$file_name" '$2 == file { print $1; found = 1; exit } END { if (!found) exit 1 }' "$checksums")" ||
     die "checksums file does not contain $file_name"
-  actual="$(shasum -a 256 "$file_path" | awk '{ print $1 }')"
+  actual="$("$tool_shasum" -a 256 "$file_path" | awk '{ print $1 }')"
   if [ "$actual" != "$expected" ]; then
     die "checksum mismatch for $file_name"
   fi
@@ -258,24 +293,24 @@ verify_dmg_identity() {
     return
   fi
 
-  require_command codesign
-  require_command spctl
-  require_command xcrun
+  require_tool codesign "$tool_codesign"
+  require_tool spctl "$tool_spctl"
+  require_tool xcrun "$tool_xcrun"
 
-  codesign --verify --strict --verbose=2 "$dmg" ||
+  "$tool_codesign" --verify --strict --verbose=2 "$dmg" ||
     die "DMG code signature verification failed"
   verify_team_id "$dmg" "DMG"
-  spctl --assess --type open --context context:primary-signature --verbose "$dmg" ||
+  "$tool_spctl" --assess --type open --context context:primary-signature --verbose "$dmg" ||
     die "DMG Gatekeeper assessment failed"
   if [ "$require_notarization" = "1" ]; then
-    xcrun stapler validate "$dmg" ||
+    "$tool_xcrun" stapler validate "$dmg" ||
       die "DMG notarization ticket validation failed"
   fi
 }
 
 codesign_team_id() {
   path="$1"
-  details="$(codesign -dv --verbose=4 "$path" 2>&1)" ||
+  details="$("$tool_codesign" -dv --verbose=4 "$path" 2>&1)" ||
     die "could not read code signature details for $path"
   printf '%s\n' "$details" |
     awk -F= '$1 == "TeamIdentifier" { print $2; found = 1; exit } END { if (!found) exit 1 }' ||
@@ -294,7 +329,7 @@ verify_team_id() {
 plist_value() {
   plist="$1"
   key="$2"
-  /usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2>/dev/null ||
+  "$tool_plistbuddy" -c "Print :$key" "$plist" 2>/dev/null ||
     die "could not read $key from $plist"
 }
 
@@ -316,7 +351,7 @@ verify_app_identity() {
   daemon_app="$app/Contents/Library/Helpers/AgentSecretDaemon.app"
   cli="$app/Contents/Resources/bin/agent-secret"
 
-  require_command /usr/libexec/PlistBuddy
+  require_tool PlistBuddy "$tool_plistbuddy"
   verify_bundle_identifier "$app" "$expected_app_bundle_id" "Agent Secret.app"
   [ -d "$daemon_app" ] || die "Agent Secret.app is missing the daemon helper app"
   verify_bundle_identifier "$daemon_app" "$expected_daemon_bundle_id" "AgentSecretDaemon.app"
@@ -326,15 +361,15 @@ verify_app_identity() {
     return
   fi
 
-  codesign --verify --deep --strict --verbose=2 "$app" ||
+  "$tool_codesign" --verify --deep --strict --verbose=2 "$app" ||
     die "app code signature verification failed"
   verify_team_id "$app" "Agent Secret.app"
   verify_team_id "$daemon_app" "AgentSecretDaemon.app"
   verify_team_id "$cli" "bundled agent-secret CLI"
-  spctl --assess --type execute --verbose "$app" ||
+  "$tool_spctl" --assess --type execute --verbose "$app" ||
     die "app Gatekeeper assessment failed"
   if [ "$require_notarization" = "1" ]; then
-    xcrun stapler validate "$app" ||
+    "$tool_xcrun" stapler validate "$app" ||
       die "app notarization ticket validation failed"
   fi
 }
@@ -357,10 +392,10 @@ stop_existing_daemon() {
   fi
 }
 
-require_command curl
-require_command hdiutil
-require_command shasum
-require_command ditto
+require_tool curl "$tool_curl"
+require_tool hdiutil "$tool_hdiutil"
+require_tool shasum "$tool_shasum"
+require_tool ditto "$tool_ditto"
 
 arch="$(detect_arch)"
 if [ -z "$version" ] && [ -z "$local_dmg" ]; then
@@ -390,7 +425,7 @@ verify_checksum "$checksums_path" "$artifact_name" "$dmg_path"
 verify_dmg_identity "$dmg_path"
 
 mkdir -p "$mount_dir"
-hdiutil attach -quiet -nobrowse -readonly -mountpoint "$mount_dir" "$dmg_path"
+"$tool_hdiutil" attach -quiet -nobrowse -readonly -mountpoint "$mount_dir" "$dmg_path"
 mounted=1
 
 source_app="$mount_dir/Agent Secret.app"
@@ -405,7 +440,7 @@ stop_existing_daemon
 echo "Installing Agent Secret.app into $app_dir"
 mkdir -p "$app_dir"
 rm -rf "$tmp_app"
-ditto "$source_app" "$tmp_app"
+"$tool_ditto" "$source_app" "$tmp_app"
 rm -rf "$target_app"
 mv "$tmp_app" "$target_app"
 

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -79,6 +79,26 @@ printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
 exit "${AGENT_SECRET_INSTALL_TEST_XCRUN_STATUS:-0}"
 SCRIPT
 
+  cat >"$fake_bin/curl" <<'SCRIPT'
+#!/bin/sh
+printf 'curl' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+exec /usr/bin/curl "$@"
+SCRIPT
+
+  cat >"$fake_bin/shasum" <<'SCRIPT'
+#!/bin/sh
+printf 'shasum' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+exec /usr/bin/shasum "$@"
+SCRIPT
+
   cat >"$fake_bin/agent-secret" <<'SCRIPT'
 #!/bin/sh
 printf 'fake-path-agent-secret' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
@@ -185,6 +205,7 @@ exit 64
 SCRIPT
 
   chmod 755 "$fake_bin/codesign" "$fake_bin/spctl" "$fake_bin/xcrun" \
+    "$fake_bin/curl" "$fake_bin/shasum" \
     "$fake_bin/agent-secret" \
     "$fake_bin/ditto" "$fake_bin/hdiutil"
 }
@@ -199,7 +220,9 @@ make_fixture() {
   shasum -a 256 "$artifact" | awk '{ print $1 "  Agent-Secret-test-macos-arm64.dmg" }' >"$checksums"
 }
 
-run_installer() {
+run_installer_with_tool_mode() {
+  local tool_mode="$1"
+  shift
   local name="$1"
   shift
   local run_dir="$tmp_dir/$name"
@@ -223,18 +246,33 @@ SCRIPT
   chmod 755 "$run_dir/bin-dir/agent-secret"
   : >"$log"
 
-  env \
-    PATH="$fake_bin:$PATH" \
-    AGENT_SECRET_DMG="$artifact" \
-    AGENT_SECRET_CHECKSUMS_FILE="$checksums" \
-    AGENT_SECRET_APP_DIR="$run_dir/apps" \
-    AGENT_SECRET_BIN_DIR="$run_dir/bin-dir" \
-    AGENT_SECRET_SKILLS_DIR="$run_dir/skills" \
-    AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1 \
-    AGENT_SECRET_NO_STOP_DAEMON=1 \
-    AGENT_SECRET_INSTALL_TEST_LOG="$log" \
-    "$@" \
-    "$project_root/install.sh"
+  local env_args=(
+    PATH="$fake_bin:$PATH"
+    AGENT_SECRET_DMG="$artifact"
+    AGENT_SECRET_CHECKSUMS_FILE="$checksums"
+    AGENT_SECRET_APP_DIR="$run_dir/apps"
+    AGENT_SECRET_BIN_DIR="$run_dir/bin-dir"
+    AGENT_SECRET_SKILLS_DIR="$run_dir/skills"
+    AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1
+    AGENT_SECRET_NO_STOP_DAEMON=1
+    AGENT_SECRET_INSTALL_TEST_LOG="$log"
+  )
+  if [ "$tool_mode" = "dev" ]; then
+    env_args+=(
+      AGENT_SECRET_INSTALL_DEV_MODE=1
+      AGENT_SECRET_INSTALL_TOOL_DIR="$fake_bin"
+    )
+  fi
+
+  env "${env_args[@]}" "$@" "$project_root/install.sh"
+}
+
+run_installer() {
+  run_installer_with_tool_mode dev "$@"
+}
+
+run_installer_production() {
+  run_installer_with_tool_mode production "$@"
 }
 
 assert_log_contains() {
@@ -296,18 +334,34 @@ test_wrong_daemon_bundle_id_stops_install() {
 }
 
 test_trust_root_overrides_require_dev_mode() {
-  if run_installer expected-team-override AGENT_SECRET_EXPECTED_TEAM_ID=BADTEAM123; then
+  if run_installer_production expected-team-override AGENT_SECRET_EXPECTED_TEAM_ID=BADTEAM123; then
     fail "installer accepted expected Team ID override without dev mode"
   fi
-  if run_installer expected-app-bundle-override \
+  if run_installer_production expected-app-bundle-override \
     AGENT_SECRET_EXPECTED_APP_BUNDLE_ID=com.example.not-agent-secret; then
     fail "installer accepted expected app bundle override without dev mode"
   fi
-  if run_installer github-url-override AGENT_SECRET_GITHUB_URL=https://example.invalid; then
+  if run_installer_production github-url-override AGENT_SECRET_GITHUB_URL=https://example.invalid; then
     fail "installer accepted GitHub URL override without dev mode"
   fi
-  if run_installer unsigned-without-dev-mode AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1; then
+  if run_installer_production unsigned-without-dev-mode AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1; then
     fail "installer accepted unsigned override without dev mode"
+  fi
+  if run_installer_production tool-dir-override AGENT_SECRET_INSTALL_TOOL_DIR="$tmp_dir/tool-dir"; then
+    fail "installer accepted tool directory override without dev mode"
+  fi
+}
+
+test_production_mode_ignores_fake_path_tools() {
+  if run_installer_production production-ignores-path; then
+    fail "production installer unexpectedly accepted the synthetic unsigned DMG"
+  fi
+
+  log="$tmp_dir/production-ignores-path/tools.log"
+  if [ -s "$log" ]; then
+    echo "---- tool log ----" >&2
+    cat "$log" >&2
+    fail "production installer executed fake PATH tools"
   fi
 }
 
@@ -391,6 +445,7 @@ test_wrong_team_id_stops_install
 test_wrong_app_bundle_id_stops_install
 test_wrong_daemon_bundle_id_stops_install
 test_trust_root_overrides_require_dev_mode
+test_production_mode_ignores_fake_path_tools
 test_destination_overrides_require_guard
 test_destination_validation_rejects_bad_paths
 test_destination_validation_rejects_symlinked_parent_dirs


### PR DESCRIPTION
## Summary
- route production installer trust operations through absolute macOS tool paths instead of caller-controlled `PATH`
- add a dev-only `AGENT_SECRET_INSTALL_TOOL_DIR` hook for installer smoke fixtures
- add smoke coverage proving production mode rejects the tool override and ignores fake tools prepended to `PATH`

Closes #186.

## Verification
- `mise run test:smoke`
- `bash -n install.sh scripts/test-install.sh`
- `mise run lint:shell`
- `mise run build`
- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5`
- `mise run test` (initial run hit known `TestProcessApproverLauncherHealthCheck` timeout; serial rerun passed)
- `mise exec -- go test ./internal/daemon -coverprofile=/tmp/asr066-daemon.cover`
- `mise run lint` (initial run hit the same health-check flake; serial rerun passed)
- `mise run lint:smart`
