### PR TITLE
ASR-068: Harden socket directory ancestry validation

### DIFF
--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -167,6 +167,32 @@ func TestManagerRejectsPermissiveCustomSocketParentWithoutChmod(t *testing.T) {
 	}
 }
 
+func TestManagerRejectsSymlinkedCustomSocketAncestorBeforeMkdirAll(t *testing.T) {
+	t.Parallel()
+
+	target := shortTempDir(t, "agent-secret-manager-target-")
+	if err := os.Chmod(target, 0o700); err != nil { //nolint:gosec // G302: manager socket target is private in this test.
+		t.Fatalf("chmod target: %v", err)
+	}
+	link := filepath.Join(shortTempDir(t, "agent-secret-manager-parent-"), "socket-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink socket ancestor: %v", err)
+	}
+	manager := Manager{
+		SocketPath:     filepath.Join(link, "nested", "agent-secretd.sock"),
+		DaemonPath:     filepath.Join(t.TempDir(), "missing-agent-secretd"),
+		StartupTimeout: time.Millisecond,
+	}
+
+	err := manager.Start(context.Background())
+	if !errors.Is(err, ErrInsecureSocketDirectory) {
+		t.Fatalf("expected insecure socket directory error, got %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(target, "nested")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("manager followed symlinked socket ancestor: %v", err)
+	}
+}
+
 func TestManagerStartRejectsUntrustedLiveSocket(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -58,12 +58,18 @@ func ValidateSocketDirectory(path string) error {
 }
 
 func prepareDefaultSocketDirectory(dir string) error {
+	if err := rejectSocketDirectoryAncestry(dir); err != nil {
+		return err
+	}
 	if err := rejectSocketDirectorySymlinkOrOwner(dir); err != nil {
 		return err
 	}
 	//nolint:gosec // G703: dir is the managed default socket directory under Application Support.
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create socket directory: %w", err)
+	}
+	if err := rejectSocketDirectoryAncestry(dir); err != nil {
+		return err
 	}
 	if err := rejectSocketDirectorySymlinkOrOwner(dir); err != nil {
 		return err
@@ -76,6 +82,9 @@ func prepareDefaultSocketDirectory(dir string) error {
 }
 
 func prepareCustomSocketDirectory(dir string) error {
+	if err := rejectSocketDirectoryAncestry(dir); err != nil {
+		return err
+	}
 	//nolint:gosec // G703: custom mkdir creates missing private parents but existing parents are validated, not chmodded.
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create socket directory: %w", err)
@@ -84,6 +93,9 @@ func prepareCustomSocketDirectory(dir string) error {
 }
 
 func rejectInsecureSocketDirectory(dir string) error {
+	if err := rejectSocketDirectoryAncestry(dir); err != nil {
+		return err
+	}
 	info, err := socketDirectoryInfo(dir)
 	if err != nil {
 		return err
@@ -119,6 +131,48 @@ func socketDirectoryInfo(dir string) (os.FileInfo, error) {
 		return nil, fmt.Errorf("%w: %s is owned by uid %d", ErrInsecureSocketDirectory, dir, stat.Uid)
 	}
 	return info, nil
+}
+
+func rejectSocketDirectoryAncestry(dir string) error {
+	cleanDir := filepath.Clean(dir)
+	for current := cleanDir; ; current = filepath.Dir(current) {
+		info, err := os.Lstat(current)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("stat socket directory ancestor: %w", err)
+		}
+		if err == nil {
+			if err := rejectSocketDirectoryAncestorInfo(cleanDir, current, info); err != nil {
+				return err
+			}
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+	}
+}
+
+func rejectSocketDirectoryAncestorInfo(cleanDir, current string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		if isAllowedSocketRootAlias(current) {
+			return nil
+		}
+		return fmt.Errorf("%w: %s contains symlink ancestor %s", ErrInsecureSocketDirectory, cleanDir, current)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %s contains non-directory ancestor %s", ErrInsecureSocketDirectory, cleanDir, current)
+	}
+	return nil
+}
+
+func isAllowedSocketRootAlias(path string) bool {
+	switch path {
+	case "/etc", "/tmp", "/var":
+		return true
+	default:
+		return false
+	}
 }
 
 func Dial(ctx context.Context, path string) (*net.UnixConn, error) {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -76,6 +76,33 @@ func TestListenUnixRejectsSymlinkDefaultSocketDirectoryWithoutChmodTarget(t *tes
 	}
 }
 
+func TestListenUnixRejectsSymlinkDefaultSocketAncestorBeforeMkdirAll(t *testing.T) {
+	home := shortTempDir(t, "agent-secret-home-")
+	t.Setenv("HOME", home)
+	path, err := DefaultSocketPath()
+	if err != nil {
+		t.Fatalf("DefaultSocketPath returned error: %v", err)
+	}
+	target := shortTempDir(t, "agent-secret-socket-target-")
+	if err := os.Chmod(target, 0o700); err != nil { //nolint:gosec // G302: test target is intentionally private.
+		t.Fatalf("chmod target: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(home, "Library")); err != nil {
+		t.Fatalf("symlink default socket ancestor: %v", err)
+	}
+
+	listener, err := ListenUnix(path)
+	if listener != nil {
+		_ = listener.Close()
+	}
+	if !errors.Is(err, ErrInsecureSocketDirectory) {
+		t.Fatalf("expected insecure socket directory error, got %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(target, "Application Support")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("MkdirAll followed symlinked default ancestor: %v", err)
+	}
+}
+
 func TestListenUnixAcceptsPrivateCustomSocketParent(t *testing.T) {
 	t.Parallel()
 
@@ -120,6 +147,31 @@ func TestListenUnixRejectsSymlinkCustomSocketParent(t *testing.T) {
 	}
 }
 
+func TestListenUnixRejectsSymlinkCustomSocketAncestorBeforeMkdirAll(t *testing.T) {
+	t.Parallel()
+
+	target := shortTempDir(t, "agent-secret-socket-target-")
+	if err := os.Chmod(target, 0o700); err != nil { //nolint:gosec // G302: custom socket targets are private in this test.
+		t.Fatalf("chmod target: %v", err)
+	}
+	link := filepath.Join(shortTempDir(t, "agent-secret-socket-parent-"), "socket-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink custom socket ancestor: %v", err)
+	}
+	path := filepath.Join(link, "nested", "agent-secretd.sock")
+
+	listener, err := ListenUnix(path)
+	if listener != nil {
+		_ = listener.Close()
+	}
+	if !errors.Is(err, ErrInsecureSocketDirectory) {
+		t.Fatalf("expected insecure socket directory error, got %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(target, "nested")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("MkdirAll followed symlinked custom ancestor: %v", err)
+	}
+}
+
 func TestValidateSocketDirectoryRejectsSymlinkParent(t *testing.T) {
 	t.Parallel()
 
@@ -133,6 +185,24 @@ func TestValidateSocketDirectoryRejectsSymlinkParent(t *testing.T) {
 	}
 
 	err := ValidateSocketDirectory(filepath.Join(link, "agent-secretd.sock"))
+	if !errors.Is(err, ErrInsecureSocketDirectory) {
+		t.Fatalf("expected insecure socket directory error, got %v", err)
+	}
+}
+
+func TestValidateSocketDirectoryRejectsSymlinkAncestor(t *testing.T) {
+	t.Parallel()
+
+	target := shortTempDir(t, "agent-secret-socket-target-")
+	if err := os.Chmod(target, 0o700); err != nil { //nolint:gosec // G302: custom socket targets are private in this test.
+		t.Fatalf("chmod target: %v", err)
+	}
+	link := filepath.Join(shortTempDir(t, "agent-secret-socket-parent-"), "socket-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink socket ancestor: %v", err)
+	}
+
+	err := ValidateSocketDirectory(filepath.Join(link, "nested", "agent-secretd.sock"))
 	if !errors.Is(err, ErrInsecureSocketDirectory) {
 		t.Fatalf("expected insecure socket directory error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- reject symlinked or non-directory socket ancestors before directory creation
- revalidate default socket ancestry after creation before binding
- add regression coverage for ListenUnix, ValidateSocketDirectory, and Manager startup

Closes #188

## Verification
- mise exec -- go test ./internal/daemon -run 'Test(ListenUnixRejectsSymlink(DefaultSocketAncestor|CustomSocketAncestor)|ValidateSocketDirectoryRejectsSymlinkAncestor|ManagerRejectsSymlinkedCustomSocketAncestor)' -count=1
- mise exec -- go test ./internal/daemon
- mise exec -- go test -race ./internal/daemon
- mise run lint:go
- mise run build
- mise run test
- mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5
- mise exec -- go test ./internal/daemon -coverprofile=/tmp/asr068-daemon.cover
- mise run lint
- git diff --check
- mise run lint:smart