### PR TITLE
ASR-085: Guard custom codesign keychain paths

### DIFF
--- a/scripts/import-codesign-certificate.sh
+++ b/scripts/import-codesign-certificate.sh
@@ -24,13 +24,17 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
+die() {
+  echo "import-codesign-certificate: $*" >&2
+  exit 1
+}
+
 require_tool() {
   local name="$1"
   local path="$2"
 
   if [[ ! -x "$path" ]]; then
-    echo "import-codesign-certificate: required command not found or not executable: $name ($path)" >&2
-    exit 1
+    die "required command not found or not executable: $name ($path)"
   fi
 }
 
@@ -64,11 +68,94 @@ append_keychain_to_search_list() {
   "$tool_security" list-keychains -d user -s "$keychain_path" "${existing_keychains[@]}"
 }
 
+strip_trailing_slashes() {
+  local value="$1"
+
+  while [[ "$value" != "/" && "${value%/}" != "$value" ]]; do
+    value="${value%/}"
+  done
+  printf '%s\n' "$value"
+}
+
+is_system_root_alias() {
+  case "$1" in
+    /etc | /tmp | /var)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+reject_symlinked_parent_dirs() {
+  local label="$1"
+  local path="$2"
+  local current="${path%/*}"
+  local next=""
+
+  if [[ "$current" == "$path" || "$current" == "" ]]; then
+    return
+  fi
+
+  while [[ "$current" != "/" ]]; do
+    if [[ -L "$current" ]] && ! is_system_root_alias "$current"; then
+      die "$label must not contain symlinked parent directories: $current"
+    fi
+
+    next="${current%/*}"
+    if [[ "$next" == "$current" || "$next" == "" ]]; then
+      current="/"
+    else
+      current="$next"
+    fi
+  done
+}
+
+validate_keychain_path() {
+  local path="$1"
+  local trusted_dir="$2"
+  local file_name="${path##*/}"
+
+  if [[ "$path" == "" ]]; then
+    die "AGENT_SECRET_CODESIGN_KEYCHAIN_PATH is empty"
+  fi
+  case "$path" in
+    /*) ;;
+    *)
+      die "AGENT_SECRET_CODESIGN_KEYCHAIN_PATH must be absolute: $path"
+      ;;
+  esac
+  case "$path" in
+    */../* | */.. | */./* | */.)
+      die "AGENT_SECRET_CODESIGN_KEYCHAIN_PATH must not contain dot segments: $path"
+      ;;
+  esac
+  case "$file_name" in
+    agent-secret-codesign.keychain-db | agent-secret-codesign-*.keychain-db) ;;
+    *)
+      die "AGENT_SECRET_CODESIGN_KEYCHAIN_PATH filename must be agent-secret-codesign*.keychain-db: $path"
+      ;;
+  esac
+  case "$path" in
+    "$trusted_dir"/*) ;;
+    *)
+      die "AGENT_SECRET_CODESIGN_KEYCHAIN_PATH must be under trusted temp directory $trusted_dir: $path"
+      ;;
+  esac
+  reject_symlinked_parent_dirs "AGENT_SECRET_CODESIGN_KEYCHAIN_PATH" "$path"
+}
+
 require_tool base64 "$tool_base64"
 require_tool security "$tool_security"
 require_tool uuidgen "$tool_uuidgen"
 require_tool mktemp "$tool_mktemp"
 require_tool rm "$tool_rm"
+
+trusted_keychain_dir="$(strip_trailing_slashes "${RUNNER_TEMP:-${TMPDIR:-/tmp}}")"
+if [[ "$trusted_keychain_dir" == "" ]]; then
+  trusted_keychain_dir="/tmp"
+fi
 
 cert_base64="${AGENT_SECRET_CODESIGN_CERT_P12_BASE64:-}"
 cert_path="${AGENT_SECRET_CODESIGN_CERT_P12_PATH:-}"
@@ -77,18 +164,17 @@ keychain_path="${AGENT_SECRET_CODESIGN_KEYCHAIN_PATH:-}"
 keychain_password="${AGENT_SECRET_CODESIGN_KEYCHAIN_PASSWORD:-}"
 
 if [[ "$cert_base64" == "" && "$cert_path" == "" ]]; then
-  echo "import-codesign-certificate: set AGENT_SECRET_CODESIGN_CERT_P12_BASE64 or AGENT_SECRET_CODESIGN_CERT_P12_PATH" >&2
-  exit 1
+  die "set AGENT_SECRET_CODESIGN_CERT_P12_BASE64 or AGENT_SECRET_CODESIGN_CERT_P12_PATH"
 fi
 
 if [[ "$cert_password" == "" ]]; then
-  echo "import-codesign-certificate: set AGENT_SECRET_CODESIGN_CERT_PASSWORD" >&2
-  exit 1
+  die "set AGENT_SECRET_CODESIGN_CERT_PASSWORD"
 fi
 
 if [[ "$keychain_path" == "" ]]; then
-  keychain_path="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/agent-secret-codesign.keychain-db"
+  keychain_path="$trusted_keychain_dir/agent-secret-codesign.keychain-db"
 fi
+validate_keychain_path "$keychain_path" "$trusted_keychain_dir"
 
 if [[ "$keychain_password" == "" ]]; then
   keychain_password="$("$tool_uuidgen")"
@@ -106,8 +192,7 @@ if [[ "$cert_base64" != "" ]]; then
 fi
 
 if [[ ! -f "$cert_path" ]]; then
-  echo "import-codesign-certificate: certificate file does not exist: $cert_path" >&2
-  exit 1
+  die "certificate file does not exist: $cert_path"
 fi
 
 "$tool_rm" -f "$keychain_path"

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -100,6 +100,62 @@ expect_any_failure \
   "$import_certificate"
 assert_path_trap_clean "$trap_log"
 
+unsafe_keychain="$tmp_dir/unrelated-user-file"
+dummy_cert="$tmp_dir/dummy.p12"
+printf 'keep\n' >"$unsafe_keychain"
+printf 'not a real certificate\n' >"$dummy_cert"
+
+expect_failure "AGENT_SECRET_CODESIGN_KEYCHAIN_PATH filename must be agent-secret-codesign*.keychain-db" \
+  env -i \
+  "PATH=$test_path" \
+  AGENT_SECRET_CODESIGN_CERT_P12_PATH="$dummy_cert" \
+  AGENT_SECRET_CODESIGN_CERT_PASSWORD=dummy-password \
+  AGENT_SECRET_CODESIGN_KEYCHAIN_PATH="$unsafe_keychain" \
+  "$import_certificate"
+
+if [[ "$(cat "$unsafe_keychain")" != "keep" ]]; then
+  fail "unsafe custom keychain path was modified"
+fi
+
+unsafe_keychain_dir="$tmp_dir/outside-temp"
+unsafe_keychain="$unsafe_keychain_dir/agent-secret-codesign.keychain-db"
+mkdir -p "$unsafe_keychain_dir"
+printf 'keep\n' >"$unsafe_keychain"
+
+expect_failure "AGENT_SECRET_CODESIGN_KEYCHAIN_PATH must be under trusted temp directory" \
+  env -i \
+  "PATH=$test_path" \
+  RUNNER_TEMP="$tmp_dir/runner-temp" \
+  AGENT_SECRET_CODESIGN_CERT_P12_PATH="$dummy_cert" \
+  AGENT_SECRET_CODESIGN_CERT_PASSWORD=dummy-password \
+  AGENT_SECRET_CODESIGN_KEYCHAIN_PATH="$unsafe_keychain" \
+  "$import_certificate"
+
+if [[ "$(cat "$unsafe_keychain")" != "keep" ]]; then
+  fail "custom keychain path outside trusted temp was modified"
+fi
+
+runner_temp="$tmp_dir/runner-temp"
+symlink_target="$tmp_dir/symlink-target"
+symlink_parent="$runner_temp/keychains-link"
+unsafe_keychain="$symlink_parent/agent-secret-codesign.keychain-db"
+mkdir -p "$runner_temp" "$symlink_target"
+printf 'keep\n' >"$symlink_target/agent-secret-codesign.keychain-db"
+ln -s "$symlink_target" "$symlink_parent"
+
+expect_failure "AGENT_SECRET_CODESIGN_KEYCHAIN_PATH must not contain symlinked parent directories" \
+  env -i \
+  "PATH=$test_path" \
+  RUNNER_TEMP="$runner_temp" \
+  AGENT_SECRET_CODESIGN_CERT_P12_PATH="$dummy_cert" \
+  AGENT_SECRET_CODESIGN_CERT_PASSWORD=dummy-password \
+  AGENT_SECRET_CODESIGN_KEYCHAIN_PATH="$unsafe_keychain" \
+  "$import_certificate"
+
+if [[ "$(cat "$symlink_target/agent-secret-codesign.keychain-db")" != "keep" ]]; then
+  fail "custom keychain path through symlinked parent was modified"
+fi
+
 expect_failure "production release requires AGENT_SECRET_CODESIGN_IDENTITY" \
   env -i \
   "PATH=$trap_dir:$test_path" \


### PR DESCRIPTION
## Summary

- validate the codesign import keychain path before the script removes or creates anything there
- require keychain paths to be absolute, temp-scoped, agent-secret named, and free of unsafe symlinked parents
- add release-signing regressions proving rejected custom paths do not modify unrelated files

## Verification

- `mise exec -- env AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh`
- `mise run lint:shell`
- `mise run test:smoke`
- `mise run build`
- `GOFLAGS=-p=1 mise run lint`
- `git diff --check`

Note: using `GOFLAGS=-p=1` for the full local lint gate avoids the unrelated local `TestProcessApproverLauncherHealthCheck` timeout seen under package concurrency in the previous issue.

Closes #223