### PR TITLE
ASR-086: Guard release mise re-exec with signing env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,13 +126,14 @@ jobs:
 
       - name: Build release artifacts
         env:
+          AGENT_SECRET_IN_MISE: "1"
           AGENT_SECRET_CODESIGN_ENTITLEMENTS: ${{ secrets.AGENT_SECRET_CODESIGN_ENTITLEMENTS }}
           AGENT_SECRET_CODESIGN_IDENTITY: ${{ secrets.AGENT_SECRET_CODESIGN_IDENTITY }}
           AGENT_SECRET_NOTARIZE: ${{ secrets.AGENT_SECRET_NOTARIZE }}
           AGENT_SECRET_NOTARY_ISSUER_ID: ${{ secrets.AGENT_SECRET_NOTARY_ISSUER_ID }}
           AGENT_SECRET_NOTARY_KEY: ${{ secrets.AGENT_SECRET_NOTARY_KEY }}
           AGENT_SECRET_NOTARY_KEY_ID: ${{ secrets.AGENT_SECRET_NOTARY_KEY_ID }}
-        run: scripts/build-release.sh "$GITHUB_REF_NAME" --require-production-signing
+        run: mise exec -- scripts/build-release.sh "$GITHUB_REF_NAME" --require-production-signing
 
       - name: Verify release artifact architecture
         run: |

--- a/README.md
+++ b/README.md
@@ -341,13 +341,15 @@ AGENT_SECRET_NOTARY_KEY="$(cat AuthKey_KEYID.p8)"
 AGENT_SECRET_NOTARY_KEY_ID=KEYID
 AGENT_SECRET_NOTARY_ISSUER_ID=ISSUER_UUID
 scripts/check-release-signing-env.sh
-scripts/build-release.sh v0.3.1 --require-production-signing
+AGENT_SECRET_IN_MISE=1 scripts/build-release.sh v0.3.1 --require-production-signing
 ```
 
 `AGENT_SECRET_NOTARY_KEY` may also point at a local `.p8` file. Notarization is
-only attempted when `AGENT_SECRET_NOTARIZE=1`; without Apple Developer ID and
-App Store Connect API key credentials, local release artifacts remain ad-hoc
-signed.
+only attempted when `AGENT_SECRET_NOTARIZE=1`. Signed local release builds must
+run from a trusted toolchain context with `AGENT_SECRET_IN_MISE=1`; the release
+builder refuses to discover `mise` through `PATH` while signing or notarization
+environment variables are present. Without Apple Developer ID and App Store
+Connect API key credentials, local release artifacts remain ad-hoc signed.
 
 For this repository's maintainer releases, the current Developer ID identity is:
 

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -534,7 +534,7 @@ Acceptance checks:
 ```bash
 scripts/build-release.sh v0.0.0-dev
 scripts/check-release-signing-env.sh
-scripts/build-release.sh v0.0.0-dev --require-production-signing
+AGENT_SECRET_IN_MISE=1 scripts/build-release.sh v0.0.0-dev --require-production-signing
 codesign --verify --deep --strict "/Applications/Agent Secret.app"
 spctl --assess --type execute --verbose "/Applications/Agent Secret.app"
 xcrun stapler validate "/Applications/Agent Secret.app"
@@ -542,7 +542,9 @@ xcrun stapler validate "/Applications/Agent Secret.app"
 
 Only the ad-hoc release builder path can be verified locally without Apple
 credentials. The Developer ID path requires the certificate and App Store
-Connect API key in the release environment.
+Connect API key in the release environment, and it must run from a trusted
+toolchain context with `AGENT_SECRET_IN_MISE=1` so the release script does not
+resolve `mise` from `PATH` while those values are present.
 
 ### Epic 5: Unattended Installer
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -184,6 +184,12 @@ Run `AGENT_SECRET_IN_MISE=1 scripts/test-workflow-actions-pinned.sh` after any
 workflow change. That smoke test fails if a `jdx/mise-action` step does not set
 both `version` and `sha256`.
 
+Signed release builds must already be inside a trusted toolchain context. The
+release builder refuses to re-exec a `mise` binary discovered through `PATH`
+when signing or notarization environment variables are present; CI uses the
+pinned `jdx/mise-action` and invokes the release builder through `mise exec`
+with `AGENT_SECRET_IN_MISE=1`.
+
 ## Failed Release Runs
 
 If a tag-triggered release fails before publication:

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -19,18 +19,44 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 output_dir="$project_root/dist"
 require_production_signing=0
-codesign_identity="${AGENT_SECRET_CODESIGN_IDENTITY:-"-"}"
-notarize="${AGENT_SECRET_NOTARIZE:-0}"
-notary_key="${AGENT_SECRET_NOTARY_KEY:-}"
-notary_key_id="${AGENT_SECRET_NOTARY_KEY_ID:-}"
-notary_issuer_id="${AGENT_SECRET_NOTARY_ISSUER_ID:-}"
+
+release_signing_env_present() {
+  local name=""
+
+  for name in \
+    AGENT_SECRET_CODESIGN_CERT_P12_BASE64 \
+    AGENT_SECRET_CODESIGN_CERT_P12_PATH \
+    AGENT_SECRET_CODESIGN_CERT_PASSWORD \
+    AGENT_SECRET_CODESIGN_ENTITLEMENTS \
+    AGENT_SECRET_CODESIGN_IDENTITY \
+    AGENT_SECRET_NOTARIZE \
+    AGENT_SECRET_NOTARY_ISSUER_ID \
+    AGENT_SECRET_NOTARY_KEY \
+    AGENT_SECRET_NOTARY_KEY_ID; do
+    if [[ "${!name:-}" != "" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 if [[ "${AGENT_SECRET_IN_MISE:-}" != "1" ]]; then
+  if release_signing_env_present; then
+    echo "build-release: refusing to re-exec PATH-discovered mise while release signing environment is present" >&2
+    echo "build-release: run from a trusted toolchain context with AGENT_SECRET_IN_MISE=1" >&2
+    exit 1
+  fi
   if command -v mise >/dev/null 2>&1; then
     export AGENT_SECRET_IN_MISE=1
     exec mise exec -- "$0" "$@"
   fi
 fi
+
+codesign_identity="${AGENT_SECRET_CODESIGN_IDENTITY:-"-"}"
+notarize="${AGENT_SECRET_NOTARIZE:-0}"
+notary_key="${AGENT_SECRET_NOTARY_KEY:-}"
+notary_key_id="${AGENT_SECRET_NOTARY_KEY_ID:-}"
+notary_issuer_id="${AGENT_SECRET_NOTARY_ISSUER_ID:-}"
 
 if [[ $# -eq 0 ]]; then
   usage >&2

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -44,7 +44,7 @@ write_path_trap_tools() {
 
   mkdir -p "$trap_dir"
   for tool in base64 security uuidgen codesign xcrun ditto hdiutil shasum \
-    mktemp rm mkdir ln chmod install cp sips iconutil go swift uname; do
+    mktemp rm mkdir ln chmod install cp sips iconutil go swift uname mise; do
     cat >"$trap_dir/$tool" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -98,6 +98,15 @@ expect_any_failure \
   AGENT_SECRET_CODESIGN_CERT_P12_BASE64=not-base64 \
   AGENT_SECRET_CODESIGN_CERT_PASSWORD=dummy-password \
   "$import_certificate"
+assert_path_trap_clean "$trap_log"
+
+expect_failure "refusing to re-exec PATH-discovered mise while release signing environment is present" \
+  env -i \
+  "PATH=$trap_dir:$test_path" \
+  AGENT_SECRET_PATH_TRAP_LOG="$trap_log" \
+  "${release_env[@]}" \
+  AGENT_SECRET_NOTARIZE=1 \
+  "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/mise-trap-out"
 assert_path_trap_clean "$trap_log"
 
 unsafe_keychain="$tmp_dir/unrelated-user-file"


### PR DESCRIPTION
## Summary

- make `scripts/build-release.sh` refuse PATH-discovered `mise` re-exec while signing/notarization environment variables are present
- add a fake-`mise` regression proving release secrets are not exposed to a PATH-controlled executable
- update the release workflow to use the pinned `jdx/mise-action` explicitly and document the trusted-toolchain requirement for signed builds

## Verification

- `mise exec -- env AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh`
- `mise exec -- env AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh`
- `mise exec -- env AGENT_SECRET_IN_MISE=1 scripts/test-workflow-actions-pinned.sh`
- `npx --yes markdownlint-cli README.md docs/macos-distribution-plan.md docs/release-process.md`
- `mise run lint:shell`
- `mise run test:smoke`
- `mise run build`
- `GOFLAGS=-p=1 mise run lint`
- `git diff --check`

Note: using `GOFLAGS=-p=1` for the full local lint gate avoids the unrelated local `TestProcessApproverLauncherHealthCheck` timeout seen under package concurrency.

Closes #224