### PR TITLE
ASR-083: Require runtime Team ID for bundled trust

### DIFF
--- a/approver/Sources/AgentSecretApprover/TrustedDaemonPeerValidator.swift
+++ b/approver/Sources/AgentSecretApprover/TrustedDaemonPeerValidator.swift
@@ -54,6 +54,7 @@ import Foundation
             "Agent Secret"
         ]
         private static let expectedTeamIDKey: String = "AgentSecretExpectedTeamID"
+        private static let developmentExpectedTeamID: String = "-"
 
         private let expectedTeamID: String
         private let signatureChecker: DaemonCodeSignatureChecking
@@ -78,6 +79,10 @@ import Foundation
                 }
                 return TrustedExecutable(path: normalized, fileIdentity: identity)
             }
+        }
+
+        private static func isInsideAppBundle(_ path: String) -> Bool {
+            containingAppBundlePath(path) != nil
         }
 
         static func defaultForCurrentProcess() -> Self {
@@ -178,7 +183,12 @@ import Foundation
             }
 
             try trusted.validateCurrentFile()
-            if !expectedTeamID.isEmpty {
+            if expectedTeamID.isEmpty, Self.isInsideAppBundle(trusted.path) {
+                throw SocketDaemonClientError.untrustedDaemon(
+                    "expected Developer ID Team ID is required for daemon signature validation"
+                )
+            }
+            if !expectedTeamID.isEmpty, expectedTeamID != Self.developmentExpectedTeamID {
                 let staticTeamID = try signatureChecker.staticCodeTeamID(for: trusted.path)
                 guard staticTeamID == expectedTeamID else {
                     throw SocketDaemonClientError.untrustedDaemon("daemon Team ID does not match")

--- a/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTeamIDTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTeamIDTests.swift
@@ -1,0 +1,98 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+#if canImport(Darwin)
+    import Darwin
+
+    final class DaemonPeerValidationTeamIDTests: XCTestCase {
+        private final class FakeSignatureChecker: DaemonCodeSignatureChecking {
+            var staticTeamIDResult: Result<String, Error> = .success("TEAMID")
+            var processTeamIDResult: Result<String, Error> = .success("TEAMID")
+            private(set) var staticPaths: [String] = []
+            private(set) var processPIDs: [pid_t] = []
+
+            func staticCodeTeamID(for path: String) throws -> String {
+                staticPaths.append(path)
+                return try staticTeamIDResult.get()
+            }
+
+            func processTeamID(for pid: pid_t) throws -> String {
+                processPIDs.append(pid)
+                return try processTeamIDResult.get()
+            }
+
+            deinit {
+                /* Required by SwiftLint. */
+            }
+        }
+
+        private static func makeAppBundleExecutable(testCase: XCTestCase) throws -> String {
+            let appDirectory = URL(fileURLWithPath: "/tmp")
+                .appendingPathComponent("agent-secret-swift-app-\(UUID().uuidString)")
+                .appendingPathExtension("app")
+            let executableDirectory = appDirectory
+                .appendingPathComponent("Contents")
+                .appendingPathComponent("MacOS")
+            try FileManager.default.createDirectory(at: executableDirectory, withIntermediateDirectories: true)
+            let executable = executableDirectory.appendingPathComponent("Agent Secret")
+            try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+            testCase.addTeardownBlock {
+                try? FileManager.default.removeItem(at: appDirectory)
+            }
+            return executable.path
+        }
+
+        func testRejectsBundledDaemonWhenExpectedTeamIDIsMissing() throws {
+            let executable = try Self.makeAppBundleExecutable(testCase: self)
+            let checker = FakeSignatureChecker()
+            let validator = TrustedDaemonPeerValidator(
+                expectedExecutablePaths: [executable],
+                expectedTeamID: "",
+                signatureChecker: checker
+            )
+            let info = DaemonPeerInfo(
+                uid: getuid(),
+                gid: getgid(),
+                pid: getpid(),
+                executablePath: executable
+            )
+
+            XCTAssertThrowsError(try validator.validateDaemonPeer(info)) { error in
+                XCTAssertEqual(
+                    error as? SocketDaemonClientError,
+                    .untrustedDaemon("expected Developer ID Team ID is required for daemon signature validation")
+                )
+            }
+            XCTAssertTrue(checker.staticPaths.isEmpty)
+            XCTAssertTrue(checker.processPIDs.isEmpty)
+        }
+
+        func testAllowsDevelopmentTeamIDSentinelForBundledDaemon() throws {
+            let executable = try Self.makeAppBundleExecutable(testCase: self)
+            let checker = FakeSignatureChecker()
+            checker.staticTeamIDResult = .failure(SocketDaemonClientError.untrustedDaemon("static check called"))
+            checker.processTeamIDResult = .failure(SocketDaemonClientError.untrustedDaemon("process check called"))
+            let validator = TrustedDaemonPeerValidator(
+                expectedExecutablePaths: [executable],
+                expectedTeamID: "-",
+                signatureChecker: checker
+            )
+            let info = DaemonPeerInfo(
+                uid: getuid(),
+                gid: getgid(),
+                pid: getpid(),
+                executablePath: executable
+            )
+
+            XCTAssertNoThrow(try validator.validateDaemonPeer(info))
+            XCTAssertTrue(checker.staticPaths.isEmpty)
+            XCTAssertTrue(checker.processPIDs.isEmpty)
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif

--- a/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/DaemonPeerValidationTests.swift
@@ -118,7 +118,8 @@ import XCTest
 
             let info = try DaemonPeerInspector.inspect(socketFileDescriptor: descriptors[0])
             let validator = try TrustedDaemonPeerValidator(
-                expectedExecutablePaths: [Self.currentExecutablePath()]
+                expectedExecutablePaths: [Self.currentExecutablePath()],
+                expectedTeamID: "-"
             )
 
             XCTAssertNoThrow(try validator.validateDaemonPeer(info))
@@ -126,7 +127,8 @@ import XCTest
 
         func testTrustedDaemonValidatorRejectsDifferentUID() throws {
             let validator = try TrustedDaemonPeerValidator(
-                expectedExecutablePaths: [Self.currentExecutablePath()]
+                expectedExecutablePaths: [Self.currentExecutablePath()],
+                expectedTeamID: "-"
             )
             let info = try Self.currentPeerInfo(uid: getuid() + 1)
 
@@ -140,7 +142,8 @@ import XCTest
 
         func testTrustedDaemonValidatorRejectsDifferentGID() throws {
             let validator = try TrustedDaemonPeerValidator(
-                expectedExecutablePaths: [Self.currentExecutablePath()]
+                expectedExecutablePaths: [Self.currentExecutablePath()],
+                expectedTeamID: "-"
             )
             let info = try Self.currentPeerInfo(gid: getgid() + 1)
 
@@ -154,7 +157,8 @@ import XCTest
 
         func testTrustedDaemonValidatorRejectsMissingPID() throws {
             let validator = try TrustedDaemonPeerValidator(
-                expectedExecutablePaths: [Self.currentExecutablePath()]
+                expectedExecutablePaths: [Self.currentExecutablePath()],
+                expectedTeamID: "-"
             )
             let info = try Self.currentPeerInfo(pid: 0)
 
@@ -243,7 +247,8 @@ import XCTest
             defer { releaseConnection.signal() }
 
             let validator = try TrustedDaemonPeerValidator(
-                expectedExecutablePaths: [Self.currentExecutablePath()]
+                expectedExecutablePaths: [Self.currentExecutablePath()],
+                expectedTeamID: "-"
             )
             let transport = try UnixSocketLineTransport(
                 path: server.path,

--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -554,8 +554,20 @@ func validateApproverPeer(expected ExpectedApprover, got peercred.Info) error {
 	if expected.PID != 0 && got.PID != expected.PID {
 		return fmt.Errorf("%w: pid %d != %d", ErrApproverPeerMismatch, got.PID, expected.PID)
 	}
+	expectedTeamID := strings.TrimSpace(expected.ExpectedTeamID)
+	enforceTeamID := false
+	if expected.VerifySignature {
+		var err error
+		expectedTeamID, enforceTeamID, err = expectedTeamIDForSignatureValidation(
+			expectedTeamID,
+			ErrApproverPeerMismatch,
+		)
+		if err != nil {
+			return err
+		}
+	}
 	if expected.ExecutablePath == "" {
-		if expected.VerifySignature && strings.TrimSpace(expected.ExpectedTeamID) != "" {
+		if enforceTeamID {
 			return fmt.Errorf("%w: executable path is unavailable for signature validation", ErrApproverPeerMismatch)
 		}
 		return nil
@@ -571,18 +583,15 @@ func validateApproverPeer(expected ExpectedApprover, got peercred.Info) error {
 	if gotPath != expectedPath {
 		return fmt.Errorf("%w: executable %q != %q", ErrApproverPeerMismatch, gotPath, expectedPath)
 	}
-	if expected.VerifySignature {
-		expectedTeamID := strings.TrimSpace(expected.ExpectedTeamID)
-		if expectedTeamID != "" {
-			if err := validatePeerSignature(
-				got,
-				expectedPath,
-				expectedTeamID,
-				expected.signatureVerifier,
-				ErrApproverPeerMismatch,
-			); err != nil {
-				return err
-			}
+	if enforceTeamID {
+		if err := validatePeerSignature(
+			got,
+			expectedPath,
+			expectedTeamID,
+			expected.signatureVerifier,
+			ErrApproverPeerMismatch,
+		); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -1064,6 +1064,55 @@ func TestDefaultApproverIdentityPolicyUsesBuildConfiguredTeamID(t *testing.T) {
 	}
 }
 
+func TestBundleApproverIdentityPolicyRejectsMissingTeamIDWhenSignatureVerificationEnabled(t *testing.T) {
+	t.Parallel()
+
+	executable := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, DefaultApproverExecutable)
+	_, err := (BundleApproverIdentityPolicy{VerifySignature: true}).ValidateApproverExecutable(executable)
+	if !errors.Is(err, ErrApproverIdentity) {
+		t.Fatalf("expected approver identity error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "expected Developer ID Team ID is required") {
+		t.Fatalf("error = %q, want missing Team ID context", err.Error())
+	}
+}
+
+func TestApproverPeerValidationRejectsMissingTeamIDWhenSignatureVerificationEnabled(t *testing.T) {
+	t.Parallel()
+
+	err := validateApproverPeer(
+		ExpectedApprover{
+			PID:             os.Getpid(),
+			ExecutablePath:  currentExecutable(t),
+			VerifySignature: true,
+		},
+		peerInfoForTest(t, os.Getpid(), currentExecutable(t)),
+	)
+	if !errors.Is(err, ErrApproverPeerMismatch) {
+		t.Fatalf("expected approver peer mismatch, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "expected Developer ID Team ID is required") {
+		t.Fatalf("error = %q, want missing Team ID context", err.Error())
+	}
+}
+
+func TestApproverPeerValidationAllowsExplicitDevelopmentTeamIDSentinel(t *testing.T) {
+	t.Parallel()
+
+	err := validateApproverPeer(
+		ExpectedApprover{
+			PID:             os.Getpid(),
+			ExecutablePath:  currentExecutable(t),
+			ExpectedTeamID:  developmentExpectedTeamID,
+			VerifySignature: true,
+		},
+		peerInfoForTest(t, os.Getpid(), currentExecutable(t)),
+	)
+	if err != nil {
+		t.Fatalf("explicit development Team ID sentinel returned error: %v", err)
+	}
+}
+
 func TestBundleApproverIdentityPolicyRejectsWrongBundleID(t *testing.T) {
 	t.Parallel()
 
@@ -1071,6 +1120,19 @@ func TestBundleApproverIdentityPolicyRejectsWrongBundleID(t *testing.T) {
 	_, err := (BundleApproverIdentityPolicy{VerifySignature: false}).ValidateApproverExecutable(executable)
 	if !errors.Is(err, ErrApproverIdentity) {
 		t.Fatalf("expected approver identity error, got %v", err)
+	}
+}
+
+func TestBundleApproverIdentityPolicyRejectsWrongExecutableName(t *testing.T) {
+	t.Parallel()
+
+	executable := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, "Fake Approver")
+	_, err := (BundleApproverIdentityPolicy{VerifySignature: false}).ValidateApproverExecutable(executable)
+	if !errors.Is(err, ErrApproverIdentity) {
+		t.Fatalf("expected approver identity error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "executable") {
+		t.Fatalf("error = %q, want executable context", err.Error())
 	}
 }
 

--- a/internal/daemon/approver_identity.go
+++ b/internal/daemon/approver_identity.go
@@ -16,6 +16,7 @@ import (
 const (
 	DefaultApproverBundleID   = "com.kovyrin.agent-secret"
 	DefaultApproverExecutable = "Agent Secret"
+	developmentExpectedTeamID = "-"
 )
 
 //nolint:gochecknoglobals // Release builds set this with -ldflags to bind local helpers to the signing Team ID.
@@ -54,6 +55,20 @@ func DefaultApproverIdentityPolicy() BundleApproverIdentityPolicy {
 
 func defaultExpectedTeamID() string {
 	return strings.TrimSpace(defaultDeveloperIDTeamID)
+}
+
+func expectedTeamIDForSignatureValidation(expectedTeamID string, errKind error) (string, bool, error) {
+	if errKind == nil {
+		errKind = ErrApproverIdentity
+	}
+	expectedTeamID = strings.TrimSpace(expectedTeamID)
+	if expectedTeamID == "" {
+		return "", false, fmt.Errorf("%w: expected Developer ID Team ID is required for signature validation", errKind)
+	}
+	if expectedTeamID == developmentExpectedTeamID {
+		return expectedTeamID, false, nil
+	}
+	return expectedTeamID, true, nil
 }
 
 func (p BundleApproverIdentityPolicy) ValidateApproverExecutable(path string) (ApproverIdentity, error) {
@@ -100,14 +115,20 @@ func (p BundleApproverIdentityPolicy) ValidateApproverExecutable(path string) (A
 	}
 
 	teamID := ""
+	expectedTeamID := strings.TrimSpace(p.ExpectedTeamID)
 	if p.VerifySignature {
+		var enforceTeamID bool
+		expectedTeamID, enforceTeamID, err = expectedTeamIDForSignatureValidation(expectedTeamID, ErrApproverIdentity)
+		if err != nil {
+			return ApproverIdentity{}, err
+		}
 		teamID, err = verifyCodeSignature(bundlePath)
 		if err != nil {
 			return ApproverIdentity{}, err
 		}
-	}
-	if p.ExpectedTeamID != "" && teamID != p.ExpectedTeamID {
-		return ApproverIdentity{}, fmt.Errorf("%w: team id %q != %q", ErrApproverIdentity, teamID, p.ExpectedTeamID)
+		if enforceTeamID && teamID != expectedTeamID {
+			return ApproverIdentity{}, fmt.Errorf("%w: team id %q != %q", ErrApproverIdentity, teamID, expectedTeamID)
+		}
 	}
 
 	return ApproverIdentity{
@@ -115,7 +136,7 @@ func (p BundleApproverIdentityPolicy) ValidateApproverExecutable(path string) (A
 		BundlePath:      bundlePath,
 		BundleID:        bundleID,
 		TeamID:          teamID,
-		ExpectedTeamID:  p.ExpectedTeamID,
+		ExpectedTeamID:  expectedTeamID,
 		VerifySignature: p.VerifySignature,
 	}, nil
 }

--- a/internal/daemon/trusted_client.go
+++ b/internal/daemon/trusted_client.go
@@ -224,10 +224,25 @@ func (e trustedExecutable) validatePeer(
 			return fmt.Errorf("%w: executable %q is outside expected app bundle %q", errKind, path, e.bundlePath)
 		}
 	}
-	if expectedTeamID != "" && verifySignature {
-		return validatePeerSignature(info, path, expectedTeamID, verifier, errKind)
+	if !verifySignature || (expectedTeamID == "" && !e.isBundledPath(path)) {
+		return nil
+	}
+	requiredTeamID, enforceTeamID, err := expectedTeamIDForSignatureValidation(expectedTeamID, errKind)
+	if err != nil {
+		return err
+	}
+	if enforceTeamID {
+		return validatePeerSignature(info, path, requiredTeamID, verifier, errKind)
 	}
 	return nil
+}
+
+func (e trustedExecutable) isBundledPath(path string) bool {
+	if e.bundlePath != "" {
+		return true
+	}
+	_, ok := containingAppBundlePath(path)
+	return ok
 }
 
 func validatePeerSignature(

--- a/internal/daemon/trusted_client_test.go
+++ b/internal/daemon/trusted_client_test.go
@@ -163,6 +163,76 @@ func TestTrustedExecutableValidatorRejectsMissingPIDForSignatureValidation(t *te
 	}
 }
 
+func TestTrustedExecutableValidatorRejectsBundledExecutableWhenTeamIDMissing(t *testing.T) {
+	t.Parallel()
+
+	trusted := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, DefaultApproverExecutable)
+	verifier := &recordingSignatureVerifier{
+		pathTeamID:    "TEAMID",
+		processTeamID: "TEAMID",
+	}
+	validator := TrustedExecutableValidator{
+		set: newTrustedExecutableSetWithVerifier([]string{trusted}, "", ErrUntrustedClient, verifier, true),
+	}
+
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted, PID: 4321})
+	if !errors.Is(err, ErrUntrustedClient) {
+		t.Fatalf("expected ErrUntrustedClient, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "expected Developer ID Team ID is required") {
+		t.Fatalf("error = %q, want missing Team ID context", err.Error())
+	}
+	if len(verifier.paths) != 0 || len(verifier.pids) != 0 {
+		t.Fatalf("signature verifier called despite missing expected team: paths=%v pids=%v", verifier.paths, verifier.pids)
+	}
+}
+
+func TestTrustedExecutableValidatorAllowsBundledExecutableWithDevelopmentTeamIDSentinel(t *testing.T) {
+	t.Parallel()
+
+	trusted := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, DefaultApproverExecutable)
+	verifier := &recordingSignatureVerifier{
+		pathErr:    errors.New("static verifier should not be called"),
+		processErr: errors.New("process verifier should not be called"),
+	}
+	validator := TrustedExecutableValidator{
+		set: newTrustedExecutableSetWithVerifier(
+			[]string{trusted},
+			developmentExpectedTeamID,
+			ErrUntrustedClient,
+			verifier,
+			true,
+		),
+	}
+
+	if err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted, PID: 4321}); err != nil {
+		t.Fatalf("ValidateExecPeer returned error for development Team ID sentinel: %v", err)
+	}
+	if len(verifier.paths) != 0 || len(verifier.pids) != 0 {
+		t.Fatalf("signature verifier called for development Team ID sentinel: paths=%v pids=%v", verifier.paths, verifier.pids)
+	}
+}
+
+func TestTrustedExecutableValidatorSkipsSignatureWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	trusted := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, DefaultApproverExecutable)
+	verifier := &recordingSignatureVerifier{
+		pathErr:    errors.New("static verifier should not be called"),
+		processErr: errors.New("process verifier should not be called"),
+	}
+	validator := TrustedExecutableValidator{
+		set: newTrustedExecutableSetWithVerifier([]string{trusted}, "", ErrUntrustedClient, verifier, false),
+	}
+
+	if err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted, PID: 4321}); err != nil {
+		t.Fatalf("ValidateExecPeer returned error when signature verification disabled: %v", err)
+	}
+	if len(verifier.paths) != 0 || len(verifier.pids) != 0 {
+		t.Fatalf("signature verifier called when verification disabled: paths=%v pids=%v", verifier.paths, verifier.pids)
+	}
+}
+
 func TestTrustedExecutableValidatorWrapsPeerProcessSignatureFailure(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -33,7 +33,7 @@ version="${AGENT_SECRET_VERSION:-$AGENT_SECRET_DEFAULT_VERSION}"
 bundle_version="${AGENT_SECRET_BUNDLE_VERSION:-$AGENT_SECRET_DEFAULT_BUNDLE_VERSION}"
 codesign_identity="${AGENT_SECRET_CODESIGN_IDENTITY:-"-"}"
 codesign_entitlements="${AGENT_SECRET_CODESIGN_ENTITLEMENTS:-}"
-approver_team_id=""
+approver_team_id="-"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -222,8 +222,8 @@ if [[ "$codesign_identity" != "-" ]]; then
     echo "build-app-bundle: codesign identity must end with a Team ID in parentheses" >&2
     exit 1
   }
-  go_build_flags+=(-ldflags "-X github.com/kovyrin/agent-secret/internal/daemon.defaultDeveloperIDTeamID=$approver_team_id")
 fi
+go_build_flags+=(-ldflags "-X github.com/kovyrin/agent-secret/internal/daemon.defaultDeveloperIDTeamID=$approver_team_id")
 "$tool_go" build "${go_build_flags[@]}" -o "$tmp_dir/agent-secret" ./cmd/agent-secret
 "$tool_go" build "${go_build_flags[@]}" -o "$tmp_dir/agent-secretd" ./cmd/agent-secretd
 


### PR DESCRIPTION
## Summary

- fail closed when bundled/signature-verified trust paths do not have an expected Developer ID Team ID
- add explicit `-` development sentinel for ad-hoc/local bundles instead of treating empty as safe
- bind ad-hoc app bundle builds to the sentinel and cover Go + Swift peer-validation paths with tests

## Verification

- `mise exec -- go test ./internal/daemon -run 'TestBundleApproverIdentityPolicyRejectsMissingTeamIDWhenSignatureVerificationEnabled|TestApproverPeerValidationRejectsMissingTeamIDWhenSignatureVerificationEnabled|TestApproverPeerValidationAllowsExplicitDevelopmentTeamIDSentinel|TestTrustedExecutableValidatorRejectsBundledExecutableWhenTeamIDMissing|TestTrustedExecutableValidatorAllowsBundledExecutableWithDevelopmentTeamIDSentinel|TestTrustedExecutableValidatorVerifiesPeerProcessSignature|TestSocketApproverRejectsFetchFromWrongApproverProcessSignature' -count=1`\n- `cd approver && mise exec -- swift test --filter 'DaemonPeerValidation'`\n- `mise exec -- env AGENT_SECRET_IN_MISE=1 scripts/build-app-bundle.sh --output /tmp/agent-secret-asr083-build >/tmp/agent-secret-asr083-build.log && /usr/libexec/PlistBuddy -c 'Print :AgentSecretExpectedTeamID' '/tmp/agent-secret-asr083-build/Agent Secret.app/Contents/Info.plist' && /tmp/agent-secret-asr083-build/'Agent Secret.app'/Contents/Resources/bin/agent-secret --help >/dev/null`\n- `mise run lint:go`\n- `mise run test:race`\n- `mise run build`\n- `mise run test`\n- `mise run test:smoke`\n- `mise run lint`\n- `git diff --check`\n\nCloses #221