### PR TITLE
ASR-080: Refresh notes on existing draft releases

### DIFF
--- a/scripts/publish-draft-release.sh
+++ b/scripts/publish-draft-release.sh
@@ -32,6 +32,7 @@ if gh release view "$tag" >/dev/null 2>&1; then
   if [ "$is_draft" != "true" ]; then
     fail "release $tag is already published; refusing to replace assets"
   fi
+  gh release edit "$tag" --title "$tag" "${release_note_args[@]}"
   gh release upload "$tag" "${artifacts[@]}" --clobber
 else
   gh release create "$tag" \

--- a/scripts/test-release-publish.sh
+++ b/scripts/test-release-publish.sh
@@ -73,8 +73,8 @@ case "${2:-}" in
         ;;
     esac
     ;;
-  upload | create)
-    ;;
+	upload | create | edit)
+		;;
   *)
     echo "unexpected gh release command: $*" >&2
     exit 2
@@ -109,6 +109,7 @@ expect_log "release create v1.0.0 $artifact_arm $artifact_intel $checksums --dra
 : >"$tmp_dir/gh.log"
 run_publish draft
 expect_log "release view v1.0.0 --json isDraft --jq .isDraft"
+expect_log "release edit v1.0.0 --title v1.0.0 --notes-file $notes_file"
 expect_log "release upload v1.0.0 $artifact_arm $artifact_intel $checksums --clobber"
 
 expect_failure "release v1.0.0 is already published; refusing to replace assets" run_publish published


### PR DESCRIPTION
## Summary
- refresh existing draft release title and notes before replacing assets
- keep the published-release guard before any edit or upload
- extend the fake-gh release publish test to assert the existing-draft edit path uses the changelog-backed notes file

Fixes #213.

## Verification
- mise exec -- bash scripts/test-release-publish.sh
- mise run lint:shell
- mise format
- mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5
- mise run test
- mise run test:race
- mise run build
- mise run test:smoke
- mise run lint
- mise run lint:smart

Note: parallel broad test/lint attempts hit the known approver health-check timeout; sequential reruns passed.