### PR TITLE
ASR-090: defer expired modal stop until run loop

### DIFF
--- a/approver/Sources/AgentSecretApprover/AppKitApplicationModalStopper.swift
+++ b/approver/Sources/AgentSecretApprover/AppKitApplicationModalStopper.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+#if canImport(AppKit)
+    import AppKit
+
+    @MainActor
+    final class AppKitApplicationModalStopper: NSObject, AppKitModalStopping {
+        func stopModal() {
+            NSApplication.shared.stopModal()
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/AppKitApprovalPresenter.swift
+++ b/approver/Sources/AgentSecretApprover/AppKitApprovalPresenter.swift
@@ -44,9 +44,13 @@ public final class AppKitApprovalPresenter: ApprovalPresenter {
 
         @MainActor
         private static func decideOnMain(for request: ApprovalRequest) -> ApprovalDecisionKind {
+            if let preflightDecision: ApprovalDecisionKind = preflightDecision(for: request) {
+                return preflightDecision
+            }
+
             let app = NSApplication.shared
             Self.activate(app)
-            var decision: ApprovalDecisionKind = .deny
+            let coordinator = AppKitModalDecisionCoordinator(stopper: AppKitApplicationModalStopper())
             let window = NSPanel(
                 contentRect: NSRect(
                     x: Self.panelOrigin,
@@ -64,15 +68,22 @@ public final class AppKitApprovalPresenter: ApprovalPresenter {
             window.isMovableByWindowBackground = true
             window.contentView = NSHostingView(
                 rootView: ApprovalRequestPanelView(request: request) { selectedDecision in
-                    decision = selectedDecision
-                    app.stopModal()
+                    coordinator.complete(with: selectedDecision)
                 }
             )
 
             Self.bringForward(window)
             _ = app.runModal(for: window)
             window.close()
-            return decision
+            return coordinator.decision
+        }
+
+        @MainActor
+        static func preflightDecision(
+            for request: ApprovalRequest,
+            now: Date = Date()
+        ) -> ApprovalDecisionKind? {
+            ApprovalPromptExpiration(expiresAt: request.expiresAt).timeoutDecision(at: now)
         }
     #endif
 

--- a/approver/Sources/AgentSecretApprover/AppKitModalDecisionCoordinator.swift
+++ b/approver/Sources/AgentSecretApprover/AppKitModalDecisionCoordinator.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+#if canImport(AppKit)
+    @MainActor
+    final class AppKitModalDecisionCoordinator {
+        private static let modalStopRunLoopModes: [RunLoop.Mode] = [
+            .default,
+            .modalPanel
+        ]
+
+        private let stopper: NSObject & AppKitModalStopping
+
+        private(set) var decision: ApprovalDecisionKind = .deny
+
+        init(stopper: NSObject & AppKitModalStopping) {
+            self.stopper = stopper
+        }
+
+        func complete(with selectedDecision: ApprovalDecisionKind) {
+            decision = selectedDecision
+            stopper.perform(
+                #selector(AppKitModalStopping.stopModal),
+                with: nil,
+                afterDelay: 0,
+                inModes: Self.modalStopRunLoopModes
+            )
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/AppKitModalStopping.swift
+++ b/approver/Sources/AgentSecretApprover/AppKitModalStopping.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+#if canImport(AppKit)
+    @MainActor
+    @objc
+    protocol AppKitModalStopping: NSObjectProtocol {
+        func stopModal()
+    }
+#endif

--- a/approver/Tests/AgentSecretApproverTests/AppKitApprovalPresenterTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/AppKitApprovalPresenterTests.swift
@@ -1,0 +1,62 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+#if canImport(AppKit)
+    import AppKit
+
+    final class AppKitApprovalPresenterTests: XCTestCase {
+        private static let fixedNow = Date(timeIntervalSince1970: 1_800_000_000)
+
+        private static func approvalRequest(expiresAt: Date) -> ApprovalRequest {
+            ApprovalRequest(
+                requestID: "req_expired",
+                nonce: "nonce_expired",
+                reason: "Run a command",
+                command: ["/usr/bin/env", "printenv", "TOKEN"],
+                cwd: "/tmp/project",
+                expiresAt: expiresAt,
+                secrets: [
+                    RequestedSecret(alias: "TOKEN", ref: "op://Example/Item/token", account: "Work")
+                ],
+                resolvedExecutable: "/usr/bin/env"
+            )
+        }
+
+        @MainActor
+        func testExpiredRequestPreflightsToTimeoutBeforeOpeningModal() {
+            let request = Self.approvalRequest(expiresAt: Self.fixedNow)
+
+            XCTAssertEqual(
+                AppKitApprovalPresenter.preflightDecision(for: request, now: Self.fixedNow),
+                .timeout
+            )
+        }
+
+        @MainActor
+        func testUnexpiredRequestDoesNotPreflightToTimeout() {
+            let request = Self.approvalRequest(expiresAt: Self.fixedNow.addingTimeInterval(0.001))
+
+            XCTAssertNil(AppKitApprovalPresenter.preflightDecision(for: request, now: Self.fixedNow))
+        }
+
+        @MainActor
+        func testModalStopIsDeferredUntilModalRunLoopTurns() {
+            let stopper = CountingModalStopper()
+            let coordinator = AppKitModalDecisionCoordinator(stopper: stopper)
+
+            coordinator.complete(with: .timeout)
+
+            XCTAssertEqual(coordinator.decision, .timeout)
+            XCTAssertEqual(stopper.stopCount, 0)
+
+            _ = RunLoop.main.run(mode: .modalPanel, before: Date().addingTimeInterval(0.1))
+
+            XCTAssertEqual(stopper.stopCount, 1)
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif

--- a/approver/Tests/AgentSecretApproverTests/CountingModalStopper.swift
+++ b/approver/Tests/AgentSecretApproverTests/CountingModalStopper.swift
@@ -1,0 +1,17 @@
+@testable import AgentSecretApprover
+import Foundation
+
+#if canImport(AppKit)
+    @MainActor
+    final class CountingModalStopper: NSObject, AppKitModalStopping {
+        private(set) var stopCount = 0
+
+        func stopModal() {
+            stopCount += 1
+        }
+
+        deinit {
+            /* Required by SwiftLint. */
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

Fixes #235.

- return `.timeout` before opening AppKit UI when an approval request is already expired
- route AppKit modal decisions through a small coordinator that schedules `stopModal` onto the modal run loop
- add AppKit tests for expired preflight and for the stop call being deferred until the modal run loop turns

## Verification

- `mise exec -- swift test --package-path approver --filter AppKitApprovalPresenterTests`
- `mise run lint:swift`
- `mise exec -- swift test --package-path approver`
- `mise run test`
- `mise run build`
- `GOFLAGS=-p=1 mise run lint`
- `mise run test:smoke`
- `git diff --check`
