### PR TITLE
ASR-070: reject symlinked audit path ancestors

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -177,10 +177,14 @@ func openPath(path string, now func() time.Time) (*Writer, error) {
 	if now == nil {
 		now = time.Now
 	}
-	if err := prepareAuditDirectory(filepath.Dir(path)); err != nil {
+	dir := filepath.Dir(path)
+	if err := prepareAuditDirectory(dir); err != nil {
 		return nil, err
 	}
 	if err := rejectInsecureFile(path); err != nil {
+		return nil, err
+	}
+	if err := rejectAuditDirectoryAncestry(dir); err != nil {
 		return nil, err
 	}
 
@@ -193,6 +197,9 @@ func openPath(path string, now func() time.Time) (*Writer, error) {
 }
 
 func prepareAuditDirectory(dir string) error {
+	if err := rejectAuditDirectoryAncestry(dir); err != nil {
+		return err
+	}
 	_, err := os.Lstat(dir)
 	if errors.Is(err, os.ErrNotExist) {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -207,6 +214,9 @@ func prepareAuditDirectory(dir string) error {
 }
 
 func rejectInsecureDirectory(dir string) error {
+	if err := rejectAuditDirectoryAncestry(dir); err != nil {
+		return err
+	}
 	info, err := os.Lstat(dir)
 	if err != nil {
 		return fmt.Errorf("stat audit directory: %w", err)
@@ -224,6 +234,48 @@ func rejectInsecureDirectory(dir string) error {
 		return fmt.Errorf("%w: %s is owned by uid %d", ErrInsecureAuditLog, dir, uid)
 	}
 	return nil
+}
+
+func rejectAuditDirectoryAncestry(dir string) error {
+	cleanDir := filepath.Clean(dir)
+	for current := cleanDir; ; current = filepath.Dir(current) {
+		info, err := os.Lstat(current)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("stat audit directory ancestor: %w", err)
+		}
+		if err == nil {
+			if err := rejectAuditDirectoryAncestorInfo(cleanDir, current, info); err != nil {
+				return err
+			}
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+	}
+}
+
+func rejectAuditDirectoryAncestorInfo(cleanDir, current string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		if isAllowedAuditRootAlias(current) {
+			return nil
+		}
+		return fmt.Errorf("%w: %s contains symlink ancestor %s", ErrInsecureAuditLog, cleanDir, current)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %s contains non-directory ancestor %s", ErrInsecureAuditLog, cleanDir, current)
+	}
+	return nil
+}
+
+func isAllowedAuditRootAlias(path string) bool {
+	switch path {
+	case "/etc", "/tmp", "/var":
+		return true
+	default:
+		return false
+	}
 }
 
 func rejectInsecureFile(path string) error {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -161,6 +161,47 @@ func TestOpenDefaultRejectsSymlinkAuditDirectoryWithoutChmodTarget(t *testing.T)
 	}
 }
 
+func TestOpenDefaultRejectsSymlinkAuditAncestorWithoutCreatingTargetPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	target := t.TempDir()
+	if err := os.Symlink(target, filepath.Join(home, "Library")); err != nil {
+		t.Fatalf("symlink audit ancestor: %v", err)
+	}
+
+	_, err := OpenDefault(time.Now)
+	if !errors.Is(err, ErrInsecureAuditLog) {
+		t.Fatalf("expected insecure audit log error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "Logs")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("symlink target Logs stat = %v, want not exist", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "Logs", "agent-secret", "audit.jsonl")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("symlink target audit log stat = %v, want not exist", err)
+	}
+}
+
+func TestOpenPathRejectsSymlinkAuditAncestorWithoutCreatingTargetPath(t *testing.T) {
+	root := t.TempDir()
+	target := t.TempDir()
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink audit ancestor: %v", err)
+	}
+	path := filepath.Join(link, "agent-secret", "audit.jsonl")
+
+	_, err := openPath(path, time.Now)
+	if !errors.Is(err, ErrInsecureAuditLog) {
+		t.Fatalf("expected insecure audit log error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "agent-secret")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("symlink target audit directory stat = %v, want not exist", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "agent-secret", "audit.jsonl")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("symlink target audit log stat = %v, want not exist", err)
+	}
+}
+
 func TestDefaultPathIgnoresEnvironmentOverrides(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

- add audit directory ancestry validation before and after `MkdirAll`
- revalidate audit directory ancestry immediately before opening the JSONL file
- reject symlink and non-directory ancestors while preserving explicit macOS root alias allowances
- add `OpenDefault` and `openPath` regressions proving symlink targets are not populated

Closes #195.

## Verification

- `mise exec -- go test ./internal/audit -run 'TestOpen(Default|Path).*SymlinkAuditAncestor|TestOpenDefaultCreatesPrivateJSONLAuditLog' -count=1`\n- `mise exec -- go test ./internal/audit -count=1`\n- `mise run lint:go`\n- `mise run build`\n- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5`\n- `mise run test` (rerun clean after known transient health-check timeout)\n- `mise run test:race` (rerun clean after known transient health-check timeout)\n- `mise run lint` (rerun clean after known transient health-check timeout in coverage phase)\n- `mise run lint:smart`\n