### PR TITLE
ASR-078: bound daemon client protocol calls

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kovyrin/agent-secret/internal/audit"
 	"github.com/kovyrin/agent-secret/internal/daemon"
@@ -161,6 +162,37 @@ func TestAppDaemonStatusAndDoctor(t *testing.T) {
 		!strings.Contains(stdout.String(), "native approver: ok") ||
 		!strings.Contains(stdout.String(), "1password desktop integration: ok") {
 		t.Fatalf("doctor output missing diagnostics: %q", stdout.String())
+	}
+}
+
+func TestAppDaemonStatusUsesDefaultProtocolDeadline(t *testing.T) {
+	client, cleanup := startStallingAppDaemon(t)
+	defer cleanup()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := NewApp(daemon.Manager{
+		SocketPath:      client.SocketPath,
+		DaemonPath:      os.Args[0],
+		ProtocolTimeout: 25 * time.Millisecond,
+		StartupTimeout:  25 * time.Millisecond,
+	}, &stdout, &stderr)
+
+	done := make(chan int, 1)
+	go func() {
+		done <- app.Run(context.Background(), []string{"daemon", "status"})
+	}()
+
+	select {
+	case code := <-done:
+		if code != 1 {
+			t.Fatalf("daemon status exit=%d, want stopped failure; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "agent-secretd: stopped") {
+			t.Fatalf("daemon status stdout = %q", stdout.String())
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("daemon status did not return after default protocol deadline")
 	}
 }
 
@@ -491,5 +523,47 @@ func startAppTestServer(t *testing.T, opts daemon.BrokerOptions) (appTestClient,
 		_ = listener.Close()
 		<-done
 		_ = os.RemoveAll(dir)
+	}
+}
+
+func startStallingAppDaemon(t *testing.T) (appTestClient, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "agent-secret-app-stall-")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	path := filepath.Join(dir, "d.sock")
+	listener, err := daemon.ListenUnix(path)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = fmt.Fscan(conn)
+		<-release
+		done <- nil
+	}()
+
+	return appTestClient{SocketPath: path}, func() {
+		close(release)
+		_ = listener.Close()
+		defer func() { _ = os.RemoveAll(dir) }()
+		select {
+		case err := <-done:
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				t.Fatalf("stalling app daemon returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("stalling app daemon did not stop")
+		}
 	}
 }

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -23,10 +23,13 @@ func (e *ProtocolError) Error() string {
 }
 
 type Client struct {
-	conn    *net.UnixConn
-	encoder *json.Encoder
-	reader  *bufio.Reader
+	conn           *net.UnixConn
+	encoder        *json.Encoder
+	reader         *bufio.Reader
+	DefaultTimeout time.Duration
 }
+
+const DefaultClientProtocolTimeout = DefaultProtocolReadTimeout
 
 func Connect(ctx context.Context, path string) (*Client, error) {
 	return ConnectWithPeerValidator(ctx, path, NewTrustedDaemonValidator(DefaultTrustedDaemonPaths()))
@@ -57,9 +60,10 @@ func validateDaemonPeer(conn *net.UnixConn, validator DaemonPeerValidator) error
 
 func NewClient(conn *net.UnixConn) *Client {
 	return &Client{
-		conn:    conn,
-		encoder: json.NewEncoder(conn),
-		reader:  bufio.NewReader(conn),
+		conn:           conn,
+		encoder:        json.NewEncoder(conn),
+		reader:         bufio.NewReader(conn),
+		DefaultTimeout: DefaultClientProtocolTimeout,
 	}
 }
 
@@ -106,6 +110,8 @@ func (c *Client) ReportCompleted(ctx context.Context, requestID string, nonce st
 
 func roundTrip[T any](ctx context.Context, c *Client, messageType string, requestID string, nonce string, payload any) (T, error) {
 	var zero T
+	ctx, cancel := c.contextWithDefaultDeadline(ctx, messageType, payload)
+	defer cancel()
 	if err := ctx.Err(); err != nil {
 		return zero, fmt.Errorf("daemon request canceled: %w", err)
 	}
@@ -161,6 +167,32 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 		return zero, fmt.Errorf("%w: %w", ErrMalformedEnvelope, err)
 	}
 	return out, nil
+}
+
+func (c *Client) contextWithDefaultDeadline(
+	ctx context.Context,
+	messageType string,
+	payload any,
+) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	timeout := c.defaultTimeout()
+	now := time.Now()
+	deadline := now.Add(timeout)
+	if messageType == TypeRequestExec {
+		if req, ok := payload.(request.ExecRequest); ok && req.ExpiresAt.After(now) {
+			deadline = req.ExpiresAt.Add(timeout)
+		}
+	}
+	return context.WithDeadline(ctx, deadline)
+}
+
+func (c *Client) defaultTimeout() time.Duration {
+	if c != nil && c.DefaultTimeout > 0 {
+		return c.DefaultTimeout
+	}
+	return DefaultClientProtocolTimeout
 }
 
 func validateResponseCorrelation(resp Envelope, requestID string, nonce string) error {

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Manager struct {
-	SocketPath     string
-	DaemonPath     string
-	DaemonArgs     []string
-	StartupTimeout time.Duration
+	SocketPath      string
+	DaemonPath      string
+	DaemonArgs      []string
+	StartupTimeout  time.Duration
+	ProtocolTimeout time.Duration
 }
 
 func NewManager(socketPath string) (Manager, error) {
@@ -124,7 +125,12 @@ func (m Manager) Stop(ctx context.Context) error {
 }
 
 func (m Manager) Connect(ctx context.Context) (*Client, error) {
-	return ConnectWithPeerValidator(ctx, m.SocketPath, NewTrustedDaemonValidator(m.trustedDaemonPaths()))
+	client, err := ConnectWithPeerValidator(ctx, m.SocketPath, NewTrustedDaemonValidator(m.trustedDaemonPaths()))
+	if err != nil {
+		return nil, err
+	}
+	client.DefaultTimeout = m.protocolTimeout()
+	return client, nil
 }
 
 func (m Manager) statusBeforeStart(ctx context.Context) error {
@@ -165,6 +171,13 @@ func (m Manager) trustedDaemonPaths() []string {
 		}
 	}
 	return trustedDaemonPathsForPath(daemonPath)
+}
+
+func (m Manager) protocolTimeout() time.Duration {
+	if m.ProtocolTimeout > 0 {
+		return m.ProtocolTimeout
+	}
+	return DefaultClientProtocolTimeout
 }
 
 func (m Manager) stopped(ctx context.Context) bool {

--- a/internal/daemon/protocol_test.go
+++ b/internal/daemon/protocol_test.go
@@ -204,6 +204,53 @@ func TestClientRoundTripHonorsContextDeadlineWaitingForResponse(t *testing.T) {
 	}
 }
 
+func TestClientRoundTripUsesDefaultDeadlineWithoutCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	client, requests, cleanup := startStallingDaemonClient(t)
+	defer cleanup()
+	client.DefaultTimeout = 25 * time.Millisecond
+
+	errc := make(chan error, 1)
+	go func() {
+		_, err := client.Status(context.Background())
+		errc <- err
+	}()
+
+	env := receiveStalledRequest(t, requests)
+	if env.Type != TypeDaemonStatus {
+		t.Fatalf("request type = %s, want %s", env.Type, TypeDaemonStatus)
+	}
+
+	err := receiveRoundTripError(t, errc)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected default deadline exceeded error, got %v", err)
+	}
+}
+
+func TestClientRequestExecDefaultDeadlineAllowsApprovalWaitUntilRequestExpiry(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := startRespondingDaemonClient(t, func(env Envelope) []byte {
+		time.Sleep(60 * time.Millisecond)
+		return execResponseFrame(t, env, ExecResponsePayload{
+			Env:           map[string]string{"TOKEN": "value"},
+			SecretAliases: []string{"TOKEN"},
+		})
+	})
+	defer cleanup()
+	client.DefaultTimeout = 25 * time.Millisecond
+
+	req := testExecRequestAt(t, time.Now(), []request.SecretSpec{{Alias: "TOKEN", Ref: "op://Example/Item/token"}})
+	got, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req)
+	if err != nil {
+		t.Fatalf("RequestExec returned error before request expiry: %v", err)
+	}
+	if got.Env["TOKEN"] != "value" {
+		t.Fatalf("exec response env = %+v", got.Env)
+	}
+}
+
 func TestClientRejectsOversizedDaemonResponseFrame(t *testing.T) {
 	t.Parallel()
 
@@ -345,6 +392,20 @@ func boundedPaddingResponseFrame(t *testing.T, padding string) []byte {
 	}
 	if int64(len(frame)+1) > DefaultMaxProtocolFrameBytes {
 		t.Fatalf("test frame size %d exceeds max %d", len(frame)+1, DefaultMaxProtocolFrameBytes)
+	}
+	return append(frame, '\n')
+}
+
+func execResponseFrame(t *testing.T, request Envelope, payload ExecResponsePayload) []byte {
+	t.Helper()
+
+	env, err := NewEnvelope(TypeOK, request.RequestID, request.Nonce, payload)
+	if err != nil {
+		t.Fatalf("NewEnvelope returned error: %v", err)
+	}
+	frame, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal exec response: %v", err)
 	}
 	return append(frame, '\n')
 }


### PR DESCRIPTION
## Summary

Fixes #211.

- add default per-round-trip deadlines to the Go daemon client
- let `request.exec` wait until request expiry plus protocol slack instead of the short default status/stop timeout
- let Manager configure the protocol timeout for production and tests
- add client and app-level stalling-daemon regressions so background-context calls cannot hang forever

## Verification

- `mise exec -- go test ./internal/daemon ./internal/cli -run 'TestClientRoundTripUsesDefaultDeadlineWithoutCallerDeadline|TestClientRequestExecDefaultDeadlineAllowsApprovalWaitUntilRequestExpiry|TestAppDaemonStatusUsesDefaultProtocolDeadline|TestServerHandlesExecLifecycle|TestClientRejectsMismatchedResponseCorrelation' -count=1 -timeout=15s`\n- `mise run test`\n- `mise run test:race`\n- `mise run build`\n- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5` after the known coverage-gate timeout in the first lint run\n- `mise run lint`\n- `mise run test:smoke`\n- `mise run lint:smart`