### PR TITLE
ASR-067: Pin release signing tools

### DIFF
--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -76,12 +76,24 @@ require_command() {
   fi
 }
 
+require_tool() {
+  local name="$1"
+  local path="$2"
+
+  if [[ ! -x "$path" ]]; then
+    echo "build-app-bundle: required command not found or not executable: $name ($path)" >&2
+    exit 1
+  fi
+}
+
+tool_codesign="/usr/bin/codesign"
+
 require_command go
 require_command swift
 require_command install
 require_command iconutil
 require_command sips
-require_command codesign
+require_tool codesign "$tool_codesign"
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-bundle.XXXXXX")"
 cleanup() {
@@ -136,7 +148,7 @@ sign_path() {
   fi
 
   args+=("$path")
-  codesign "${args[@]}" >/dev/null
+  "$tool_codesign" "${args[@]}" >/dev/null
 }
 
 codesign_team_id() {

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -109,14 +109,21 @@ if [[ "$require_production_signing" == "1" ]]; then
   require_production_release_signing
 fi
 
-require_command() {
+require_tool() {
   local name="$1"
+  local path="$2"
 
-  if ! command -v "$name" >/dev/null 2>&1; then
-    echo "build-release: required command not found: $name" >&2
+  if [[ ! -x "$path" ]]; then
+    echo "build-release: required command not found or not executable: $name ($path)" >&2
     exit 1
   fi
 }
+
+tool_hdiutil="/usr/bin/hdiutil"
+tool_ditto="/usr/bin/ditto"
+tool_shasum="/usr/bin/shasum"
+tool_codesign="/usr/bin/codesign"
+tool_xcrun="/usr/bin/xcrun"
 
 case "$(uname -m)" in
   arm64)
@@ -131,14 +138,14 @@ case "$(uname -m)" in
     ;;
 esac
 
-require_command hdiutil
-require_command ditto
-require_command shasum
+require_tool hdiutil "$tool_hdiutil"
+require_tool ditto "$tool_ditto"
+require_tool shasum "$tool_shasum"
 if [[ "$codesign_identity" != "-" ]]; then
-  require_command codesign
+  require_tool codesign "$tool_codesign"
 fi
 if [[ "$notarize" == "1" ]]; then
-  require_command xcrun
+  require_tool xcrun "$tool_xcrun"
 fi
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-release.XXXXXX")"
@@ -178,7 +185,7 @@ submit_for_notarization() {
     notary_key_path="$(prepare_notary_key)"
   fi
 
-  xcrun notarytool submit "$path" \
+  "$tool_xcrun" notarytool submit "$path" \
     --key "$notary_key_path" \
     --key-id "$notary_key_id" \
     --issuer "$notary_issuer_id" \
@@ -198,25 +205,25 @@ if [[ "$notarize" == "1" ]]; then
   app_zip="$tmp_dir/AgentSecretApp.zip"
   (
     cd "$build_dir"
-    ditto -c -k --keepParent "Agent Secret.app" "$app_zip"
+    "$tool_ditto" -c -k --keepParent "Agent Secret.app" "$app_zip"
   )
   submit_for_notarization "$app_zip"
 
   echo "Stapling notarization ticket to app bundle..."
-  xcrun stapler staple "$build_dir/Agent Secret.app"
-  xcrun stapler validate "$build_dir/Agent Secret.app"
+  "$tool_xcrun" stapler staple "$build_dir/Agent Secret.app"
+  "$tool_xcrun" stapler validate "$build_dir/Agent Secret.app"
 fi
 
 echo "Preparing DMG contents..."
 rm -rf "$dmg_root"
 mkdir -p "$dmg_root"
-ditto "$build_dir/Agent Secret.app" "$dmg_root/Agent Secret.app"
+"$tool_ditto" "$build_dir/Agent Secret.app" "$dmg_root/Agent Secret.app"
 ln -s /Applications "$dmg_root/Applications"
 
 echo "Creating $dmg_path..."
 mkdir -p "$output_dir"
 rm -f "$dmg_path"
-hdiutil create \
+"$tool_hdiutil" create \
   -volname "Agent Secret $version" \
   -srcfolder "$dmg_root" \
   -format UDZO \
@@ -224,11 +231,11 @@ hdiutil create \
   "$dmg_path" >/dev/null
 
 echo "Verifying DMG..."
-hdiutil verify "$dmg_path" >/dev/null
+"$tool_hdiutil" verify "$dmg_path" >/dev/null
 
 if [[ "$codesign_identity" != "-" ]]; then
   echo "Signing DMG with $codesign_identity..."
-  codesign --force --sign "$codesign_identity" --timestamp "$dmg_path" >/dev/null
+  "$tool_codesign" --force --sign "$codesign_identity" --timestamp "$dmg_path" >/dev/null
 fi
 
 if [[ "$notarize" == "1" ]]; then
@@ -236,14 +243,14 @@ if [[ "$notarize" == "1" ]]; then
   submit_for_notarization "$dmg_path"
 
   echo "Stapling notarization ticket..."
-  xcrun stapler staple "$dmg_path"
-  xcrun stapler validate "$dmg_path"
+  "$tool_xcrun" stapler staple "$dmg_path"
+  "$tool_xcrun" stapler validate "$dmg_path"
 fi
 
 echo "Writing checksums..."
 (
   cd "$output_dir"
-  shasum -a 256 "$artifact_name" >"$checksums_path"
+  "$tool_shasum" -a 256 "$artifact_name" >"$checksums_path"
 )
 
 echo "$dmg_path"

--- a/scripts/import-codesign-certificate.sh
+++ b/scripts/import-codesign-certificate.sh
@@ -24,14 +24,19 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-require_command() {
+require_tool() {
   local name="$1"
+  local path="$2"
 
-  if ! command -v "$name" >/dev/null 2>&1; then
-    echo "import-codesign-certificate: required command not found: $name" >&2
+  if [[ ! -x "$path" ]]; then
+    echo "import-codesign-certificate: required command not found or not executable: $name ($path)" >&2
     exit 1
   fi
 }
+
+tool_base64="/usr/bin/base64"
+tool_security="/usr/bin/security"
+tool_uuidgen="/usr/bin/uuidgen"
 
 trim_keychain_path() {
   local path="$1"
@@ -52,14 +57,14 @@ append_keychain_to_search_list() {
     if [[ "$keychain" != "" && "$keychain" != "$keychain_path" ]]; then
       existing_keychains+=("$keychain")
     fi
-  done < <(security list-keychains -d user)
+  done < <("$tool_security" list-keychains -d user)
 
-  security list-keychains -d user -s "$keychain_path" "${existing_keychains[@]}"
+  "$tool_security" list-keychains -d user -s "$keychain_path" "${existing_keychains[@]}"
 }
 
-require_command base64
-require_command security
-require_command uuidgen
+require_tool base64 "$tool_base64"
+require_tool security "$tool_security"
+require_tool uuidgen "$tool_uuidgen"
 
 cert_base64="${AGENT_SECRET_CODESIGN_CERT_P12_BASE64:-}"
 cert_path="${AGENT_SECRET_CODESIGN_CERT_P12_PATH:-}"
@@ -82,7 +87,7 @@ if [[ "$keychain_path" == "" ]]; then
 fi
 
 if [[ "$keychain_password" == "" ]]; then
-  keychain_password="$(uuidgen)"
+  keychain_password="$("$tool_uuidgen")"
 fi
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-codesign.XXXXXX")"
@@ -93,7 +98,7 @@ trap cleanup EXIT
 
 if [[ "$cert_base64" != "" ]]; then
   cert_path="$tmp_dir/developer-id.p12"
-  printf '%s' "$cert_base64" | base64 --decode >"$cert_path"
+  printf '%s' "$cert_base64" | "$tool_base64" --decode >"$cert_path"
 fi
 
 if [[ ! -f "$cert_path" ]]; then
@@ -102,15 +107,15 @@ if [[ ! -f "$cert_path" ]]; then
 fi
 
 rm -f "$keychain_path"
-security create-keychain -p "$keychain_password" "$keychain_path"
-security set-keychain-settings -lut 21600 "$keychain_path"
-security unlock-keychain -p "$keychain_password" "$keychain_path"
-security import "$cert_path" \
+"$tool_security" create-keychain -p "$keychain_password" "$keychain_path"
+"$tool_security" set-keychain-settings -lut 21600 "$keychain_path"
+"$tool_security" unlock-keychain -p "$keychain_password" "$keychain_path"
+"$tool_security" import "$cert_path" \
   -k "$keychain_path" \
   -P "$cert_password" \
   -T /usr/bin/codesign \
   -T /usr/bin/productsign >/dev/null
-security set-key-partition-list \
+"$tool_security" set-key-partition-list \
   -S apple-tool:,apple:,codesign: \
   -s \
   -k "$keychain_password" \
@@ -118,4 +123,4 @@ security set-key-partition-list \
 append_keychain_to_search_list "$keychain_path"
 
 echo "Imported Developer ID identities:"
-security find-identity -v -p codesigning "$keychain_path"
+"$tool_security" find-identity -v -p codesigning "$keychain_path"

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -5,6 +5,7 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 check_script="$project_root/scripts/check-release-signing-env.sh"
 build_release="$project_root/scripts/build-release.sh"
+import_certificate="$project_root/scripts/import-codesign-certificate.sh"
 test_path="${PATH:-/usr/bin:/bin}"
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-release-signing-test.XXXXXX")"
@@ -30,6 +31,38 @@ expect_failure() {
   fi
 }
 
+expect_any_failure() {
+  if "$@" >"$tmp_dir/stdout" 2>"$tmp_dir/stderr"; then
+    fail "expected command to fail"
+  fi
+}
+
+write_path_trap_tools() {
+  local trap_dir="$1"
+  local log="$2"
+  local tool=""
+
+  mkdir -p "$trap_dir"
+  for tool in base64 security uuidgen codesign xcrun ditto hdiutil shasum; do
+    cat >"$trap_dir/$tool" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$(basename "$0") $*" >>"$AGENT_SECRET_PATH_TRAP_LOG"
+exit 44
+BASH
+    chmod 755 "$trap_dir/$tool"
+  done
+  : >"$log"
+}
+
+assert_path_trap_clean() {
+  local log="$1"
+
+  if [[ -s "$log" ]]; then
+    fail "release script executed PATH trap tool: $(cat "$log")"
+  fi
+}
+
 release_env=(
   AGENT_SECRET_CODESIGN_CERT_P12_BASE64=dummy-p12
   AGENT_SECRET_CODESIGN_CERT_PASSWORD=dummy-password
@@ -52,5 +85,34 @@ env -i "PATH=$test_path" "${release_env[@]}" AGENT_SECRET_NOTARIZE=1 "$check_scr
 
 expect_failure "production release requires AGENT_SECRET_CODESIGN_IDENTITY" \
   env -i "PATH=$test_path" AGENT_SECRET_IN_MISE=1 "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/out"
+
+trap_dir="$tmp_dir/path-trap-bin"
+trap_log="$tmp_dir/path-trap.log"
+write_path_trap_tools "$trap_dir" "$trap_log"
+
+expect_any_failure \
+  env -i \
+  "PATH=$trap_dir:$test_path" \
+  AGENT_SECRET_PATH_TRAP_LOG="$trap_log" \
+  AGENT_SECRET_CODESIGN_CERT_P12_BASE64=not-base64 \
+  AGENT_SECRET_CODESIGN_CERT_PASSWORD=dummy-password \
+  "$import_certificate"
+assert_path_trap_clean "$trap_log"
+
+expect_failure "production release requires AGENT_SECRET_CODESIGN_IDENTITY" \
+  env -i \
+  "PATH=$trap_dir:$test_path" \
+  AGENT_SECRET_PATH_TRAP_LOG="$trap_log" \
+  AGENT_SECRET_IN_MISE=1 \
+  "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/path-trap-out"
+assert_path_trap_clean "$trap_log"
+
+if grep -En '(^|[|;&][[:space:]]*)(base64|security|uuidgen)([[:space:]]|$)' "$import_certificate"; then
+  fail "import-codesign-certificate.sh contains bare secret-handling tool invocation"
+fi
+if grep -En '(^|[|;&][[:space:]]*)(codesign|xcrun|ditto|hdiutil|shasum)([[:space:]]|$)' \
+  "$build_release" "$project_root/scripts/build-app-bundle.sh"; then
+  fail "release build scripts contain bare Apple tool invocation"
+fi
 
 echo "test-release-signing-env: ok"


### PR DESCRIPTION
## Summary
- use absolute macOS tool paths for release signing, notarization, certificate import, DMG, and checksum operations
- keep Go/Swift/mise discovery separate from Apple/security tool execution
- add release-signing tests with PATH trap tools plus static guards against bare Apple/security tool invocations

Closes #187.

## Verification
- `bash -n scripts/import-codesign-certificate.sh scripts/build-release.sh scripts/build-app-bundle.sh scripts/test-release-signing-env.sh`
- `scripts/test-release-signing-env.sh`
- `mise run lint:shell`
- `mise run test:smoke`
- `mise run build`
- `mise run test`
- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5`
- `mise exec -- go test ./internal/daemon -coverprofile=/tmp/asr067-daemon.cover`
- `mise run lint` (rerun passed after known health-check flake in coverage gate)
- `mise run lint:smart`
