### PR TITLE
ASR-081: Preserve untrusted app bundles during uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ curl -fsSL "$base_url/${version}/uninstall.sh" | sh
 By default uninstall removes the app, CLI symlink, skill symlink, and known
 application support files, but leaves `~/Library/Logs/agent-secret` audit logs
 in place. Set `AGENT_SECRET_REMOVE_AUDIT_LOGS=1` to remove those logs too.
+App bundle removal is gated by the expected bundle identifiers and Developer ID
+Team ID. If the target app cannot be verified, uninstall leaves it in place
+unless `AGENT_SECRET_FORCE_REMOVE_UNTRUSTED_APP=1` is set.
 To pin an uninstall to a specific installed release, set `version` to that
 release tag instead of resolving the latest release.
 Custom app, command, skill, support, or audit paths require

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -177,7 +177,9 @@ The uninstall script should:
 
 1. Stop the per-user daemon if it is running.
 2. Remove the Agent Secret CLI symlink if it points at an Agent Secret app.
-3. Remove `Agent Secret.app` from the configured app directory.
+3. Remove `Agent Secret.app` from the configured app directory only after the
+   app bundle, daemon helper bundle, bundled CLI, and Developer ID Team ID match
+   the expected production identity.
 4. Remove the Agent Secret skill symlink if it points at the app bundle.
 5. Remove `~/Library/Application Support/agent-secret`.
 6. Leave audit logs in place unless explicitly requested.
@@ -189,6 +191,7 @@ AGENT_SECRET_APP_DIR="$HOME/Applications" uninstall.sh
 AGENT_SECRET_BIN_DIR="$HOME/.local/bin" uninstall.sh
 AGENT_SECRET_SKILLS_DIR="$HOME/.agents/skills" uninstall.sh
 AGENT_SECRET_REMOVE_AUDIT_LOGS=1 uninstall.sh
+AGENT_SECRET_FORCE_REMOVE_UNTRUSTED_APP=1 uninstall.sh
 ```
 
 For isolated tests, `AGENT_SECRET_SUPPORT_DIR` and `AGENT_SECRET_AUDIT_DIR`
@@ -196,7 +199,8 @@ may point at temporary `agent-secret` directories only when
 `AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1` is also set. The script refuses
 empty, relative, broad, symlinked, and non-`agent-secret` support or audit
 directory targets. The same custom-path guard applies to app, command, and
-skill destination roots.
+skill destination roots. Unsigned or otherwise unverified app bundles are left
+in place unless `AGENT_SECRET_FORCE_REMOVE_UNTRUSTED_APP=1` is set explicitly.
 
 Audit logs are durable by design and should require an explicit separate
 removal command:

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -239,11 +239,20 @@ func (c *Client) setReadDeadline(ctx context.Context) error {
 }
 
 func (c *Client) setContextDeadline(ctx context.Context, set func(time.Time) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return nil
 	}
-	return set(deadline)
+	if err := set(deadline); err != nil {
+		if ctxErr := contextErrorAfterIOError(ctx, err); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
+	return nil
 }
 
 func (c *Client) clearDeadlines() {

--- a/scripts/test-uninstall.sh
+++ b/scripts/test-uninstall.sh
@@ -52,6 +52,23 @@ make_symlink() {
   ln -s "$target" "$link"
 }
 
+make_untrusted_app() {
+  local app="$1"
+
+  mkdir -p "$app/Contents/Resources/bin"
+  printf 'keep\n' >"$app/keep.txt"
+  cat >"$app/Contents/Resources/bin/agent-secret" <<'SCRIPT'
+#!/bin/sh
+printf 'fake-bundled-agent-secret' >>"$AGENT_SECRET_UNINSTALL_TEST_LOG"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"$AGENT_SECRET_UNINSTALL_TEST_LOG"
+done
+printf '\n' >>"$AGENT_SECRET_UNINSTALL_TEST_LOG"
+exit 0
+SCRIPT
+  chmod 755 "$app/Contents/Resources/bin/agent-secret"
+}
+
 custom_guard_rejects_override() {
   local run_dir="$tmp_dir/custom-guard"
   local support="$run_dir/important/agent-secret"
@@ -223,6 +240,7 @@ safe_custom_paths_remove_only_known_files() {
     safe \
     HOME="$home" \
     AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_FORCE_REMOVE_UNTRUSTED_APP=1 \
     AGENT_SECRET_REMOVE_AUDIT_LOGS=1 \
     AGENT_SECRET_APP_DIR="$app_dir" \
     AGENT_SECRET_BIN_DIR="$bin_dir" \
@@ -235,6 +253,75 @@ safe_custom_paths_remove_only_known_files() {
       fail "safe uninstall left expected removed path in place: $path"
     fi
   done
+}
+
+untrusted_app_is_left_in_place_by_default() {
+  local run_dir="$tmp_dir/untrusted-app-default"
+  local home="$run_dir/home"
+  local app_dir="$run_dir/apps"
+  local app="$app_dir/Agent Secret.app"
+  local bin_dir="$run_dir/bin"
+  local skills_dir="$run_dir/skills"
+  local support="$run_dir/support/agent-secret"
+  local log="$run_dir/uninstall.log"
+
+  mkdir -p "$home" "$bin_dir" "$skills_dir" "$support"
+  : >"$log"
+  make_untrusted_app "$app"
+
+  run_uninstall \
+    untrusted-app-default \
+    HOME="$home" \
+    AGENT_SECRET_NO_STOP_DAEMON=0 \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_APP_DIR="$app_dir" \
+    AGENT_SECRET_BIN_DIR="$bin_dir" \
+    AGENT_SECRET_SKILLS_DIR="$skills_dir" \
+    AGENT_SECRET_SUPPORT_DIR="$support" \
+    AGENT_SECRET_UNINSTALL_TEST_LOG="$log"
+
+  if [ ! -f "$app/keep.txt" ]; then
+    fail "uninstaller removed an untrusted app bundle by default"
+  fi
+  if ! grep -F "leaving unverified Agent Secret.app in place" "$run_dir/stderr" >/dev/null; then
+    fail "uninstaller did not report preserving untrusted app: $(cat "$run_dir/stderr")"
+  fi
+  if grep -F "fake-bundled-agent-secret daemon stop" "$log" >/dev/null; then
+    fail "uninstaller executed untrusted bundled agent-secret"
+  fi
+}
+
+force_removes_untrusted_app_explicitly() {
+  local run_dir="$tmp_dir/untrusted-app-force"
+  local home="$run_dir/home"
+  local app_dir="$run_dir/apps"
+  local app="$app_dir/Agent Secret.app"
+  local bin_dir="$run_dir/bin"
+  local skills_dir="$run_dir/skills"
+  local support="$run_dir/support/agent-secret"
+  local log="$run_dir/uninstall.log"
+
+  mkdir -p "$home" "$bin_dir" "$skills_dir" "$support"
+  : >"$log"
+  make_untrusted_app "$app"
+
+  run_uninstall \
+    untrusted-app-force \
+    HOME="$home" \
+    AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS=1 \
+    AGENT_SECRET_FORCE_REMOVE_UNTRUSTED_APP=1 \
+    AGENT_SECRET_APP_DIR="$app_dir" \
+    AGENT_SECRET_BIN_DIR="$bin_dir" \
+    AGENT_SECRET_SKILLS_DIR="$skills_dir" \
+    AGENT_SECRET_SUPPORT_DIR="$support" \
+    AGENT_SECRET_UNINSTALL_TEST_LOG="$log"
+
+  if [ -e "$app" ]; then
+    fail "explicit force uninstall left untrusted app bundle in place"
+  fi
+  if ! grep -F "force-removing unverified Agent Secret.app" "$run_dir/stderr" >/dev/null; then
+    fail "force uninstall did not report forced app removal: $(cat "$run_dir/stderr")"
+  fi
 }
 
 untrusted_existing_cli_is_not_used_for_daemon_stop() {
@@ -381,6 +468,9 @@ SCRIPT
   if grep -F "fake-bundled-agent-secret daemon stop" "$log" >/dev/null; then
     fail "uninstaller trusted fake app and executed bundled agent-secret"
   fi
+  if [ ! -d "$app" ]; then
+    fail "uninstaller removed app after refusing PATH-provided codesign trust"
+  fi
 }
 
 custom_guard_rejects_override
@@ -390,6 +480,8 @@ dangerous_destination_paths_are_rejected_even_with_guard
 symlinked_parent_dirs_are_rejected
 symlinked_dirs_are_rejected
 safe_custom_paths_remove_only_known_files
+untrusted_app_is_left_in_place_by_default
+force_removes_untrusted_app_explicitly
 untrusted_existing_cli_is_not_used_for_daemon_stop
 fake_path_codesign_is_not_used_for_trust_checks
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -10,6 +10,7 @@ skills_dir="${AGENT_SECRET_SKILLS_DIR:-$default_skills_dir}"
 remove_audit_logs="${AGENT_SECRET_REMOVE_AUDIT_LOGS:-0}"
 no_stop_daemon="${AGENT_SECRET_NO_STOP_DAEMON:-0}"
 allow_custom_uninstall_paths="${AGENT_SECRET_ALLOW_CUSTOM_UNINSTALL_PATHS:-0}"
+force_remove_untrusted_app="${AGENT_SECRET_FORCE_REMOVE_UNTRUSTED_APP:-0}"
 expected_team_id="B6L7QLWTZW"
 expected_app_bundle_id="com.kovyrin.agent-secret"
 expected_daemon_bundle_id="com.kovyrin.agent-secret.daemon"
@@ -24,6 +25,13 @@ fail() {
   echo "agent-secret uninstall: $*" >&2
   exit 1
 }
+
+case "$force_remove_untrusted_app" in
+  0 | 1) ;;
+  *)
+    fail "AGENT_SECRET_FORCE_REMOVE_UNTRUSTED_APP must be 0 or 1"
+    ;;
+esac
 
 plist_value() {
   plist="$1"
@@ -57,7 +65,7 @@ team_id_matches() {
   [ "$team_id" = "$expected_team_id" ]
 }
 
-existing_app_is_trusted_for_stop() {
+existing_app_is_trusted() {
   daemon_app="$target_app/Contents/Library/Helpers/AgentSecretDaemon.app"
   cli="$target_app/Contents/Resources/bin/agent-secret"
 
@@ -83,11 +91,31 @@ stop_existing_daemon() {
     return
   fi
 
-  if existing_app_is_trusted_for_stop; then
+  if existing_app_is_trusted; then
     "$existing" daemon stop >/dev/null 2>&1 || true
   else
     echo "agent-secret uninstall: skipping daemon stop because existing Agent Secret.app could not be verified" >&2
   fi
+}
+
+remove_app_bundle() {
+  echo "Removing $target_app"
+  if [ ! -d "$target_app" ]; then
+    return
+  fi
+
+  if existing_app_is_trusted; then
+    rm -rf "$target_app"
+    return
+  fi
+
+  if [ "$force_remove_untrusted_app" = "1" ]; then
+    echo "agent-secret uninstall: force-removing unverified Agent Secret.app: $target_app" >&2
+    rm -rf "$target_app"
+    return
+  fi
+
+  echo "agent-secret uninstall: leaving unverified Agent Secret.app in place: $target_app" >&2
 }
 
 remove_cli_link() {
@@ -304,9 +332,7 @@ skill_link="$skills_dir/agent-secret"
 stop_existing_daemon
 remove_cli_link
 remove_skill_link
-
-echo "Removing $target_app"
-rm -rf "$target_app"
+remove_app_bundle
 
 remove_known_support_dir
 


### PR DESCRIPTION
## Summary
- reuse the uninstall app identity check before deleting Agent Secret.app
- leave unverified app bundles in place by default and add an explicit force env for test/dev cleanup
- add uninstall regressions for default preservation, explicit forced removal, and refusing PATH-provided codesign trust
- document the uninstall trust gate and force escape hatch

Fixes #214.

## Verification
- mise exec -- bash scripts/test-uninstall.sh
- npx --yes markdownlint-cli README.md docs/macos-distribution-plan.md
- mise run lint:shell
- mise run test
- mise run build
- mise run test:smoke
- mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5
- mise run test:race
- mise run lint
- mise run lint:smart

Note: parallel race/lint attempts hit the known approver health-check timeout; sequential reruns passed.