### PR TITLE
ASR-079: Pin install and release helper tools

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 set -eu
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
 
 die() {
   echo "agent-secret install: $*" >&2

--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -67,15 +67,6 @@ done
 
 version="$(agent_secret_normalize_short_version "$version")"
 
-require_command() {
-  local name="$1"
-
-  if ! command -v "$name" >/dev/null 2>&1; then
-    echo "build-app-bundle: required command not found: $name" >&2
-    exit 1
-  fi
-}
-
 require_tool() {
   local name="$1"
   local path="$2"
@@ -86,18 +77,31 @@ require_tool() {
   fi
 }
 
+tool_go="${GOROOT:-}/bin/go"
+tool_swift="/usr/bin/swift"
+tool_mktemp="/usr/bin/mktemp"
+tool_rm="/bin/rm"
+tool_mkdir="/bin/mkdir"
+tool_install="/usr/bin/install"
+tool_cp="/bin/cp"
+tool_sips="/usr/bin/sips"
+tool_iconutil="/usr/bin/iconutil"
 tool_codesign="/usr/bin/codesign"
 
-require_command go
-require_command swift
-require_command install
-require_command iconutil
-require_command sips
+require_tool go "$tool_go"
+require_tool swift "$tool_swift"
+require_tool mktemp "$tool_mktemp"
+require_tool rm "$tool_rm"
+require_tool mkdir "$tool_mkdir"
+require_tool install "$tool_install"
+require_tool cp "$tool_cp"
+require_tool sips "$tool_sips"
+require_tool iconutil "$tool_iconutil"
 require_tool codesign "$tool_codesign"
 
-tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-bundle.XXXXXX")"
+tmp_dir="$("$tool_mktemp" -d "${TMPDIR:-/tmp}/agent-secret-bundle.XXXXXX")"
 cleanup() {
-  rm -rf "$tmp_dir"
+  "$tool_rm" -rf "$tmp_dir"
 }
 trap cleanup EXIT
 
@@ -112,8 +116,8 @@ make_icon() {
   local iconset_dir="$2"
   local out="$3"
 
-  rm -rf "$iconset_dir"
-  mkdir -p "$iconset_dir"
+  "$tool_rm" -rf "$iconset_dir"
+  "$tool_mkdir" -p "$iconset_dir"
 
   local icon_specs=(
     "16:icon_16x16.png"
@@ -131,9 +135,9 @@ make_icon() {
   for spec in "${icon_specs[@]}"; do
     local size="${spec%%:*}"
     local name="${spec#*:}"
-    sips -z "$size" "$size" "$icon_source" --out "$iconset_dir/$name" >/dev/null
+    "$tool_sips" -z "$size" "$size" "$icon_source" --out "$iconset_dir/$name" >/dev/null
   done
-  iconutil -c icns "$iconset_dir" -o "$out"
+  "$tool_iconutil" -c icns "$iconset_dir" -o "$out"
 }
 
 sign_path() {
@@ -166,10 +170,10 @@ build_daemon_app() {
   local binary_path="$1"
   local bundle="$2"
 
-  rm -rf "$bundle"
-  mkdir -p "$bundle/Contents/MacOS" "$bundle/Contents/Resources"
-  install -m 0755 "$binary_path" "$bundle/Contents/MacOS/$AGENT_SECRET_APP_EXECUTABLE"
-  cp "$tmp_dir/AppIcon.icns" "$bundle/Contents/Resources/$AGENT_SECRET_ICON_FILE.icns"
+  "$tool_rm" -rf "$bundle"
+  "$tool_mkdir" -p "$bundle/Contents/MacOS" "$bundle/Contents/Resources"
+  "$tool_install" -m 0755 "$binary_path" "$bundle/Contents/MacOS/$AGENT_SECRET_APP_EXECUTABLE"
+  "$tool_cp" "$tmp_dir/AppIcon.icns" "$bundle/Contents/Resources/$AGENT_SECRET_ICON_FILE.icns"
 
   cat >"$bundle/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -220,12 +224,12 @@ if [[ "$codesign_identity" != "-" ]]; then
   }
   go_build_flags+=(-ldflags "-X github.com/kovyrin/agent-secret/internal/daemon.defaultDeveloperIDTeamID=$approver_team_id")
 fi
-go build "${go_build_flags[@]}" -o "$tmp_dir/agent-secret" ./cmd/agent-secret
-go build "${go_build_flags[@]}" -o "$tmp_dir/agent-secretd" ./cmd/agent-secretd
+"$tool_go" build "${go_build_flags[@]}" -o "$tmp_dir/agent-secret" ./cmd/agent-secret
+"$tool_go" build "${go_build_flags[@]}" -o "$tmp_dir/agent-secretd" ./cmd/agent-secretd
 
 echo "Building Swift app executable..."
 cd "$project_root/approver"
-swift build -c release --product agent-secret-approver
+"$tool_swift" build -c release --product agent-secret-approver
 approver_binary="$project_root/approver/.build/release/agent-secret-approver"
 if [[ ! -x "$approver_binary" ]]; then
   echo "build-app-bundle: missing Swift executable $approver_binary" >&2
@@ -233,28 +237,28 @@ if [[ ! -x "$approver_binary" ]]; then
 fi
 
 echo "Creating app icon..."
-swift "$project_root/scripts/make-daemon-icon.swift" "$icon_png"
+"$tool_swift" "$project_root/scripts/make-daemon-icon.swift" "$icon_png"
 make_icon "$icon_png" "$iconset" "$tmp_dir/AppIcon.icns"
 
 echo "Creating daemon helper app..."
 build_daemon_app "$tmp_dir/agent-secretd" "$daemon_bundle"
 
 echo "Creating Agent Secret.app..."
-rm -rf "$app_bundle"
-mkdir -p \
+"$tool_rm" -rf "$app_bundle"
+"$tool_mkdir" -p \
   "$app_bundle/Contents/MacOS" \
   "$app_bundle/Contents/Resources/bin" \
   "$app_bundle/Contents/Resources/skills" \
   "$app_bundle/Contents/Library/Helpers"
-install -m 0755 "$approver_binary" "$app_bundle/Contents/MacOS/$AGENT_SECRET_APP_EXECUTABLE"
-install -m 0755 "$tmp_dir/agent-secret" "$app_bundle/Contents/Resources/bin/agent-secret"
+"$tool_install" -m 0755 "$approver_binary" "$app_bundle/Contents/MacOS/$AGENT_SECRET_APP_EXECUTABLE"
+"$tool_install" -m 0755 "$tmp_dir/agent-secret" "$app_bundle/Contents/Resources/bin/agent-secret"
 if [[ ! -f "$skill_source/SKILL.md" ]]; then
   echo "build-app-bundle: missing bundled skill at $skill_source" >&2
   exit 1
 fi
-cp -R "$skill_source" "$app_bundle/Contents/Resources/skills/agent-secret"
-cp "$tmp_dir/AppIcon.icns" "$app_bundle/Contents/Resources/$AGENT_SECRET_ICON_FILE.icns"
-cp -R "$daemon_bundle" "$app_bundle/Contents/Library/Helpers/AgentSecretDaemon.app"
+"$tool_cp" -R "$skill_source" "$app_bundle/Contents/Resources/skills/agent-secret"
+"$tool_cp" "$tmp_dir/AppIcon.icns" "$app_bundle/Contents/Resources/$AGENT_SECRET_ICON_FILE.icns"
+"$tool_cp" -R "$daemon_bundle" "$app_bundle/Contents/Library/Helpers/AgentSecretDaemon.app"
 
 cat >"$app_bundle/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -124,8 +124,14 @@ tool_ditto="/usr/bin/ditto"
 tool_shasum="/usr/bin/shasum"
 tool_codesign="/usr/bin/codesign"
 tool_xcrun="/usr/bin/xcrun"
+tool_mktemp="/usr/bin/mktemp"
+tool_rm="/bin/rm"
+tool_mkdir="/bin/mkdir"
+tool_ln="/bin/ln"
+tool_uname="/usr/bin/uname"
+tool_chmod="/bin/chmod"
 
-case "$(uname -m)" in
+case "$("$tool_uname" -m)" in
   arm64)
     arch="arm64"
     ;;
@@ -133,7 +139,7 @@ case "$(uname -m)" in
     arch="x86_64"
     ;;
   *)
-    echo "build-release: unsupported architecture: $(uname -m)" >&2
+    echo "build-release: unsupported architecture: $("$tool_uname" -m)" >&2
     exit 1
     ;;
 esac
@@ -141,6 +147,12 @@ esac
 require_tool hdiutil "$tool_hdiutil"
 require_tool ditto "$tool_ditto"
 require_tool shasum "$tool_shasum"
+require_tool mktemp "$tool_mktemp"
+require_tool rm "$tool_rm"
+require_tool mkdir "$tool_mkdir"
+require_tool ln "$tool_ln"
+require_tool uname "$tool_uname"
+require_tool chmod "$tool_chmod"
 if [[ "$codesign_identity" != "-" ]]; then
   require_tool codesign "$tool_codesign"
 fi
@@ -148,9 +160,9 @@ if [[ "$notarize" == "1" ]]; then
   require_tool xcrun "$tool_xcrun"
 fi
 
-tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-release.XXXXXX")"
+tmp_dir="$("$tool_mktemp" -d "${TMPDIR:-/tmp}/agent-secret-release.XXXXXX")"
 cleanup() {
-  rm -rf "$tmp_dir"
+  "$tool_rm" -rf "$tmp_dir"
 }
 trap cleanup EXIT
 
@@ -174,7 +186,7 @@ prepare_notary_key() {
 
   local key_path="$tmp_dir/AuthKey_${notary_key_id}.p8"
   printf '%s\n' "$notary_key" >"$key_path"
-  chmod 0600 "$key_path"
+  "$tool_chmod" 0600 "$key_path"
   echo "$key_path"
 }
 
@@ -215,14 +227,14 @@ if [[ "$notarize" == "1" ]]; then
 fi
 
 echo "Preparing DMG contents..."
-rm -rf "$dmg_root"
-mkdir -p "$dmg_root"
+"$tool_rm" -rf "$dmg_root"
+"$tool_mkdir" -p "$dmg_root"
 "$tool_ditto" "$build_dir/Agent Secret.app" "$dmg_root/Agent Secret.app"
-ln -s /Applications "$dmg_root/Applications"
+"$tool_ln" -s /Applications "$dmg_root/Applications"
 
 echo "Creating $dmg_path..."
-mkdir -p "$output_dir"
-rm -f "$dmg_path"
+"$tool_mkdir" -p "$output_dir"
+"$tool_rm" -f "$dmg_path"
 "$tool_hdiutil" create \
   -volname "Agent Secret $version" \
   -srcfolder "$dmg_root" \

--- a/scripts/import-codesign-certificate.sh
+++ b/scripts/import-codesign-certificate.sh
@@ -37,6 +37,8 @@ require_tool() {
 tool_base64="/usr/bin/base64"
 tool_security="/usr/bin/security"
 tool_uuidgen="/usr/bin/uuidgen"
+tool_mktemp="/usr/bin/mktemp"
+tool_rm="/bin/rm"
 
 trim_keychain_path() {
   local path="$1"
@@ -65,6 +67,8 @@ append_keychain_to_search_list() {
 require_tool base64 "$tool_base64"
 require_tool security "$tool_security"
 require_tool uuidgen "$tool_uuidgen"
+require_tool mktemp "$tool_mktemp"
+require_tool rm "$tool_rm"
 
 cert_base64="${AGENT_SECRET_CODESIGN_CERT_P12_BASE64:-}"
 cert_path="${AGENT_SECRET_CODESIGN_CERT_P12_PATH:-}"
@@ -90,9 +94,9 @@ if [[ "$keychain_password" == "" ]]; then
   keychain_password="$("$tool_uuidgen")"
 fi
 
-tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-codesign.XXXXXX")"
+tmp_dir="$("$tool_mktemp" -d "${TMPDIR:-/tmp}/agent-secret-codesign.XXXXXX")"
 cleanup() {
-  rm -rf "$tmp_dir"
+  "$tool_rm" -rf "$tmp_dir"
 }
 trap cleanup EXIT
 
@@ -106,7 +110,7 @@ if [[ ! -f "$cert_path" ]]; then
   exit 1
 fi
 
-rm -f "$keychain_path"
+"$tool_rm" -f "$keychain_path"
 "$tool_security" create-keychain -p "$keychain_password" "$keychain_path"
 "$tool_security" set-keychain-settings -lut 21600 "$keychain_path"
 "$tool_security" unlock-keychain -p "$keychain_password" "$keychain_path"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -204,10 +204,25 @@ fi
 exit 64
 SCRIPT
 
+  for tool in mktemp rm cp mv mkdir awk sed head basename uname; do
+    cat >"$fake_bin/$tool" <<'SCRIPT'
+#!/bin/sh
+printf '%s' "${0##*/}" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+exit 44
+SCRIPT
+  done
+
   chmod 755 "$fake_bin/codesign" "$fake_bin/spctl" "$fake_bin/xcrun" \
     "$fake_bin/curl" "$fake_bin/shasum" \
     "$fake_bin/agent-secret" \
-    "$fake_bin/ditto" "$fake_bin/hdiutil"
+    "$fake_bin/ditto" "$fake_bin/hdiutil" \
+    "$fake_bin/mktemp" "$fake_bin/rm" "$fake_bin/cp" "$fake_bin/mv" \
+    "$fake_bin/mkdir" "$fake_bin/awk" "$fake_bin/sed" "$fake_bin/head" \
+    "$fake_bin/basename" "$fake_bin/uname"
 }
 
 make_fixture() {

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -43,11 +43,12 @@ write_path_trap_tools() {
   local tool=""
 
   mkdir -p "$trap_dir"
-  for tool in base64 security uuidgen codesign xcrun ditto hdiutil shasum; do
+  for tool in base64 security uuidgen codesign xcrun ditto hdiutil shasum \
+    mktemp rm mkdir ln chmod install cp sips iconutil go swift uname; do
     cat >"$trap_dir/$tool" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$(basename "$0") $*" >>"$AGENT_SECRET_PATH_TRAP_LOG"
+printf '%s\n' "${0##*/} $*" >>"$AGENT_SECRET_PATH_TRAP_LOG"
 exit 44
 BASH
     chmod 755 "$trap_dir/$tool"
@@ -107,10 +108,10 @@ expect_failure "production release requires AGENT_SECRET_CODESIGN_IDENTITY" \
   "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/path-trap-out"
 assert_path_trap_clean "$trap_log"
 
-if grep -En '(^|[|;&][[:space:]]*)(base64|security|uuidgen)([[:space:]]|$)' "$import_certificate"; then
+if grep -En '(^|[|;&][[:space:]]*)(base64|security|uuidgen|mktemp|rm|chmod)([[:space:]]|$)' "$import_certificate"; then
   fail "import-codesign-certificate.sh contains bare secret-handling tool invocation"
 fi
-if grep -En '(^|[|;&][[:space:]]*)(codesign|xcrun|ditto|hdiutil|shasum)([[:space:]]|$)' \
+if grep -En '(^|[|;&][[:space:]]*)(codesign|xcrun|ditto|hdiutil|shasum|mktemp|rm|mkdir|ln|chmod|install|cp|sips|iconutil|go|swift|uname)([[:space:]]|$)' \
   "$build_release" "$project_root/scripts/build-app-bundle.sh"; then
   fail "release build scripts contain bare Apple tool invocation"
 fi


### PR DESCRIPTION
## Summary
- constrain the installer to system tool lookup before any filesystem helpers run
- pin release/build/import helper commands to absolute system paths instead of PATH lookup
- extend install and release trap tests to cover file utilities, Go, Swift, and icon helpers

Fixes #212.

## Verification
- mise exec -- bash scripts/test-install.sh
- mise exec -- bash scripts/test-release-signing-env.sh
- mise run lint:shell
- mise run test
- mise run test:race
- mise run build
- mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5
- mise run test:smoke
- mise run lint
- mise run lint:smart

Note: one parallel lint/test run hit the known approver health-check timeout; the focused repeat and standalone lint pass both succeeded.