### PR TITLE
ASR-075: Move approver daemon I/O off main actor

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalController.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalController.swift
@@ -4,7 +4,7 @@ import Foundation
 public final class ApprovalController {
     private static let reusableDecisionUses: Int = 3
 
-    private let client: ApprovalDaemonClient
+    private let client: ApprovalDaemonClientWorker
     private let presenter: ApprovalPresenter
     private let logger: ApprovalLogger
 
@@ -14,7 +14,7 @@ public final class ApprovalController {
         presenter: ApprovalPresenter,
         logger: ApprovalLogger = UnifiedApprovalLogger(category: "decisions")
     ) {
-        self.client = client
+        self.client = ApprovalDaemonClientWorker(client: client)
         self.presenter = presenter
         self.logger = logger
     }
@@ -22,9 +22,9 @@ public final class ApprovalController {
     /// Executes one approval interaction and returns the submitted decision.
     @preconcurrency
     @MainActor
-    public func run() throws -> ApprovalDecision {
+    public func run() async throws -> ApprovalDecision {
         logger.record("approval_request_fetch_started", requestID: nil)
-        let request: ApprovalRequest = try client.fetchPendingRequest()
+        let request: ApprovalRequest = try await client.fetchPendingRequest()
         logger.record("approval_request_loaded", requestID: request.requestID)
 
         let decisionKind: ApprovalDecisionKind = presenter.decide(for: request)
@@ -36,7 +36,7 @@ public final class ApprovalController {
             reusableUses: reusableUses
         )
 
-        try client.submit(decision)
+        try await client.submit(decision)
         logger.record("approval_decision_submitted", requestID: request.requestID)
         return decision
     }

--- a/approver/Sources/AgentSecretApprover/ApprovalDaemonClientWorker.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalDaemonClientWorker.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Serial worker that keeps blocking daemon socket I/O off the main actor.
+final class ApprovalDaemonClientWorker: @unchecked Sendable {
+    private let client: ApprovalDaemonClient
+    private let queue: DispatchQueue
+
+    init(
+        client: ApprovalDaemonClient,
+        queue: DispatchQueue = DispatchQueue(label: "com.kovyrin.agent-secret.approver.daemon-client")
+    ) {
+        self.client = client
+        self.queue = queue
+    }
+
+    func fetchPendingRequest() async throws -> ApprovalRequest {
+        try await perform {
+            try self.client.fetchPendingRequest()
+        }
+    }
+
+    func submit(_ decision: ApprovalDecision) async throws {
+        try await perform {
+            try self.client.submit(decision)
+        }
+    }
+
+    private func perform<Value>(_ operation: @escaping @Sendable () throws -> Value) async throws -> Value {
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async {
+                do {
+                    let value = try operation()
+                    continuation.resume(returning: value)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}

--- a/approver/Sources/AgentSecretApprover/MockDaemonClient.swift
+++ b/approver/Sources/AgentSecretApprover/MockDaemonClient.swift
@@ -2,10 +2,16 @@ import Foundation
 
 /// In-memory daemon client used by tests and local smoke runs.
 public final class MockDaemonClient: ApprovalDaemonClient {
+    private let lock = NSLock()
     private let request: ApprovalRequest
+    private var lastSubmittedDecision: ApprovalDecision?
 
     /// Decision submitted by the controller.
-    public private(set) var submittedDecision: ApprovalDecision?
+    public var submittedDecision: ApprovalDecision? {
+        lock.lock()
+        defer { lock.unlock() }
+        return lastSubmittedDecision
+    }
 
     /// Creates a mock daemon client with one pending request.
     public init(request: ApprovalRequest) {
@@ -19,7 +25,9 @@ public final class MockDaemonClient: ApprovalDaemonClient {
 
     /// Captures a submitted decision for assertions.
     public func submit(_ decision: ApprovalDecision) {
-        submittedDecision = decision
+        lock.lock()
+        defer { lock.unlock() }
+        lastSubmittedDecision = decision
     }
 
     deinit {

--- a/approver/Sources/AgentSecretApproverApp/AgentSecretApproverMain.swift
+++ b/approver/Sources/AgentSecretApproverApp/AgentSecretApproverMain.swift
@@ -6,7 +6,7 @@ private enum AgentSecretApproverMain {
     private static let usageExitCode: Int32 = 64
 
     @MainActor
-    static func main() {
+    static func main() async {
         do {
             let arguments: [String] = Array(CommandLine.arguments.dropFirst())
             if arguments == ["--health-check"] {
@@ -20,7 +20,7 @@ private enum AgentSecretApproverMain {
             let presenter: ApprovalPresenter = AppKitApprovalPresenter()
             let client: ApprovalDaemonClient = try SocketDaemonClient(socketPath: socketPath)
             let controller = ApprovalController(client: client, presenter: presenter)
-            _ = try controller.run()
+            _ = try await controller.run()
         } catch {
             FileHandle.standardError.write(Data("agent-secret-approver: \(error)\n".utf8))
             exit(usageExitCode)

--- a/approver/Sources/AgentSecretApproverSmoke/main.swift
+++ b/approver/Sources/AgentSecretApproverSmoke/main.swift
@@ -14,7 +14,7 @@ private let kController: ApprovalController = .init(
     presenter: StaticDecisionPresenter(decision: kOptions.decision),
     logger: kLogger
 )
-private let kDecision: ApprovalDecision = try kController.run()
+private let kDecision: ApprovalDecision = try await kController.run()
 
 try assert(kDecision.requestID == kRequest.requestID, "decision request ID mismatch")
 try assert(kDecision.nonce == kRequest.nonce, "decision nonce mismatch")

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerConcurrencyTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerConcurrencyTests.swift
@@ -1,0 +1,111 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class ApprovalControllerConcurrencyTests: XCTestCase {
+    private struct NoopApprovalLogger: ApprovalLogger {
+        func record(_: String, requestID _: String?) {
+            /* Intentionally ignored. */
+        }
+    }
+
+    private enum ThreadObservation {
+        case unrecorded
+        case main
+        case background
+    }
+
+    private final class ThreadRecordingDaemonClient: ApprovalDaemonClient {
+        private let lock = NSLock()
+        private let request: ApprovalRequest
+        private var fetchObservation: ThreadObservation = .unrecorded
+        private var submitObservation: ThreadObservation = .unrecorded
+
+        var fetchThreadObservation: ThreadObservation {
+            lock.lock()
+            defer { lock.unlock() }
+            return fetchObservation
+        }
+
+        var submitThreadObservation: ThreadObservation {
+            lock.lock()
+            defer { lock.unlock() }
+            return submitObservation
+        }
+
+        init(request: ApprovalRequest) {
+            self.request = request
+        }
+
+        func fetchPendingRequest() -> ApprovalRequest {
+            lock.lock()
+            fetchObservation = Thread.isMainThread ? .main : .background
+            lock.unlock()
+            return request
+        }
+
+        func submit(_: ApprovalDecision) {
+            lock.lock()
+            submitObservation = Thread.isMainThread ? .main : .background
+            lock.unlock()
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+
+    @MainActor
+    private final class ThreadRecordingPresenter: ApprovalPresenter {
+        private(set) var decideRanOnMainThread = false
+
+        func decide(for _: ApprovalRequest) -> ApprovalDecisionKind {
+            decideRanOnMainThread = Thread.isMainThread
+            return .approveOnce
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+
+    private static var sampleRequest: ApprovalRequest {
+        ApprovalRequest(
+            requestID: "req_concurrency",
+            nonce: "nonce_concurrency",
+            reason: "Run concurrency check",
+            command: ["/usr/bin/env", "true"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: 1_800_000_000),
+            secrets: [
+                RequestedSecret(
+                    alias: "EXAMPLE_TOKEN",
+                    ref: "op://Example Vault/Example Item/token",
+                    account: "Work"
+                )
+            ],
+            resolvedExecutable: "/usr/bin/env"
+        )
+    }
+
+    @MainActor
+    func testDaemonClientRunsOffMainThreadWhilePresenterRunsOnMainThread() async throws {
+        let client = ThreadRecordingDaemonClient(request: Self.sampleRequest)
+        let presenter = ThreadRecordingPresenter()
+        let controller = ApprovalController(
+            client: client,
+            presenter: presenter,
+            logger: NoopApprovalLogger()
+        )
+
+        _ = try await controller.run()
+
+        XCTAssertEqual(client.fetchThreadObservation, .background)
+        XCTAssertEqual(client.submitThreadObservation, .background)
+        XCTAssertTrue(presenter.decideRanOnMainThread)
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
@@ -73,7 +73,7 @@ final class ApprovalControllerTests: XCTestCase {
     }
 
     @MainActor
-    func testReusableDecisionCarriesThreeUseLimit() throws {
+    func testReusableDecisionCarriesThreeUseLimit() async throws {
         let request: ApprovalRequest = Self.sampleRequest
         let client = MockDaemonClient(request: request)
         let controller = ApprovalController(
@@ -82,7 +82,7 @@ final class ApprovalControllerTests: XCTestCase {
             logger: RecordingLogger()
         )
 
-        let decision: ApprovalDecision = try controller.run()
+        let decision: ApprovalDecision = try await controller.run()
 
         XCTAssertEqual(decision.decision, .approveReusable)
         XCTAssertEqual(decision.reusableUses, Self.expectedReusableUses)
@@ -123,7 +123,7 @@ final class ApprovalControllerTests: XCTestCase {
     }
 
     @MainActor
-    func testSubmitsApproveOnceDecisionWithoutSecretValues() throws {
+    func testSubmitsApproveOnceDecisionWithoutSecretValues() async throws {
         let request: ApprovalRequest = Self.sampleRequest
         let client = MockDaemonClient(request: request)
         let logger = RecordingLogger()
@@ -133,7 +133,7 @@ final class ApprovalControllerTests: XCTestCase {
             logger: logger
         )
 
-        let decision: ApprovalDecision = try controller.run()
+        let decision: ApprovalDecision = try await controller.run()
 
         XCTAssertEqual(
             decision,


### PR DESCRIPTION
## Summary

- Adds a serial async worker for `ApprovalDaemonClient` so blocking daemon fetch/submit calls run off the app main actor.
- Makes `ApprovalController.run()` async while keeping presenter interaction isolated to `@MainActor`.
- Adds a regression proving daemon fetch/submit execute on a background thread while presentation still runs on the main thread.

Closes #200

## Verification

- `mise run lint:swift`
- `mise exec -- swift test --package-path approver --filter 'ApprovalControllerTests|ApprovalControllerConcurrencyTests'`
- `mise exec -- swift test --package-path approver`
- `mise run build`
- `mise run test`
- `mise run test:race`
- `mise run test:smoke`
- `mise run lint`
- `mise run lint:smart`
