### PR TITLE
ASR-088: Defer approver daemon client setup off MainActor

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalController.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalController.swift
@@ -7,12 +7,21 @@ public final class ApprovalController {
     private let logger: ApprovalLogger
 
     /// Creates a controller with daemon, presenter, and metadata logger dependencies.
-    public init(
+    public convenience init(
         client: ApprovalDaemonClient,
         presenter: ApprovalPresenter,
         logger: ApprovalLogger = UnifiedApprovalLogger(category: "decisions")
     ) {
-        self.client = ApprovalDaemonClientWorker(client: client)
+        self.init(clientFactory: { client }, presenter: presenter, logger: logger)
+    }
+
+    /// Creates a controller that builds the daemon client on the background worker queue.
+    public init(
+        clientFactory: @escaping () throws -> ApprovalDaemonClient,
+        presenter: ApprovalPresenter,
+        logger: ApprovalLogger = UnifiedApprovalLogger(category: "decisions")
+    ) {
+        client = ApprovalDaemonClientWorker(clientFactory: clientFactory)
         self.presenter = presenter
         self.logger = logger
     }

--- a/approver/Sources/AgentSecretApprover/ApprovalDaemonClientWorker.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalDaemonClientWorker.swift
@@ -2,27 +2,44 @@ import Foundation
 
 /// Serial worker that keeps blocking daemon socket I/O off the main actor.
 final class ApprovalDaemonClientWorker: @unchecked Sendable {
-    private let client: ApprovalDaemonClient
+    private let clientFactory: () throws -> ApprovalDaemonClient
+    private var client: ApprovalDaemonClient?
     private let queue: DispatchQueue
 
-    init(
+    convenience init(
         client: ApprovalDaemonClient,
         queue: DispatchQueue = DispatchQueue(label: "com.kovyrin.agent-secret.approver.daemon-client")
     ) {
-        self.client = client
+        self.init(clientFactory: { client }, queue: queue)
+    }
+
+    init(
+        clientFactory: @escaping () throws -> ApprovalDaemonClient,
+        queue: DispatchQueue = DispatchQueue(label: "com.kovyrin.agent-secret.approver.daemon-client")
+    ) {
+        self.clientFactory = clientFactory
         self.queue = queue
     }
 
     func fetchPendingRequest() async throws -> ApprovalRequest {
         try await perform {
-            try self.client.fetchPendingRequest()
+            try self.clientOnQueue().fetchPendingRequest()
         }
     }
 
     func submit(_ decision: ApprovalDecision) async throws {
         try await perform {
-            try self.client.submit(decision)
+            try self.clientOnQueue().submit(decision)
         }
+    }
+
+    private func clientOnQueue() throws -> ApprovalDaemonClient {
+        if let client {
+            return client
+        }
+        let client = try clientFactory()
+        self.client = client
+        return client
     }
 
     private func perform<Value>(_ operation: @escaping @Sendable () throws -> Value) async throws -> Value {

--- a/approver/Sources/AgentSecretApproverApp/AgentSecretApproverMain.swift
+++ b/approver/Sources/AgentSecretApproverApp/AgentSecretApproverMain.swift
@@ -18,8 +18,10 @@ private enum AgentSecretApproverMain {
                 exit(0)
             }
             let presenter: ApprovalPresenter = AppKitApprovalPresenter()
-            let client: ApprovalDaemonClient = try SocketDaemonClient(socketPath: socketPath)
-            let controller = ApprovalController(client: client, presenter: presenter)
+            let controller = ApprovalController(
+                clientFactory: { try SocketDaemonClient(socketPath: socketPath) },
+                presenter: presenter
+            )
             _ = try await controller.run()
         } catch {
             FileHandle.standardError.write(Data("agent-secret-approver: \(error)\n".utf8))

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerConcurrencyTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerConcurrencyTests.swift
@@ -15,6 +15,40 @@ final class ApprovalControllerConcurrencyTests: XCTestCase {
         case background
     }
 
+    private final class BlockingFactoryState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var factoryObservation: ThreadObservation = .unrecorded
+        private var watchdogDidReleaseFactory = false
+
+        var factoryThreadObservation: ThreadObservation {
+            lock.lock()
+            defer { lock.unlock() }
+            return factoryObservation
+        }
+
+        var watchdogReleasedFactory: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return watchdogDidReleaseFactory
+        }
+
+        func recordFactoryThread() {
+            lock.lock()
+            factoryObservation = Thread.isMainThread ? .main : .background
+            lock.unlock()
+        }
+
+        func recordWatchdogRelease() {
+            lock.lock()
+            watchdogDidReleaseFactory = true
+            lock.unlock()
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+
     private final class ThreadRecordingDaemonClient: ApprovalDaemonClient {
         private let lock = NSLock()
         private let request: ApprovalRequest
@@ -102,6 +136,45 @@ final class ApprovalControllerConcurrencyTests: XCTestCase {
 
         XCTAssertEqual(client.fetchThreadObservation, .background)
         XCTAssertEqual(client.submitThreadObservation, .background)
+        XCTAssertTrue(presenter.decideRanOnMainThread)
+    }
+
+    @MainActor
+    func testDaemonClientFactoryDoesNotBlockMainActor() async throws {
+        let factoryStarted = expectation(description: "daemon client factory started")
+        let releaseFactory = DispatchSemaphore(value: 0)
+        let state = BlockingFactoryState()
+        let presenter = ThreadRecordingPresenter()
+        let controller = ApprovalController(
+            clientFactory: {
+                state.recordFactoryThread()
+                factoryStarted.fulfill()
+                releaseFactory.wait()
+                return ThreadRecordingDaemonClient(request: Self.sampleRequest)
+            },
+            presenter: presenter,
+            logger: NoopApprovalLogger()
+        )
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5) {
+            state.recordWatchdogRelease()
+            releaseFactory.signal()
+        }
+
+        let runTask = Task { @MainActor in
+            try await controller.run()
+        }
+
+        await fulfillment(of: [factoryStarted], timeout: 1)
+
+        XCTAssertEqual(state.factoryThreadObservation, .background)
+        XCTAssertFalse(
+            state.watchdogReleasedFactory,
+            "MainActor stayed blocked until the watchdog released daemon client construction"
+        )
+
+        releaseFactory.signal()
+        _ = try await runTask.value
         XCTAssertTrue(presenter.decideRanOnMainThread)
     }
 

--- a/approver/Tests/AgentSecretApproverTests/ApproverAppEntrypointTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApproverAppEntrypointTests.swift
@@ -11,6 +11,9 @@ final class ApproverAppEntrypointTests: XCTestCase {
     private static let smokeEntrypointPath: String = "Sources/AgentSecretApproverSmoke/main.swift"
     private static let healthCheckFlag: String = "--health-check"
     private static let mainActorIsolationEscapeHatch: String = "assumeIsolated"
+    private static let eagerSocketClientConstruction: String =
+        "let client: ApprovalDaemonClient = try SocketDaemonClient(socketPath: socketPath)"
+    private static let daemonClientFactoryLabel: String = "clientFactory:"
 
     private static func packageRootURL() -> URL? {
         var url = URL(fileURLWithPath: #filePath)
@@ -54,6 +57,13 @@ final class ApproverAppEntrypointTests: XCTestCase {
         XCTAssertFalse(source.contains(Self.mainActorIsolationEscapeHatch))
         XCTAssertTrue(source.contains("@MainActor"))
         XCTAssertTrue(source.contains("static func main()"))
+    }
+
+    func testShippedApproverDefersSocketClientConstructionOffMainActor() throws {
+        let source: String = try Self.sourceText(at: Self.appEntrypointPath)
+
+        XCTAssertFalse(source.contains(Self.eagerSocketClientConstruction))
+        XCTAssertTrue(source.contains(Self.daemonClientFactoryLabel))
     }
 
     func testSmokeEntrypointOwnsMockOnlySurface() throws {


### PR DESCRIPTION
## Summary

- make the approval daemon worker lazily construct its daemon client on the serial background queue
- update the shipped approver entrypoint to pass a socket-client factory instead of opening and validating the daemon socket on `@MainActor`
- add regressions proving a blocked client factory does not pin MainActor and that the app entrypoint keeps deferred construction

## Verification

- `cd approver && mise exec -- swift test --filter ApprovalControllerConcurrencyTests`
- `cd approver && mise exec -- swift test --filter 'ApprovalControllerConcurrencyTests|ApproverAppEntrypointTests'`\n- `mise run lint:swift`\n- `mise run test:smoke`\n- `mise run build`\n- `GOFLAGS=-p=1 mise run lint`\n- `git diff --check`\n\nNote: using `GOFLAGS=-p=1` for the full local lint gate avoids the unrelated local `TestProcessApproverLauncherHealthCheck` timeout seen under package concurrency.\n\nCloses #226