### PR TITLE
ASR-089: reserve reusable approval deliveries

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -166,7 +166,7 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 		}
 	}
 	if err := b.requestActive(execCtx, req); err != nil {
-		b.rollbackReusableApproval(grant.reusableMutationID)
+		b.rollbackReusableGrant(grant)
 		return ExecGrant{}, err
 	}
 	if err := b.reusableApprovalActive(grant.ApprovalID, grant.approvalExpiresAt); err != nil {
@@ -175,11 +175,11 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 
 	event := audit.FromExecRequest(audit.EventCommandStarting, requestID, req)
 	if err := b.recordRequiredAudit(execCtx, event); err != nil {
-		b.rollbackReusableApproval(grant.reusableMutationID)
+		b.rollbackReusableGrant(grant)
 		return ExecGrant{}, err
 	}
 	if err := b.requestActive(execCtx, req); err != nil {
-		b.rollbackReusableApproval(grant.reusableMutationID)
+		b.rollbackReusableGrant(grant)
 		return ExecGrant{}, err
 	}
 	if err := b.reusableApprovalActive(grant.ApprovalID, grant.approvalExpiresAt); err != nil {
@@ -286,10 +286,10 @@ func (b *Broker) MarkPayloadDelivered(requestID string) error {
 	approval, err := b.store.FinishReusableAttempt(active.approvalID, policy.DeliveryPayloadDelivered)
 	if err != nil {
 		b.clearReusableCacheScope(active.approvalID)
+		b.mu.Lock()
+		delete(b.active, requestID)
+		b.mu.Unlock()
 		if errors.Is(err, policy.ErrExpired) {
-			b.mu.Lock()
-			delete(b.active, requestID)
-			b.mu.Unlock()
 			return ErrRequestExpired
 		}
 		return err
@@ -416,16 +416,28 @@ func (b *Broker) recordDaemonStopAttempt(ctx context.Context, event audit.Event)
 }
 
 func (b *Broker) reusableGrant(ctx context.Context, req request.ExecRequest) (ExecGrant, error) {
-	approval, err := b.store.FindReusable(ctx, req, b.audit)
+	approval, err := b.store.ReserveReusable(ctx, req, b.audit)
 	if err != nil {
 		if errors.Is(err, policy.ErrAuditFailed) {
 			return ExecGrant{}, err
 		}
-		if approval.ID != "" && (errors.Is(err, policy.ErrExpired) || errors.Is(err, policy.ErrUseExhausted)) {
+		if approval.ID != "" && errors.Is(err, policy.ErrExpired) {
+			b.clearReusableCacheScope(approval.ID)
+		}
+		if approval.ID != "" &&
+			errors.Is(err, policy.ErrUseExhausted) &&
+			approval.Uses >= approval.MaxUses &&
+			approval.ReservedUses == 0 {
 			b.clearReusableCacheScope(approval.ID)
 		}
 		return ExecGrant{}, nil
 	}
+	delivered := false
+	defer func() {
+		if !delivered {
+			b.releaseReusableReservation(approval.ID)
+		}
+	}()
 	if err := b.requestActive(ctx, req); err != nil {
 		return ExecGrant{}, err
 	}
@@ -447,6 +459,7 @@ func (b *Broker) reusableGrant(ctx context.Context, req request.ExecRequest) (Ex
 		return ExecGrant{}, err
 	}
 
+	delivered = true
 	return ExecGrant{
 		Env:                values,
 		SecretAliases:      aliases(req.Secrets),
@@ -513,7 +526,7 @@ func (b *Broker) freshGrant(
 	approvalID := ""
 	approvalExpiresAt := time.Time{}
 	if decision.Reusable {
-		approval, err := b.store.AddReusableWithLimit(req, decision.ReusableUses, "", "")
+		approval, err := b.store.AddReusableWithReservedUse(req, decision.ReusableUses, "", "")
 		if err != nil {
 			return ExecGrant{}, err
 		}
@@ -548,6 +561,25 @@ func (b *Broker) rollbackReusableApproval(approvalID string) {
 	}
 	b.store.RemoveReusable(approvalID)
 	b.clearReusableCacheScope(approvalID)
+}
+
+func (b *Broker) rollbackReusableGrant(grant ExecGrant) {
+	if grant.reusableMutationID != "" {
+		b.rollbackReusableApproval(grant.reusableMutationID)
+		return
+	}
+	b.releaseReusableReservation(grant.ApprovalID)
+}
+
+func (b *Broker) releaseReusableReservation(approvalID string) {
+	if approvalID == "" {
+		return
+	}
+	if _, err := b.store.FinishReusableAttempt(approvalID, policy.DeliveryPrePayloadFailure); err != nil {
+		if errors.Is(err, policy.ErrExpired) || errors.Is(err, policy.ErrUseExhausted) {
+			b.clearReusableCacheScope(approvalID)
+		}
+	}
 }
 
 func (b *Broker) reusableApprovalActive(approvalID string, expiresAt time.Time) error {

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -950,6 +950,54 @@ func TestBrokerReusableApprovalUsesApprovedUseLimit(t *testing.T) {
 	}
 }
 
+func TestBrokerReservesReusableUseBeforePayloadDelivery(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true, ReusableUses: 2}}
+	resolver := &mockResolver{values: map[string]string{ref: "first"}}
+	broker := newTestBroker(t, BrokerOptions{
+		Approver: approver,
+		Resolver: resolver,
+		Audit:    &memoryAudit{},
+		Cache:    policy.NewSecretCache(),
+	})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req.ReusableUses = 2
+
+	first, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+	if err != nil {
+		t.Fatalf("first HandleExec returned error: %v", err)
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); err != nil {
+		t.Fatalf("first MarkPayloadDelivered returned error: %v", err)
+	}
+
+	second, err := broker.HandleExec(context.Background(), "req_2", "nonce_2", req)
+	if err != nil {
+		t.Fatalf("second HandleExec returned error: %v", err)
+	}
+	if second.ApprovalID != first.ApprovalID {
+		t.Fatalf("second approval id = %q, want reusable approval %q", second.ApprovalID, first.ApprovalID)
+	}
+	if second.Env["TOKEN"] != "first" {
+		t.Fatalf("second delivery did not reuse cached first value: %+v", second.Env)
+	}
+
+	approver.decision = ApprovalDecision{Approved: false}
+	_, err = broker.HandleExec(context.Background(), "req_3", "nonce_3", req)
+	if !errors.Is(err, ErrApprovalDenied) {
+		t.Fatalf("third HandleExec reused a reserved one-use approval; got %v", err)
+	}
+	if approver.calls != 2 {
+		t.Fatalf("approver calls = %d, want fresh approval after reserved use exhausted cache availability", approver.calls)
+	}
+
+	if err := broker.MarkPayloadDelivered("req_2"); err != nil {
+		t.Fatalf("second MarkPayloadDelivered returned error: %v", err)
+	}
+}
+
 func TestBrokerReusableApprovalMissesWhenUseLimitChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -47,12 +47,13 @@ type Store struct {
 }
 
 type ReusableApproval struct {
-	ID        string
-	Nonce     string
-	Key       ReuseKey
-	ExpiresAt time.Time
-	MaxUses   int
-	Uses      int
+	ID           string
+	Nonce        string
+	Key          ReuseKey
+	ExpiresAt    time.Time
+	MaxUses      int
+	Uses         int
+	ReservedUses int
 }
 
 type ReuseKey struct {
@@ -129,12 +130,34 @@ func (s *Store) AddReusableWithLimit(
 	id string,
 	nonce string,
 ) (ReusableApproval, error) {
+	return s.addReusableWithLimit(req, maxUses, id, nonce, 0)
+}
+
+func (s *Store) AddReusableWithReservedUse(
+	req request.ExecRequest,
+	maxUses int,
+	id string,
+	nonce string,
+) (ReusableApproval, error) {
+	return s.addReusableWithLimit(req, maxUses, id, nonce, 1)
+}
+
+func (s *Store) addReusableWithLimit(
+	req request.ExecRequest,
+	maxUses int,
+	id string,
+	nonce string,
+	reservedUses int,
+) (ReusableApproval, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	maxUses = request.ReusableUsesOrDefault(maxUses)
 	if maxUses < 1 || maxUses > request.MaxReusableUses {
 		return ReusableApproval{}, fmt.Errorf("%w: must be between 1 and %d", request.ErrInvalidReusableUses, request.MaxReusableUses)
+	}
+	if reservedUses < 0 || reservedUses > maxUses {
+		return ReusableApproval{}, fmt.Errorf("%w: reserved uses must be between 0 and %d", ErrUseExhausted, maxUses)
 	}
 	req.ReusableUses = maxUses
 
@@ -154,11 +177,12 @@ func (s *Store) AddReusableWithLimit(
 	}
 
 	approval := &ReusableApproval{
-		ID:        id,
-		Nonce:     nonce,
-		Key:       NewReuseKey(req),
-		ExpiresAt: req.ExpiresAt,
-		MaxUses:   maxUses,
+		ID:           id,
+		Nonce:        nonce,
+		Key:          NewReuseKey(req),
+		ExpiresAt:    req.ExpiresAt,
+		MaxUses:      maxUses,
+		ReservedUses: reservedUses,
 	}
 	s.approvals[id] = approval
 
@@ -169,20 +193,62 @@ func (s *Store) FindReusable(ctx context.Context, req request.ExecRequest, sink 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	approval, err := s.findReusableLocked(ctx, req, sink)
+	if err != nil {
+		if approval != nil {
+			return *approval, err
+		}
+		return ReusableApproval{}, err
+	}
+	return *approval, nil
+}
+
+func (s *Store) ReserveReusable(ctx context.Context, req request.ExecRequest, sink ReuseAuditSink) (ReusableApproval, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	approval, err := s.findReusableLocked(ctx, req, sink)
+	if err != nil {
+		if approval != nil {
+			return *approval, err
+		}
+		return ReusableApproval{}, err
+	}
+	approval.ReservedUses++
+	return *approval, nil
+}
+
+func (s *Store) findReusableLocked(
+	ctx context.Context,
+	req request.ExecRequest,
+	sink ReuseAuditSink,
+) (*ReusableApproval, error) {
 	key := NewReuseKey(req)
 	now := s.now()
+	var expired *ReusableApproval
+	var exhausted *ReusableApproval
 	for id, approval := range s.approvals {
 		if !approval.Key.Equal(key) {
 			continue
 		}
 		if !now.Before(approval.ExpiresAt) {
+			snapshot := *approval
 			delete(s.approvals, id)
-			return *approval, ErrExpired
+			if expired == nil {
+				expired = &snapshot
+			}
+			continue
 		}
-		remainingUses := approval.MaxUses - approval.Uses
+		remainingUses := approval.MaxUses - approval.Uses - approval.ReservedUses
 		if remainingUses <= 0 {
-			delete(s.approvals, id)
-			return *approval, ErrUseExhausted
+			snapshot := *approval
+			if approval.Uses >= approval.MaxUses && approval.ReservedUses == 0 {
+				delete(s.approvals, id)
+			}
+			if exhausted == nil {
+				exhausted = &snapshot
+			}
+			continue
 		}
 
 		event := ReuseAuditEvent{
@@ -192,14 +258,20 @@ func (s *Store) FindReusable(ctx context.Context, req request.ExecRequest, sink 
 		}
 		if sink != nil {
 			if err := sink.ApprovalReused(ctx, event); err != nil {
-				return ReusableApproval{}, fmt.Errorf("%w: %w", ErrAuditFailed, err)
+				return nil, fmt.Errorf("%w: %w", ErrAuditFailed, err)
 			}
 		}
 
-		return *approval, nil
+		return approval, nil
 	}
 
-	return ReusableApproval{}, ErrMismatch
+	if expired != nil {
+		return expired, ErrExpired
+	}
+	if exhausted != nil {
+		return exhausted, ErrUseExhausted
+	}
+	return nil, ErrMismatch
 }
 
 func (s *Store) FinishReusableAttempt(id string, result DeliveryResult) (ReusableApproval, error) {
@@ -215,9 +287,14 @@ func (s *Store) FinishReusableAttempt(id string, result DeliveryResult) (Reusabl
 		return *approval, ErrExpired
 	}
 	if consumesUse(result) {
+		if approval.ReservedUses > 0 {
+			approval.ReservedUses--
+		}
 		approval.Uses++
+	} else if result == DeliveryPrePayloadFailure && approval.ReservedUses > 0 {
+		approval.ReservedUses--
 	}
-	if approval.Uses >= approval.MaxUses {
+	if approval.Uses >= approval.MaxUses && approval.ReservedUses == 0 {
 		delete(s.approvals, id)
 	}
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -164,6 +164,57 @@ func TestReusableApprovalDoesNotConsumeUseBeforePayload(t *testing.T) {
 	}
 }
 
+func TestReusableApprovalReservationsBlockConcurrentDelivery(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	store := NewStore(func() time.Time { return now })
+	req := testRequest(t, now)
+	req.ReusableUses = 1
+	approval, err := store.AddReusableWithReservedUse(req, 1, "appr_1", "nonce_1")
+	if err != nil {
+		t.Fatalf("AddReusableWithReservedUse returned error: %v", err)
+	}
+	if approval.ReservedUses != 1 {
+		t.Fatalf("reserved uses = %d, want 1", approval.ReservedUses)
+	}
+
+	blocked, err := store.ReserveReusable(context.Background(), req, nil)
+	if !errors.Is(err, ErrUseExhausted) {
+		t.Fatalf("expected reservation to exhaust available delivery slots, got %v", err)
+	}
+	if blocked.ID != approval.ID {
+		t.Fatalf("blocked approval id = %q, want %q", blocked.ID, approval.ID)
+	}
+
+	afterFailure, err := store.FinishReusableAttempt(approval.ID, DeliveryPrePayloadFailure)
+	if err != nil {
+		t.Fatalf("FinishReusableAttempt after pre-payload failure returned error: %v", err)
+	}
+	if afterFailure.Uses != 0 || afterFailure.ReservedUses != 0 {
+		t.Fatalf("after pre-payload failure = uses:%d reserved:%d, want uses:0 reserved:0", afterFailure.Uses, afterFailure.ReservedUses)
+	}
+
+	retry, err := store.ReserveReusable(context.Background(), req, nil)
+	if err != nil {
+		t.Fatalf("ReserveReusable after release returned error: %v", err)
+	}
+	if retry.ReservedUses != 1 {
+		t.Fatalf("retry reserved uses = %d, want 1", retry.ReservedUses)
+	}
+
+	afterDelivery, err := store.FinishReusableAttempt(approval.ID, DeliveryPayloadDelivered)
+	if err != nil {
+		t.Fatalf("FinishReusableAttempt after payload returned error: %v", err)
+	}
+	if afterDelivery.Uses != 1 || afterDelivery.ReservedUses != 0 {
+		t.Fatalf("after payload delivery = uses:%d reserved:%d, want uses:1 reserved:0", afterDelivery.Uses, afterDelivery.ReservedUses)
+	}
+	if _, err := store.FindReusable(context.Background(), req, nil); !errors.Is(err, ErrMismatch) {
+		t.Fatalf("expected delivered one-use approval to be removed, got %v", err)
+	}
+}
+
 func TestReusableApprovalConsumesUseForAllPostPayloadOutcomes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #234.

- reserve reusable approval delivery capacity before returning cached env payloads
- reserve the first delivery for newly approved reusable grants so fresh approvals cannot be concurrently over-issued before payload accounting runs
- release reservations on pre-payload failures, and consume them only after payload delivery
- keep cache clearing tied to actual expiry/exhaustion instead of in-flight reserved uses

## Verification

- `mise exec -- go test ./internal/policy -run 'TestReusableApproval(ReservationsBlockConcurrentDelivery|DoesNotConsumeUseBeforePayload|UsesRequestedUseLimit|ConsumesUseForAllPostPayloadOutcomes)' -count=1`
- `mise exec -- go test ./internal/daemon -run 'TestBroker(ReservesReusableUseBeforePayloadDelivery|ReusableApprovalUsesApprovedUseLimit)|TestServerFailedExecResponseWriteDoesNotConsumeReusableUse' -count=1`
- `mise exec -- go test ./internal/policy ./internal/daemon -count=1`
- `mise run test`
- `GOFLAGS=-p=1 mise run lint`
- `mise run build`
- `mise run test:race`
- `mise run test:smoke`
- `git diff --check`
