### PR TITLE
ASR-069: cancel in-flight execs on daemon stop

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -21,6 +21,7 @@ var (
 	ErrMissingCache         = errors.New("approved secret cache entry missing")
 	ErrNoResolver           = errors.New("secret resolver unavailable")
 	ErrRequestAlreadyActive = errors.New("connection already has an active exec request")
+	ErrDaemonStopped        = errors.New("daemon stopped")
 	ErrRequestExpired       = errors.New("request expired")
 	ErrUnknownRequest       = errors.New("unknown request")
 )
@@ -61,6 +62,8 @@ type Broker struct {
 	fetchLimit int
 	active     map[string]*activeExec
 	expiry     map[string]*time.Timer
+	stopOnce   sync.Once
+	stop       chan struct{}
 }
 
 type ExecGrant struct {
@@ -117,7 +120,6 @@ func NewBroker(opts BrokerOptions) (*Broker, error) {
 	if fetchLimit <= 0 {
 		fetchLimit = 4
 	}
-
 	return &Broker{
 		now:        now,
 		store:      store,
@@ -128,12 +130,16 @@ func NewBroker(opts BrokerOptions) (*Broker, error) {
 		fetchLimit: fetchLimit,
 		active:     make(map[string]*activeExec),
 		expiry:     make(map[string]*time.Timer),
+		stop:       make(chan struct{}),
 	}, nil
 }
 
 func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string, req request.ExecRequest) (ExecGrant, error) {
 	if requestID == "" || nonce == "" {
 		return ExecGrant{}, ErrInvalidNonce
+	}
+	if b.stopped() {
+		return ExecGrant{}, ErrDaemonStopped
 	}
 	req = req.WithReceiptTime(b.now())
 	if err := b.preflightAudit(ctx); err != nil {
@@ -193,15 +199,37 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 
 func (b *Broker) requestContext(ctx context.Context, req request.ExecRequest) (context.Context, context.CancelFunc) {
 	ttl := req.ExpiresAt.Sub(b.now())
-	return context.WithTimeout(ctx, ttl)
+	ttlCtx, cancelTTL := context.WithTimeout(ctx, ttl)
+	execCtx, cancelExec := context.WithCancelCause(ttlCtx)
+	watcherDone := make(chan struct{})
+	go func() {
+		select {
+		case <-b.stop:
+			cancelExec(ErrDaemonStopped)
+		case <-execCtx.Done():
+		case <-watcherDone:
+		}
+	}()
+
+	return execCtx, func() {
+		close(watcherDone)
+		cancelExec(context.Canceled)
+		cancelTTL()
+	}
 }
 
 func (b *Broker) requestActive(ctx context.Context, req request.ExecRequest) error {
 	if err := ctx.Err(); err != nil {
+		if errors.Is(context.Cause(ctx), ErrDaemonStopped) {
+			return ErrDaemonStopped
+		}
 		if errors.Is(err, context.DeadlineExceeded) && req.Expired(b.now()) {
 			return ErrRequestExpired
 		}
 		return err
+	}
+	if b.stopped() {
+		return ErrDaemonStopped
 	}
 	if req.Expired(b.now()) {
 		return ErrRequestExpired
@@ -216,18 +244,29 @@ func (b *Broker) requestError(ctx context.Context, req request.ExecRequest, err 
 	if errors.Is(err, ErrRequestExpired) {
 		return err
 	}
-	if errors.Is(b.requestActive(ctx, req), ErrRequestExpired) {
-		return ErrRequestExpired
+	if activeErr := b.requestActive(ctx, req); activeErr != nil {
+		if errors.Is(activeErr, ErrDaemonStopped) || errors.Is(activeErr, ErrRequestExpired) {
+			return activeErr
+		}
 	}
 	return err
 }
 
 func (b *Broker) MarkPayloadDelivered(requestID string) error {
+	if b.stopped() {
+		return ErrDaemonStopped
+	}
 	b.mu.Lock()
 	active, ok := b.active[requestID]
 	b.mu.Unlock()
 	if !ok {
 		return ErrUnknownRequest
+	}
+	if b.stopped() {
+		b.mu.Lock()
+		delete(b.active, requestID)
+		b.mu.Unlock()
+		return ErrDaemonStopped
 	}
 	if active.approvalID == "" {
 		b.mu.Lock()
@@ -253,6 +292,12 @@ func (b *Broker) MarkPayloadDelivered(requestID string) error {
 			return ErrRequestExpired
 		}
 		return err
+	}
+	if b.stopped() {
+		b.mu.Lock()
+		delete(b.active, requestID)
+		b.mu.Unlock()
+		return ErrDaemonStopped
 	}
 	if approval.Uses >= approval.MaxUses {
 		b.clearReusableCacheScope(approval.ID)
@@ -331,6 +376,7 @@ func (b *Broker) Stop(ctx context.Context) {
 }
 
 func (b *Broker) stopWithAudit(ctx context.Context, event audit.Event) {
+	b.stopOnce.Do(func() { close(b.stop) })
 	b.recordDaemonStopAttempt(ctx, event)
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -340,7 +386,7 @@ func (b *Broker) stopWithAudit(ctx context.Context, event audit.Event) {
 		delete(b.expiry, id)
 	}
 	b.cache.Clear()
-	b.store = policy.NewStore(b.now)
+	b.store.Clear()
 }
 
 func (b *Broker) recordDaemonStopAttempt(ctx context.Context, event audit.Event) {
@@ -488,6 +534,10 @@ func (b *Broker) rollbackReusableApproval(approvalID string) {
 func (b *Broker) reusableApprovalActive(approvalID string, expiresAt time.Time) error {
 	if approvalID == "" || expiresAt.IsZero() {
 		return nil
+	}
+	if b.stopped() {
+		b.rollbackReusableApproval(approvalID)
+		return ErrDaemonStopped
 	}
 	if b.now().Before(expiresAt) {
 		return nil
@@ -686,6 +736,9 @@ func (b *Broker) recordSecretFetchFailed(
 }
 
 func secretFetchErrorCode(err error) string {
+	if errors.Is(err, ErrDaemonStopped) {
+		return "daemon_stopped"
+	}
 	if errors.Is(err, context.Canceled) {
 		return "context_canceled"
 	}
@@ -745,6 +798,9 @@ func (b *Broker) cachedValues(approvalID string, secrets []request.Secret) (map[
 }
 
 func (b *Broker) activeRequest(requestID string, nonce string) (*activeExec, error) {
+	if b.stopped() {
+		return nil, ErrDaemonStopped
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -756,6 +812,15 @@ func (b *Broker) activeRequest(requestID string, nonce string) (*activeExec, err
 		return nil, ErrInvalidNonce
 	}
 	return active, nil
+}
+
+func (b *Broker) stopped() bool {
+	select {
+	case <-b.stop:
+		return true
+	default:
+		return false
+	}
 }
 
 type secretIdentity struct {

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -87,6 +87,23 @@ func (a *contextExpiringApprover) ApproveExec(
 	return ApprovalDecision{}, ErrRequestExpired
 }
 
+type blockingApprover struct {
+	started  chan struct{}
+	canceled chan struct{}
+}
+
+func (a *blockingApprover) ApproveExec(
+	ctx context.Context,
+	_ string,
+	_ string,
+	_ request.ExecRequest,
+) (ApprovalDecision, error) {
+	close(a.started)
+	<-ctx.Done()
+	close(a.canceled)
+	return ApprovalDecision{}, ctx.Err()
+}
+
 type mockResolver struct {
 	mu     sync.Mutex
 	values map[string]string
@@ -156,6 +173,18 @@ type deadlineObservingResolver struct {
 func (r *deadlineObservingResolver) Resolve(ctx context.Context, _ string, _ string) (string, error) {
 	<-ctx.Done()
 	close(r.done)
+	return "", ctx.Err()
+}
+
+type blockingResolver struct {
+	started  chan struct{}
+	canceled chan struct{}
+}
+
+func (r *blockingResolver) Resolve(ctx context.Context, _ string, _ string) (string, error) {
+	close(r.started)
+	<-ctx.Done()
+	close(r.canceled)
 	return "", ctx.Err()
 }
 
@@ -238,6 +267,19 @@ type contextCheckingAudit struct {
 func (m *contextCheckingAudit) Record(ctx context.Context, event audit.Event) error {
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	return m.memoryAudit.Record(ctx, event)
+}
+
+type callbackAudit struct {
+	memoryAudit
+
+	onRecord func(audit.Event)
+}
+
+func (m *callbackAudit) Record(ctx context.Context, event audit.Event) error {
+	if m.onRecord != nil {
+		m.onRecord(event)
 	}
 	return m.memoryAudit.Record(ctx, event)
 }
@@ -1045,6 +1087,144 @@ func TestBrokerStopClearsReusableCache(t *testing.T) {
 	broker.Stop(context.Background())
 	if _, ok := cache.Get(grant.ApprovalID, ref, ""); ok {
 		t.Fatal("daemon stop left reusable cache scope reachable")
+	}
+}
+
+func TestBrokerStopCancelsPendingApproval(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	approver := &blockingApprover{started: make(chan struct{}), canceled: make(chan struct{})}
+	resolver := &mockResolver{values: map[string]string{ref: "value"}}
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    aud,
+	})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+		errCh <- err
+	}()
+	receiveBrokerSignal(t, approver.started, "approval was not requested before stop")
+
+	broker.Stop(context.Background())
+
+	receiveBrokerSignal(t, approver.canceled, "stop did not cancel pending approval")
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrDaemonStopped) {
+			t.Fatalf("HandleExec error = %v, want daemon stopped", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HandleExec did not return after daemon stop")
+	}
+	if calls := resolver.Calls(); len(calls) != 0 {
+		t.Fatalf("resolver called after stopped pending approval: %v", calls)
+	}
+	events := aud.Events()
+	if !containsAuditEvent(events, audit.EventDaemonStop) {
+		t.Fatalf("daemon stop was not audited: %+v", events)
+	}
+	if containsAuditEvent(events, audit.EventApprovalGranted) ||
+		containsAuditEvent(events, audit.EventCommandStarting) {
+		t.Fatalf("stopped approval reached post-approval audit events: %+v", events)
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); !errors.Is(err, ErrDaemonStopped) {
+		t.Fatalf("MarkPayloadDelivered after stop = %v, want daemon stopped", err)
+	}
+}
+
+func TestBrokerStopCancelsSecretResolution(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	resolver := &blockingResolver{started: make(chan struct{}), canceled: make(chan struct{})}
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
+		Resolver: resolver,
+		Audit:    aud,
+	})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+		errCh <- err
+	}()
+	receiveBrokerSignal(t, resolver.started, "secret resolution did not start before stop")
+
+	broker.Stop(context.Background())
+
+	receiveBrokerSignal(t, resolver.canceled, "stop did not cancel secret resolution")
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrDaemonStopped) {
+			t.Fatalf("HandleExec error = %v, want daemon stopped", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HandleExec did not return after daemon stop")
+	}
+	if containsAuditEvent(aud.Events(), audit.EventCommandStarting) {
+		t.Fatalf("stopped resolution reached command_starting audit: %+v", aud.Events())
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); !errors.Is(err, ErrDaemonStopped) {
+		t.Fatalf("MarkPayloadDelivered after stop = %v, want daemon stopped", err)
+	}
+}
+
+func TestBrokerStopBlocksReusablePayloadAfterCachedValuesAreRead(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	cache := policy.NewSecretCache()
+	resolver := &mockResolver{values: map[string]string{ref: "value"}}
+	var broker *Broker
+	var stopOnce sync.Once
+	aud := &callbackAudit{}
+	aud.onRecord = func(event audit.Event) {
+		if event.Type != audit.EventCommandStarting || event.RequestID != "req_2" {
+			return
+		}
+		stopOnce.Do(func() {
+			broker.Stop(context.Background())
+		})
+	}
+	broker = newTestBroker(t, BrokerOptions{
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true}},
+		Resolver: resolver,
+		Audit:    aud,
+		Cache:    cache,
+	})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+
+	first, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if err != nil {
+		t.Fatalf("initial HandleExec returned error: %v", err)
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); err != nil {
+		t.Fatalf("initial MarkPayloadDelivered returned error: %v", err)
+	}
+	if _, ok := cache.Get(first.ApprovalID, ref, ""); !ok {
+		t.Fatal("expected reusable value in cache before stop")
+	}
+
+	_, err = broker.HandleExec(context.Background(), "req_2", "nonce_2", req)
+	if !errors.Is(err, ErrDaemonStopped) {
+		t.Fatalf("reusable HandleExec after stop during command_starting = %v, want daemon stopped", err)
+	}
+	if err := broker.MarkPayloadDelivered("req_2"); !errors.Is(err, ErrDaemonStopped) {
+		t.Fatalf("reusable MarkPayloadDelivered after stop = %v, want daemon stopped", err)
+	}
+	if _, ok := cache.Get(first.ApprovalID, ref, ""); ok {
+		t.Fatal("daemon stop left reusable cache value reachable")
+	}
+	if calls := resolver.Calls(); !reflect.DeepEqual(calls, []string{ref}) {
+		t.Fatalf("resolver calls = %v, want only initial fresh resolution", calls)
 	}
 }
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -167,6 +167,10 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 			_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "bad_envelope", err)
 			continue
 		}
+		if s.stopped() && env.Type != TypeDaemonStatus {
+			_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(ErrDaemonStopped), ErrDaemonStopped)
+			return
+		}
 
 		nextReadTimeout = s.readTimeout
 		if commandStarted {
@@ -177,35 +181,11 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 		case TypeDaemonStatus:
 			_ = writeOK(encoder, env.RequestID, env.Nonce, StatusPayload{PID: os.Getpid()})
 		case TypeDaemonStop:
-			peer, err := s.peerInfo(conn)
-			if err != nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "peer_rejected", err)
-				continue
+			if s.handleDaemonStop(ctx, conn, encoder, env) {
+				return
 			}
-			if err := s.execValidator.ValidateExecPeer(peer); err != nil {
-				s.broker.recordDaemonStopAttempt(ctx, daemonStopAuditEvent(peer, err))
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
-				continue
-			}
-			_ = writeOK(encoder, env.RequestID, env.Nonce, StatusPayload{PID: os.Getpid()})
-			s.stopWithAudit(ctx, daemonStopAuditEvent(peer, nil))
-			return
 		case TypeApprovalPending:
-			if s.approvals == nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "approval_unavailable", ErrApprovalUnavailable)
-				continue
-			}
-			peer, err := s.peerInfo(conn)
-			if err != nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "peer_rejected", err)
-				continue
-			}
-			payload, err := s.approvals.FetchPending(ctx, peer)
-			if err != nil {
-				_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
-				continue
-			}
-			if err := writeOK(encoder, payload.RequestID, payload.Nonce, payload); err == nil {
+			if payload, ok := s.handleApprovalPending(ctx, conn, encoder, env); ok {
 				nextReadTimeout = s.approvalDecisionReadTimeout(payload.ExpiresAt)
 			}
 		case TypeApprovalDecision:
@@ -255,6 +235,53 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 	}
 }
 
+func (s *Server) handleApprovalPending(
+	ctx context.Context,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env Envelope,
+) (ApprovalRequestPayload, bool) {
+	if s.approvals == nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "approval_unavailable", ErrApprovalUnavailable)
+		return ApprovalRequestPayload{}, false
+	}
+	peer, err := s.peerInfo(conn)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "peer_rejected", err)
+		return ApprovalRequestPayload{}, false
+	}
+	payload, err := s.approvals.FetchPending(ctx, peer)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return ApprovalRequestPayload{}, false
+	}
+	if err := writeOK(encoder, payload.RequestID, payload.Nonce, payload); err != nil {
+		return ApprovalRequestPayload{}, false
+	}
+	return payload, true
+}
+
+func (s *Server) handleDaemonStop(
+	ctx context.Context,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env Envelope,
+) bool {
+	peer, err := s.peerInfo(conn)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, "peer_rejected", err)
+		return false
+	}
+	if err := s.execValidator.ValidateExecPeer(peer); err != nil {
+		s.broker.recordDaemonStopAttempt(ctx, daemonStopAuditEvent(peer, err))
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return false
+	}
+	s.stopWithAudit(ctx, daemonStopAuditEvent(peer, nil))
+	_ = writeOK(encoder, env.RequestID, env.Nonce, StatusPayload{PID: os.Getpid()})
+	return true
+}
+
 func (s *Server) handleRequestExec(
 	ctx context.Context,
 	conn *net.UnixConn,
@@ -281,6 +308,10 @@ func (s *Server) handleRequestExec(
 	}
 	if err := s.broker.MarkPayloadDelivered(env.RequestID); err != nil {
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return ""
+	}
+	if s.stopped() {
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(ErrDaemonStopped), ErrDaemonStopped)
 		return ""
 	}
 	_ = writeOK(encoder, env.RequestID, env.Nonce, ExecResponsePayload{
@@ -427,6 +458,8 @@ func codeForError(err error) string {
 		return "no_pending_approval"
 	case errors.Is(err, ErrRequestAlreadyActive):
 		return "request_active"
+	case errors.Is(err, ErrDaemonStopped):
+		return "daemon_stopped"
 	case errors.Is(err, ErrRequestExpired):
 		return "request_expired"
 	case errors.Is(err, ErrStaleApproval):
@@ -435,5 +468,14 @@ func codeForError(err error) string {
 		return "untrusted_client"
 	default:
 		return "request_failed"
+	}
+}
+
+func (s *Server) stopped() bool {
+	select {
+	case <-s.stop:
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -501,6 +501,72 @@ func TestServerDaemonStopTerminatesListener(t *testing.T) {
 	assertRequesterAudit(t, events[0], peer, "")
 }
 
+func TestServerRejectsExecOnExistingConnectionAfterStop(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	resolver := &mockResolver{values: map[string]string{ref: "value"}}
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
+		Resolver: resolver,
+		Audit:    &memoryAudit{},
+	})
+	dir, err := os.MkdirTemp("/tmp", "agent-secret-test-")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	path := filepath.Join(dir, "d.sock")
+	listener, err := ListenUnix(path)
+	if err != nil {
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+	server, err := NewServer(ServerOptions{
+		Broker:        broker,
+		Validator:     allowPeerValidator{},
+		ExecValidator: NewTrustedExecutableValidator(CurrentExecutableTrustedClientPaths()),
+	})
+	if err != nil {
+		t.Fatalf("NewServer returned error: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- server.Serve(ctx, listener) }()
+	defer func() {
+		cancel()
+		_ = listener.Close()
+		select {
+		case err := <-done:
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				t.Fatalf("server returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("server did not stop")
+		}
+	}()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	client := NewClient(conn)
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.Status(context.Background()); err != nil {
+		t.Fatalf("Status returned error: %v", err)
+	}
+	server.Stop(context.Background())
+	_, err = client.RequestExec(context.Background(), "req_1", "nonce_1", testExecRequest(t, []request.SecretSpec{
+		{Alias: "TOKEN", Ref: ref},
+	}))
+	if !IsProtocolError(err, "daemon_stopped") {
+		t.Fatalf("RequestExec after stop error = %v, want daemon_stopped", err)
+	}
+	if calls := resolver.Calls(); len(calls) != 0 {
+		t.Fatalf("resolver called after daemon stop: %v", calls)
+	}
+}
+
 func TestServerRejectsUntrustedDaemonStopPeer(t *testing.T) {
 	t.Parallel()
 
@@ -1036,6 +1102,7 @@ func TestCodeForErrorMapsProtocolFailures(t *testing.T) {
 		{err: ErrApproverIdentity, want: "approver_identity_mismatch"},
 		{err: ErrNoPendingApproval, want: "no_pending_approval"},
 		{err: ErrRequestAlreadyActive, want: "request_active"},
+		{err: ErrDaemonStopped, want: "daemon_stopped"},
 		{err: ErrRequestExpired, want: "request_expired"},
 		{err: ErrStaleApproval, want: "stale_approval"},
 		{err: ErrUntrustedClient, want: "untrusted_client"},

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -219,6 +219,14 @@ func (s *Store) RemoveReusable(id string) bool {
 	return true
 }
 
+func (s *Store) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.approvals = make(map[string]*ReusableApproval)
+	s.sessions = make(map[string]*Session)
+}
+
 func (s *Store) CreateSession(id string, nonce string, expiresAt time.Time, grants []SecretGrant, maxReads int) (Session, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

- add a broker stop cancellation boundary that makes pending approvals, secret resolution, reusable grants, and payload delivery return `daemon_stopped` after stop
- clear policy state in place on stop to avoid racing a store pointer swap with in-flight exec work
- make existing protocol connections reject secret-bearing requests after stop and report the new protocol error code
- add broker and server regressions for pending approval, pending resolution, cached reusable values before payload delivery, and existing-connection exec after stop

Closes #194.

## Verification

- `mise exec -- go test ./internal/daemon -run 'TestBrokerStop(ClearsReusableCache|CancelsPendingApproval|CancelsSecretResolution|BlocksReusablePayloadAfterCachedValuesAreRead)$|TestServerRejectsExecOnExistingConnectionAfterStop|TestCodeForErrorMapsProtocolFailures' -count=1`\n- `mise exec -- go test -race ./internal/daemon ./internal/policy`\n- `mise run lint:go`\n- `mise run build`\n- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5`\n- `mise run test` (rerun clean after one known transient `TestProcessApproverLauncherHealthCheck` timeout)\n- `mise run lint`\n- `mise run lint:smart`\n