### PR TITLE
ASR-074: Preserve explicit denial after approval expiry

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalPromptExpiration.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPromptExpiration.swift
@@ -12,9 +12,12 @@ struct ApprovalPromptExpiration: Equatable {
     }
 
     func guardDecision(_ decision: ApprovalDecisionKind, at now: Date) -> ApprovalDecisionKind {
-        if isExpired(at: now) {
-            return .timeout
+        switch decision {
+        case .approveOnce, .approveReusable:
+            isExpired(at: now) ? .timeout : decision
+
+        default:
+            decision
         }
-        return decision
     }
 }

--- a/approver/Tests/AgentSecretApproverTests/ApprovalPromptExpirationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalPromptExpirationTests.swift
@@ -12,7 +12,7 @@ final class ApprovalPromptExpirationTests: XCTestCase {
         XCTAssertEqual(expiration.timeoutDecision(at: expiresAt.addingTimeInterval(1)), .timeout)
     }
 
-    func testLateDecisionsBecomeTimeouts() {
+    func testLateApprovalDecisionsBecomeTimeouts() {
         let expiresAt = Date(timeIntervalSince1970: 1_800_000_000)
         let expiration = ApprovalPromptExpiration(expiresAt: expiresAt)
 
@@ -22,7 +22,20 @@ final class ApprovalPromptExpirationTests: XCTestCase {
         )
         XCTAssertEqual(expiration.guardDecision(.approveOnce, at: expiresAt), .timeout)
         XCTAssertEqual(expiration.guardDecision(.approveReusable, at: expiresAt.addingTimeInterval(1)), .timeout)
-        XCTAssertEqual(expiration.guardDecision(.deny, at: expiresAt.addingTimeInterval(1)), .timeout)
+    }
+
+    func testLateDenyDecisionRemainsDeny() {
+        let expiresAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let expiration = ApprovalPromptExpiration(expiresAt: expiresAt)
+
+        XCTAssertEqual(expiration.guardDecision(.deny, at: expiresAt), .deny)
+        XCTAssertEqual(expiration.guardDecision(.deny, at: expiresAt.addingTimeInterval(1)), .deny)
+    }
+
+    func testTimeoutDecisionRemainsTimeout() {
+        let expiresAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let expiration = ApprovalPromptExpiration(expiresAt: expiresAt)
+
         XCTAssertEqual(expiration.guardDecision(.timeout, at: expiresAt.addingTimeInterval(1)), .timeout)
     }
 

--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -207,18 +207,23 @@ func (a *SocketApprover) SubmitDecision(
 	if decision.RequestID != job.payload.RequestID || decision.Nonce != job.payload.Nonce {
 		return ErrStaleApproval
 	}
-	if !a.now().Before(job.payload.ExpiresAt) || decision.Decision == "timeout" {
-		a.complete(job, approvalResult{err: ErrRequestExpired})
-		return nil
-	}
-
 	switch decision.Decision {
 	case "approve_once":
+		if !a.now().Before(job.payload.ExpiresAt) {
+			a.complete(job, approvalResult{err: ErrRequestExpired})
+			return nil
+		}
 		a.complete(job, approvalResult{decision: ApprovalDecision{Approved: true}})
 	case "approve_reusable":
+		if !a.now().Before(job.payload.ExpiresAt) {
+			a.complete(job, approvalResult{err: ErrRequestExpired})
+			return nil
+		}
 		a.complete(job, approvalResult{decision: ApprovalDecision{Approved: true, Reusable: true}})
 	case "deny":
 		a.complete(job, approvalResult{err: ErrApprovalDenied})
+	case "timeout":
+		a.complete(job, approvalResult{err: ErrRequestExpired})
 	default:
 		return fmt.Errorf("%w: invalid approval decision %q", ErrMalformedEnvelope, decision.Decision)
 	}

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -609,8 +609,24 @@ func TestSocketApproverRejectsInvalidDecision(t *testing.T) {
 	}
 }
 
-func TestSocketApproverTreatsExpiredDenialAsTimeout(t *testing.T) {
+func TestSocketApproverTreatsExpiredApprovalAsTimeout(t *testing.T) {
 	t.Parallel()
+
+	if err := submitExpiredDecisionForTest(t, "approve_once"); !errors.Is(err, ErrRequestExpired) {
+		t.Fatalf("ApproveExec error = %v, want expired", err)
+	}
+}
+
+func TestSocketApproverPreservesExpiredDenial(t *testing.T) {
+	t.Parallel()
+
+	if err := submitExpiredDecisionForTest(t, "deny"); !errors.Is(err, ErrApprovalDenied) {
+		t.Fatalf("ApproveExec error = %v, want denied", err)
+	}
+}
+
+func submitExpiredDecisionForTest(t *testing.T, decision string) error {
+	t.Helper()
 
 	exe := currentExecutable(t)
 	now := time.Date(2026, 4, 28, 15, 0, 0, 0, time.UTC)
@@ -639,14 +655,12 @@ func TestSocketApproverTreatsExpiredDenialAsTimeout(t *testing.T) {
 	err := approver.SubmitDecision(context.Background(), peerInfoForTest(t, os.Getpid(), exe), ApprovalDecisionPayload{
 		RequestID: "req_1",
 		Nonce:     "nonce_1",
-		Decision:  "deny",
+		Decision:  decision,
 	})
 	if err != nil {
-		t.Fatalf("expired denial decision returned error: %v", err)
+		t.Fatalf("expired %s decision returned error: %v", decision, err)
 	}
-	if err := <-errCh; !errors.Is(err, ErrRequestExpired) {
-		t.Fatalf("ApproveExec error = %v, want expired", err)
-	}
+	return <-errCh
 }
 
 func TestProcessApproverLauncherExecutablePath(t *testing.T) {

--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -241,7 +241,7 @@ func (b *Broker) requestError(ctx context.Context, req request.ExecRequest, err 
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, ErrRequestExpired) {
+	if errors.Is(err, ErrApprovalDenied) || errors.Is(err, ErrRequestExpired) {
 		return err
 	}
 	if activeErr := b.requestActive(ctx, req); activeErr != nil {
@@ -714,7 +714,9 @@ func (b *Broker) recordApprovalError(
 func (b *Broker) recordApprovalDenied(ctx context.Context, requestID string, req request.ExecRequest) error {
 	event := audit.FromExecRequest(audit.EventApprovalDenied, requestID, req)
 	event.ErrorCode = "approval_denied"
-	return b.recordRequiredAudit(ctx, event)
+	auditCtx, cancel := terminalAuditContext(ctx)
+	defer cancel()
+	return b.recordRequiredAudit(auditCtx, event)
 }
 
 func (b *Broker) recordSecretFetchFailed(

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -87,6 +87,21 @@ func (a *contextExpiringApprover) ApproveExec(
 	return ApprovalDecision{}, ErrRequestExpired
 }
 
+type contextDenyingApprover struct {
+	done chan struct{}
+}
+
+func (a *contextDenyingApprover) ApproveExec(
+	ctx context.Context,
+	_ string,
+	_ string,
+	_ request.ExecRequest,
+) (ApprovalDecision, error) {
+	<-ctx.Done()
+	close(a.done)
+	return ApprovalDecision{}, ErrApprovalDenied
+}
+
 type blockingApprover struct {
 	started  chan struct{}
 	canceled chan struct{}
@@ -374,17 +389,53 @@ func TestBrokerApprovalTimeoutAuditsOutcomeWithoutResolveOrCommandStart(t *testi
 func TestBrokerApprovalTimeoutAuditIgnoresExpiredRequestContext(t *testing.T) {
 	t.Parallel()
 
+	done := make(chan struct{})
+	assertDeadlineApprovalFailureAudited(t, deadlineApprovalFailureCase{
+		approver:  &contextExpiringApprover{done: done},
+		done:      done,
+		err:       ErrRequestExpired,
+		eventType: audit.EventApprovalTimedOut,
+		errorCode: "request_expired",
+		name:      "approval timeout",
+	})
+}
+
+func TestBrokerLateDenialAuditsDenialWithoutResolveOrCommandStart(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan struct{})
+	assertDeadlineApprovalFailureAudited(t, deadlineApprovalFailureCase{
+		approver:  &contextDenyingApprover{done: done},
+		done:      done,
+		err:       ErrApprovalDenied,
+		eventType: audit.EventApprovalDenied,
+		errorCode: "approval_denied",
+		name:      "late denial",
+	})
+}
+
+type deadlineApprovalFailureCase struct {
+	approver  Approver
+	done      <-chan struct{}
+	err       error
+	eventType audit.EventType
+	errorCode string
+	name      string
+}
+
+func assertDeadlineApprovalFailureAudited(t *testing.T, tc deadlineApprovalFailureCase) {
+	t.Helper()
+
 	ref := "op://Example/Item/token"
 	now := time.Now()
 	req := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
 	req.TTL = 25 * time.Millisecond
 	req.ExpiresAt = req.ReceivedAt.Add(req.TTL)
-	approver := &contextExpiringApprover{done: make(chan struct{})}
 	resolver := &mockResolver{values: map[string]string{ref: "value"}}
 	aud := &contextCheckingAudit{}
 	broker, err := NewBroker(BrokerOptions{
 		Now:      time.Now,
-		Approver: approver,
+		Approver: tc.approver,
 		Resolver: resolver,
 		Audit:    aud,
 	})
@@ -393,21 +444,21 @@ func TestBrokerApprovalTimeoutAuditIgnoresExpiredRequestContext(t *testing.T) {
 	}
 
 	_, err = broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
-	if !errors.Is(err, ErrRequestExpired) {
-		t.Fatalf("expected request expiry, got %v", err)
+	if !errors.Is(err, tc.err) {
+		t.Fatalf("expected %s, got %v", tc.err, err)
 	}
-	receiveBrokerSignal(t, approver.done, "approver did not observe request deadline")
+	receiveBrokerSignal(t, tc.done, "approver did not observe request deadline")
 	if calls := resolver.Calls(); len(calls) != 0 {
-		t.Fatalf("resolver was called after approval timeout: %v", calls)
+		t.Fatalf("resolver was called after %s: %v", tc.name, calls)
 	}
 
 	events := aud.Events()
-	want := []audit.EventType{audit.EventApprovalRequested, audit.EventApprovalTimedOut}
+	want := []audit.EventType{audit.EventApprovalRequested, tc.eventType}
 	if got := auditEventTypes(events); !reflect.DeepEqual(got, want) {
 		t.Fatalf("audit events = %v, want %v", got, want)
 	}
-	if events[1].ErrorCode != "request_expired" {
-		t.Fatalf("approval timeout error code = %q", events[1].ErrorCode)
+	if events[1].ErrorCode != tc.errorCode {
+		t.Fatalf("%s error code = %q", tc.name, events[1].ErrorCode)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve explicit `.deny` decisions in the Swift expiration guard while keeping late approval decisions mapped to timeout
- make daemon `SubmitDecision` apply expiry only to approval/timeout decisions, not correlated deny decisions
- preserve denial errors through broker expiry wrapping and record denial audit events with a terminal audit context

Closes #199.

## Verification

- `mise exec -- swift test --package-path approver --filter ApprovalPromptExpirationTests`
- `mise exec -- go test ./internal/daemon -run 'TestSocketApproverTreatsExpiredApprovalAsTimeout|TestSocketApproverPreservesExpiredDenial|TestBrokerLateDenialAuditsDenialWithoutResolveOrCommandStart|TestBrokerApprovalTimeoutAuditIgnoresExpiredRequestContext' -count=5`
- `mise exec -- go test ./internal/daemon`
- `mise exec -- swift test --package-path approver`
- `mise run lint:go`
- `mise run lint:swift`
- `mise run build`
- `mise run test`
- `mise run test:race`
- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5`
- `mise run lint`
- `mise run test:smoke`
- `mise run lint:smart`
