### PR TITLE
ASR-087: Keep approval decisions visible for large secret scopes

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalPanelStyle.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelStyle.swift
@@ -117,6 +117,7 @@ import Foundation
             static let secretPanelPadding: CGFloat = 14
             static let sectionLabelFontSize: CGFloat = 14
             static let sectionSpacing: CGFloat = 10
+            static let scrollableApprovalContentMaxHeight: CGFloat = 430
             static let singleLineLimit: Int = 1
             static let singleSecretCount: Int = 1
             static let subtleBorderOpacity: Double = 0.18

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
@@ -18,20 +18,7 @@ import Foundation
 
         var body: some View {
             VStack(alignment: .leading, spacing: Metric.sectionSpacing) {
-                header
-                prompt
-                if viewModel.highScopeWarning {
-                    ApprovalPanelHighScopeWarning(
-                        printsEnvironmentWarning: viewModel.printsEnvironmentWarning,
-                        secretCount: viewModel.secretCount
-                    )
-                }
-                secretSection
-                requestContext
-                if !viewModel.cautionMessages.isEmpty {
-                    caution
-                }
-                details
+                scrollableRequestSummary
                 decisionButtons
                 footer
             }
@@ -52,6 +39,30 @@ import Foundation
             ) { date in
                 handleClockTick(date)
             }
+        }
+
+        private var scrollableRequestSummary: some View {
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: Metric.sectionSpacing) {
+                    header
+                    prompt
+                    if viewModel.highScopeWarning {
+                        ApprovalPanelHighScopeWarning(
+                            printsEnvironmentWarning: viewModel.printsEnvironmentWarning,
+                            secretCount: viewModel.secretCount
+                        )
+                    }
+                    secretSection
+                    requestContext
+                    if !viewModel.cautionMessages.isEmpty {
+                        caution
+                    }
+                    details
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: Metric.scrollableApprovalContentMaxHeight)
+            .scrollIndicators(.visible)
         }
 
         var viewModel: ApprovalRequestViewModel {

--- a/approver/Tests/AgentSecretApproverTests/ApprovalRequestPanelLayoutTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalRequestPanelLayoutTests.swift
@@ -1,0 +1,55 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+#if canImport(AppKit) && canImport(SwiftUI)
+    import AppKit
+    import SwiftUI
+
+    final class ApprovalRequestPanelLayoutTests: XCTestCase {
+        private static let fixedNow = Date(timeIntervalSince1970: 1_800_000_000)
+        private static let panelHeight: CGFloat = 660
+        private static let panelWidth: CGFloat = 832
+
+        private static func manyVaultGroupRequest(groupCount: Int) -> ApprovalRequest {
+            let secrets = (1 ... groupCount).map { index in
+                RequestedSecret(
+                    alias: "SERVICE_\(index)_TOKEN",
+                    ref: "op://Vault \(index)/Service/token",
+                    account: "Account \(index)"
+                )
+            }
+            return ApprovalRequest(
+                requestID: "req_many_groups",
+                nonce: "nonce_many_groups",
+                reason: "Run a release workflow that needs many scoped credentials",
+                command: ["/usr/bin/env", "agent-secret", "exec", "--", "make", "release"],
+                cwd: "/tmp/project",
+                expiresAt: fixedNow.addingTimeInterval(120),
+                secrets: secrets,
+                resolvedExecutable: "/usr/bin/env"
+            )
+        }
+
+        @MainActor
+        func testManyVaultGroupsStayInsideFixedApprovalPanelHeight() {
+            let request = Self.manyVaultGroupRequest(groupCount: 32)
+            let host = NSHostingView(
+                rootView: ApprovalRequestPanelView(request: request, now: Self.fixedNow) { _ in
+                    /* No decision action needed. */
+                }
+            )
+            host.frame = NSRect(
+                origin: .zero,
+                size: NSSize(width: Self.panelWidth, height: Self.panelHeight)
+            )
+            host.layoutSubtreeIfNeeded()
+
+            XCTAssertLessThanOrEqual(host.fittingSize.height, Self.panelHeight)
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- move pre-decision approval context into a bounded vertical scroll region
- keep Deny/Allow controls and footer outside that scroll region so they remain reachable in the fixed AppKit panel
- add an AppKit hosting layout regression with 32 vault groups that must still fit within the 660px presenter height

## Verification

- `cd approver && mise exec -- swift test --filter ApprovalRequestPanelLayoutTests`
- `mise run lint:swift`
- `cd approver && mise exec -- swift test --filter 'ApprovalPanel|ApprovalRequestPanelLayout'`\n- `mise run test:smoke`\n- `mise run build`\n- `GOFLAGS=-p=1 mise run lint`\n- `git diff --check`\n\nNote: using `GOFLAGS=-p=1` for the full local lint gate avoids the unrelated local `TestProcessApproverLauncherHealthCheck` timeout seen under package concurrency.\n\nCloses #225