### PR TITLE
ASR-077: bind reusable approval use counts

### DIFF
--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/kovyrin/agent-secret/internal/peercred"
-	"github.com/kovyrin/agent-secret/internal/policy"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
 
@@ -223,7 +222,11 @@ func (a *SocketApprover) SubmitDecision(
 		if err := validateReusableDecisionUses(decision, job.payload.ReusableUses); err != nil {
 			return err
 		}
-		a.complete(job, approvalResult{decision: ApprovalDecision{Approved: true, Reusable: true}})
+		a.complete(job, approvalResult{decision: ApprovalDecision{
+			Approved:     true,
+			Reusable:     true,
+			ReusableUses: job.payload.ReusableUses,
+		}})
 	case "deny":
 		a.complete(job, approvalResult{err: ErrApprovalDenied})
 	case "timeout":
@@ -386,7 +389,7 @@ func approvalPayload(requestID string, nonce string, req request.ExecRequest) Ap
 		OverrideEnv:            req.OverrideEnv,
 		OverriddenAliases:      slices.Clone(req.OverriddenAliases),
 		AllowMutableExecutable: req.AllowMutableExecutable,
-		ReusableUses:           policy.DefaultReusableUses,
+		ReusableUses:           request.ReusableUsesOrDefault(req.ReusableUses),
 	}
 }
 

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/kovyrin/agent-secret/internal/fileidentity"
 	"github.com/kovyrin/agent-secret/internal/peercred"
-	"github.com/kovyrin/agent-secret/internal/policy"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
 
@@ -135,6 +134,7 @@ func TestSocketApproverLaunchesAndAcceptsExpectedPeerDecision(t *testing.T) {
 	launcher := &recordingLauncher{expected: ExpectedApprover{PID: os.Getpid(), ExecutablePath: exe}}
 	approver := newSocketApproverForTest(t, launcher, time.Now)
 	req := approvalTestRequest(t, time.Now().Add(time.Minute))
+	req.ReusableUses = 2
 
 	resultCh := make(chan ApprovalDecision, 1)
 	errCh := make(chan error, 1)
@@ -158,10 +158,10 @@ func TestSocketApproverLaunchesAndAcceptsExpectedPeerDecision(t *testing.T) {
 	if payload.Secrets[0].Account != "Work" {
 		t.Fatalf("payload secret account = %q, want Work", payload.Secrets[0].Account)
 	}
-	if payload.ReusableUses != policy.DefaultReusableUses {
-		t.Fatalf("payload reusable uses = %d, want policy default %d", payload.ReusableUses, policy.DefaultReusableUses)
+	if payload.ReusableUses != 2 {
+		t.Fatalf("payload reusable uses = %d, want request count 2", payload.ReusableUses)
 	}
-	uses := policy.DefaultReusableUses
+	uses := payload.ReusableUses
 	err = approver.SubmitDecision(context.Background(), peerInfoForTest(t, os.Getpid(), exe), ApprovalDecisionPayload{
 		RequestID:    "req_1",
 		Nonce:        "nonce_1",
@@ -176,6 +176,9 @@ func TestSocketApproverLaunchesAndAcceptsExpectedPeerDecision(t *testing.T) {
 	case decision := <-resultCh:
 		if !decision.Approved || !decision.Reusable {
 			t.Fatalf("unexpected approval result: %+v", decision)
+		}
+		if decision.ReusableUses != 2 {
+			t.Fatalf("decision reusable uses = %d, want 2", decision.ReusableUses)
 		}
 	case err := <-errCh:
 		t.Fatalf("ApproveExec returned error: %v", err)

--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -31,8 +31,9 @@ type Approver interface {
 }
 
 type ApprovalDecision struct {
-	Approved bool
-	Reusable bool
+	Approved     bool
+	Reusable     bool
+	ReusableUses int
 }
 
 type Resolver interface {
@@ -494,7 +495,7 @@ func (b *Broker) freshGrant(
 	approvalID := ""
 	approvalExpiresAt := time.Time{}
 	if decision.Reusable {
-		approval, err := b.store.AddReusable(req, "", "")
+		approval, err := b.store.AddReusableWithLimit(req, decision.ReusableUses, "", "")
 		if err != nil {
 			return ExecGrant{}, err
 		}

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -893,6 +893,105 @@ func TestBrokerReusableApprovalMissesWhenEnvironmentFingerprintChanges(t *testin
 	}
 }
 
+func TestBrokerReusableApprovalUsesApprovedUseLimit(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true, ReusableUses: 2}}
+	resolver := &mockResolver{values: map[string]string{ref: "first"}}
+	cache := policy.NewSecretCache()
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    &memoryAudit{},
+		Cache:    cache,
+	})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req.ReusableUses = 2
+
+	first, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if err != nil {
+		t.Fatalf("first HandleExec returned error: %v", err)
+	}
+	if first.ApprovalID == "" {
+		t.Fatal("expected reusable approval id")
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); err != nil {
+		t.Fatalf("first MarkPayloadDelivered returned error: %v", err)
+	}
+
+	resolver.values[ref] = "second"
+	second, err := broker.HandleExec(context.Background(), "req_2", "nonce_2", req)
+	if err != nil {
+		t.Fatalf("second HandleExec returned error: %v", err)
+	}
+	if second.Env["TOKEN"] != "first" {
+		t.Fatalf("second delivery did not reuse cached first value: %+v", second.Env)
+	}
+	if err := broker.MarkPayloadDelivered("req_2"); err != nil {
+		t.Fatalf("second MarkPayloadDelivered returned error: %v", err)
+	}
+	if _, ok := cache.Get(first.ApprovalID, ref, ""); ok {
+		t.Fatal("two-use approval cache scope remained after two deliveries")
+	}
+
+	third, err := broker.HandleExec(context.Background(), "req_3", "nonce_3", req)
+	if err != nil {
+		t.Fatalf("third HandleExec returned error: %v", err)
+	}
+	if third.Env["TOKEN"] != "second" {
+		t.Fatalf("fresh approval after exhaustion used stale value: %+v", third.Env)
+	}
+	if third.ApprovalID == first.ApprovalID {
+		t.Fatalf("fresh approval reused exhausted approval id %q", first.ApprovalID)
+	}
+	if approver.calls != 2 {
+		t.Fatalf("approver calls = %d, want fresh approval after two deliveries", approver.calls)
+	}
+}
+
+func TestBrokerReusableApprovalMissesWhenUseLimitChanges(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true, ReusableUses: 2}}
+	resolver := &mockResolver{values: map[string]string{ref: "first"}}
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    &memoryAudit{},
+		Cache:    policy.NewSecretCache(),
+	})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req.ReusableUses = 2
+
+	first, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if err != nil {
+		t.Fatalf("first HandleExec returned error: %v", err)
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); err != nil {
+		t.Fatalf("MarkPayloadDelivered returned error: %v", err)
+	}
+
+	resolver.values[ref] = "second"
+	changed := req
+	changed.ReusableUses = 3
+	approver.decision.ReusableUses = 3
+	second, err := broker.HandleExec(context.Background(), "req_2", "nonce_2", changed)
+	if err != nil {
+		t.Fatalf("second HandleExec returned error: %v", err)
+	}
+	if second.ApprovalID == first.ApprovalID {
+		t.Fatalf("changed use limit reused approval %q", first.ApprovalID)
+	}
+	if second.Env["TOKEN"] != "second" {
+		t.Fatalf("changed use limit used cached value from old approval: %+v", second.Env)
+	}
+	if approver.calls != 2 {
+		t.Fatalf("approver calls = %d, want fresh approval after reusable use limit change", approver.calls)
+	}
+}
+
 func TestBrokerClearsReusableCacheOnExpiry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -26,7 +26,7 @@ var (
 	ErrUseExhausted  = errors.New("reusable approval use count exhausted")
 )
 
-const DefaultReusableUses = 3
+const DefaultReusableUses = request.DefaultReusableUses
 
 type ReuseAuditSink interface {
 	ApprovalReused(ctx context.Context, event ReuseAuditEvent) error
@@ -65,6 +65,7 @@ type ReuseKey struct {
 	Secrets                []SecretGrant
 	DeliveryMode           request.DeliveryMode
 	TTL                    time.Duration
+	ReusableUses           int
 	OverrideEnv            bool
 	OverriddenAliases      []string
 	AllowMutableExecutable bool
@@ -119,8 +120,23 @@ func NewStore(now func() time.Time) *Store {
 }
 
 func (s *Store) AddReusable(req request.ExecRequest, id string, nonce string) (ReusableApproval, error) {
+	return s.AddReusableWithLimit(req, request.ReusableUsesOrDefault(req.ReusableUses), id, nonce)
+}
+
+func (s *Store) AddReusableWithLimit(
+	req request.ExecRequest,
+	maxUses int,
+	id string,
+	nonce string,
+) (ReusableApproval, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	maxUses = request.ReusableUsesOrDefault(maxUses)
+	if maxUses < 1 || maxUses > request.MaxReusableUses {
+		return ReusableApproval{}, fmt.Errorf("%w: must be between 1 and %d", request.ErrInvalidReusableUses, request.MaxReusableUses)
+	}
+	req.ReusableUses = maxUses
 
 	if id == "" {
 		var err error
@@ -142,7 +158,7 @@ func (s *Store) AddReusable(req request.ExecRequest, id string, nonce string) (R
 		Nonce:     nonce,
 		Key:       NewReuseKey(req),
 		ExpiresAt: req.ExpiresAt,
-		MaxUses:   DefaultReusableUses,
+		MaxUses:   maxUses,
 	}
 	s.approvals[id] = approval
 
@@ -357,6 +373,7 @@ func NewReuseKey(req request.ExecRequest) ReuseKey {
 		Secrets:                secrets,
 		DeliveryMode:           req.DeliveryMode,
 		TTL:                    req.TTL,
+		ReusableUses:           request.ReusableUsesOrDefault(req.ReusableUses),
 		OverrideEnv:            req.OverrideEnv,
 		OverriddenAliases:      overridden,
 		AllowMutableExecutable: req.AllowMutableExecutable,
@@ -373,6 +390,7 @@ func (k ReuseKey) Equal(other ReuseKey) bool {
 		slices.Equal(k.Secrets, other.Secrets) &&
 		k.DeliveryMode == other.DeliveryMode &&
 		k.TTL == other.TTL &&
+		k.ReusableUses == other.ReusableUses &&
 		k.OverrideEnv == other.OverrideEnv &&
 		k.AllowMutableExecutable == other.AllowMutableExecutable &&
 		slices.Equal(k.OverriddenAliases, other.OverriddenAliases)

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -92,6 +92,7 @@ func TestReusableApprovalMissesOnPolicyChanges(t *testing.T) {
 		{name: "overridden alias", mutate: func(r *request.ExecRequest) { r.OverriddenAliases = []string{"TOKEN"} }},
 		{name: "mutable executable opt-in", mutate: func(r *request.ExecRequest) { r.AllowMutableExecutable = true }},
 		{name: "ttl", mutate: func(r *request.ExecRequest) { r.TTL = 5 * time.Minute }},
+		{name: "reusable uses", mutate: func(r *request.ExecRequest) { r.ReusableUses = request.DefaultReusableUses + 1 }},
 	}
 
 	for _, tt := range tests {
@@ -106,6 +107,40 @@ func TestReusableApprovalMissesOnPolicyChanges(t *testing.T) {
 				t.Fatalf("expected mismatch, got %v", err)
 			}
 		})
+	}
+}
+
+func TestReusableApprovalUsesRequestedUseLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	store := NewStore(func() time.Time { return now })
+	req := testRequest(t, now)
+	req.ReusableUses = 2
+
+	approval, err := store.AddReusableWithLimit(req, 2, "appr_1", "nonce_1")
+	if err != nil {
+		t.Fatalf("AddReusableWithLimit returned error: %v", err)
+	}
+	if approval.MaxUses != 2 {
+		t.Fatalf("max uses = %d, want 2", approval.MaxUses)
+	}
+
+	audit := &memoryReuseAudit{}
+	if _, err := store.FindReusable(context.Background(), req, audit); err != nil {
+		t.Fatalf("FindReusable returned error: %v", err)
+	}
+	if len(audit.events) != 1 || audit.events[0].RemainingUse != 2 {
+		t.Fatalf("unexpected audit events: %+v", audit.events)
+	}
+
+	for range 2 {
+		if _, err := store.FinishReusableAttempt(approval.ID, DeliveryPayloadDelivered); err != nil {
+			t.Fatalf("FinishReusableAttempt returned error: %v", err)
+		}
+	}
+	if _, err := store.FindReusable(context.Background(), req, nil); !errors.Is(err, ErrMismatch) {
+		t.Fatalf("expected two-use approval to be removed, got %v", err)
 	}
 }
 

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -16,10 +16,12 @@ import (
 )
 
 const (
-	MaxReasonLength = 240
-	DefaultExecTTL  = 2 * time.Minute
-	MinExecTTL      = 10 * time.Second
-	MaxExecTTL      = 10 * time.Minute
+	MaxReasonLength     = 240
+	DefaultExecTTL      = 2 * time.Minute
+	MinExecTTL          = 10 * time.Second
+	MaxExecTTL          = 10 * time.Minute
+	DefaultReusableUses = 3
+	MaxReusableUses     = 20
 )
 
 var (
@@ -30,6 +32,7 @@ var (
 	ErrMutableExecutable   = errors.New("mutable executable requires explicit opt-in")
 	ErrInvalidReason       = errors.New("invalid reason")
 	ErrInvalidReference    = errors.New("invalid 1Password secret reference")
+	ErrInvalidReusableUses = errors.New("invalid reusable use count")
 	ErrInvalidRequest      = errors.New("invalid exec request")
 	ErrInvalidTTL          = errors.New("invalid ttl")
 )
@@ -73,6 +76,7 @@ type ExecOptions struct {
 	ReceivedAt             time.Time
 	DeliveryMode           DeliveryMode
 	MaxReads               int
+	ReusableUses           int
 	OverrideEnv            bool
 	ForceRefresh           bool
 	AllowMutableExecutable bool
@@ -92,6 +96,7 @@ type ExecRequest struct {
 	ExpiresAt              time.Time
 	DeliveryMode           DeliveryMode
 	MaxReads               int
+	ReusableUses           int
 	OverrideEnv            bool
 	OverriddenAliases      []string
 	ForceRefresh           bool
@@ -120,6 +125,9 @@ func (r ExecRequest) ValidateForDaemon() error {
 		return fmt.Errorf("%w: daemon does not implement %q delivery", ErrInvalidDeliveryMode, r.DeliveryMode)
 	}
 	if err := validateDelivery(r.DeliveryMode, r.MaxReads); err != nil {
+		return err
+	}
+	if err := validateReusableUses(r.ReusableUses); err != nil {
 		return err
 	}
 	if r.TTL < MinExecTTL || r.TTL > MaxExecTTL {
@@ -166,6 +174,10 @@ func NewExec(opts ExecOptions) (ExecRequest, error) {
 		mode = DeliveryEnvExec
 	}
 	if err := validateDelivery(mode, opts.MaxReads); err != nil {
+		return ExecRequest{}, err
+	}
+	reusableUses := ReusableUsesOrDefault(opts.ReusableUses)
+	if err := validateReusableUses(reusableUses); err != nil {
 		return ExecRequest{}, err
 	}
 
@@ -231,6 +243,7 @@ func NewExec(opts ExecOptions) (ExecRequest, error) {
 		ExpiresAt:              receivedAt.Add(ttl),
 		DeliveryMode:           mode,
 		MaxReads:               opts.MaxReads,
+		ReusableUses:           reusableUses,
 		OverrideEnv:            opts.OverrideEnv,
 		OverriddenAliases:      overriddenAliases,
 		ForceRefresh:           opts.ForceRefresh,
@@ -246,6 +259,13 @@ func EnvironmentFingerprint(env []string) string {
 		sum.Write([]byte{0})
 	}
 	return "env-v1:" + hex.EncodeToString(sum.Sum(nil))
+}
+
+func ReusableUsesOrDefault(uses int) int {
+	if uses == 0 {
+		return DefaultReusableUses
+	}
+	return uses
 }
 
 func ParseSecretRef(ref string) (SecretRef, error) {
@@ -300,6 +320,14 @@ func validateDelivery(mode DeliveryMode, maxReads int) error {
 		}
 	default:
 		return fmt.Errorf("%w: %q", ErrInvalidDeliveryMode, mode)
+	}
+	return nil
+}
+
+func validateReusableUses(uses int) error {
+	uses = ReusableUsesOrDefault(uses)
+	if uses < 1 || uses > MaxReusableUses {
+		return fmt.Errorf("%w: must be between 1 and %d", ErrInvalidReusableUses, MaxReusableUses)
 	}
 	return nil
 }

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -48,6 +48,9 @@ func TestNewExecValidatesAndNormalizesRequest(t *testing.T) {
 	if req.DeliveryMode != DeliveryEnvExec {
 		t.Fatalf("delivery mode = %s", req.DeliveryMode)
 	}
+	if req.ReusableUses != DefaultReusableUses {
+		t.Fatalf("reusable uses = %d, want default %d", req.ReusableUses, DefaultReusableUses)
+	}
 	if req.ResolvedExecutable != bin {
 		t.Fatalf("resolved executable = %q, want %q", req.ResolvedExecutable, bin)
 	}
@@ -105,6 +108,8 @@ func TestNewExecRejectsInvalidInputs(t *testing.T) {
 		{name: "session max reads zero", opts: mutate(baseOptions(dir, "reason"), func(o *ExecOptions) {
 			o.DeliveryMode = DeliverySessionSocket
 		}), want: ErrInvalidMaxReads},
+		{name: "reusable uses too low", opts: mutate(baseOptions(dir, "reason"), func(o *ExecOptions) { o.ReusableUses = -1 }), want: ErrInvalidReusableUses},
+		{name: "reusable uses too high", opts: mutate(baseOptions(dir, "reason"), func(o *ExecOptions) { o.ReusableUses = MaxReusableUses + 1 }), want: ErrInvalidReusableUses},
 		{name: "env conflict without override", opts: mutate(baseOptions(dir, "reason"), func(o *ExecOptions) {
 			o.Env = append(o.Env, "TOKEN=already")
 		}), want: ErrInvalidAlias},


### PR DESCRIPTION
## Summary

Fixes #210.

- carry the approved reusable use limit through `ApprovalDecision` into the broker cache insert
- add reusable use count to request/policy reuse keys so different limits cannot match the same approval
- add regressions for two-use approvals exhausting after two deliveries and use-limit changes requiring a fresh approval

## Verification

- `mise exec -- go test ./internal/request ./internal/policy ./internal/daemon -run 'TestNewExecValidatesAndNormalizesRequest|TestNewExecRejectsInvalidInputs|TestReusableApproval(UsesRequestedUseLimit|MissesOnPolicyChanges)|TestBrokerReusableApproval(UsesApprovedUseLimit|MissesWhenUseLimitChanges)|TestSocketApproverLaunchesAndAcceptsExpectedPeerDecision$'`\n- `mise run test`\n- `mise run test:race`\n- `mise run build`\n- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5` after one known health-check timeout during the first lint coverage run\n- `mise run lint`\n- `mise run test:smoke`\n- `mise run lint:smart`