### PR TITLE
ASR-091: bound resolver fan-in by request context

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -645,11 +645,8 @@ func (b *Broker) resolveUniqueRefs(ctx context.Context, requestID string, req re
 
 	sem := make(chan struct{}, b.fetchLimit)
 	results := make(chan result, len(identities))
-	var wg sync.WaitGroup
 	for _, identity := range identities {
-		wg.Add(1)
 		go func(identity secretIdentity) {
-			defer wg.Done()
 			select {
 			case sem <- struct{}{}:
 			case <-fetchCtx.Done():
@@ -658,38 +655,45 @@ func (b *Broker) resolveUniqueRefs(ctx context.Context, requestID string, req re
 			defer func() { <-sem }()
 
 			value, err := b.resolver.Resolve(fetchCtx, identity.ref, identity.account)
-			results <- result{identity: identity, value: value, err: err}
+			select {
+			case results <- result{identity: identity, value: value, err: err}:
+			case <-fetchCtx.Done():
+			}
 		}(identity)
 	}
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
 
 	resolved := make(map[secretIdentity]string, len(identities))
-	var firstErr error
-	for got := range results {
-		if got.err != nil {
-			if firstErr == nil {
-				cancelFetches()
-				if err := b.recordSecretFetchFailed(ctx, requestID, secrets, got.identity, got.err); err != nil {
-					firstErr = err
-				} else {
-					firstErr = fmt.Errorf("resolve approved ref: %w", got.err)
-				}
+	pending := make(map[secretIdentity]struct{}, len(identities))
+	for _, identity := range identities {
+		pending[identity] = struct{}{}
+	}
+	for remaining := len(identities); remaining > 0; remaining-- {
+		var got result
+		select {
+		case got = <-results:
+			delete(pending, got.identity)
+		case <-fetchCtx.Done():
+			err := contextCause(fetchCtx)
+			if auditErr := b.recordSecretFetchFailedForIdentities(
+				ctx,
+				requestID,
+				secrets,
+				pendingIdentities(identities, pending),
+				err,
+			); auditErr != nil {
+				return nil, auditErr
 			}
-			continue
+			return nil, fmt.Errorf("resolve approved ref: %w", err)
 		}
-		if firstErr == nil {
-			resolved[got.identity] = got.value
-		}
-	}
 
-	if firstErr != nil {
-		return nil, firstErr
-	}
-	if err := fetchCtx.Err(); err != nil {
-		return nil, fmt.Errorf("resolve approved ref: %w", err)
+		if got.err != nil {
+			cancelFetches()
+			if err := b.recordSecretFetchFailed(ctx, requestID, secrets, got.identity, got.err); err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("resolve approved ref: %w", got.err)
+		}
+		resolved[got.identity] = got.value
 	}
 
 	return resolved, nil
@@ -777,10 +781,29 @@ func (b *Broker) recordSecretFetchFailed(
 	identity secretIdentity,
 	err error,
 ) error {
+	return b.recordSecretFetchFailureEvent(ctx, requestID, auditRefsForIdentity(secrets, identity), err)
+}
+
+func (b *Broker) recordSecretFetchFailedForIdentities(
+	ctx context.Context,
+	requestID string,
+	secrets []request.Secret,
+	identities []secretIdentity,
+	err error,
+) error {
+	return b.recordSecretFetchFailureEvent(ctx, requestID, auditRefsForIdentities(secrets, identities), err)
+}
+
+func (b *Broker) recordSecretFetchFailureEvent(
+	ctx context.Context,
+	requestID string,
+	refs []audit.SecretRef,
+	err error,
+) error {
 	event := audit.Event{
 		Type:       audit.EventSecretFetchFailed,
 		RequestID:  requestID,
-		SecretRefs: auditRefsForIdentity(secrets, identity),
+		SecretRefs: refs,
 		ErrorCode:  secretFetchErrorCode(err),
 	}
 	auditCtx, cancel := terminalAuditContext(ctx)
@@ -801,6 +824,13 @@ func secretFetchErrorCode(err error) string {
 	return "resolve_failed"
 }
 
+func contextCause(ctx context.Context) error {
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	return ctx.Err()
+}
+
 func auditRefsForIdentity(secrets []request.Secret, identity secretIdentity) []audit.SecretRef {
 	refs := []audit.SecretRef{}
 	for _, secret := range secrets {
@@ -817,6 +847,44 @@ func auditRefsForIdentity(secrets []request.Secret, identity secretIdentity) []a
 		return []audit.SecretRef{{Ref: identity.ref, Account: identity.account}}
 	}
 	return refs
+}
+
+func auditRefsForIdentities(secrets []request.Secret, identities []secretIdentity) []audit.SecretRef {
+	refs := []audit.SecretRef{}
+	seen := make(map[secretIdentity]struct{}, len(identities))
+	for _, identity := range identities {
+		seen[identity] = struct{}{}
+	}
+	matched := make(map[secretIdentity]struct{}, len(identities))
+	for _, secret := range secrets {
+		identity := secretIdentity{ref: secret.Ref.Raw, account: secret.Account}
+		if _, ok := seen[identity]; !ok {
+			continue
+		}
+		matched[identity] = struct{}{}
+		refs = append(refs, audit.SecretRef{
+			Alias:   secret.Alias,
+			Ref:     secret.Ref.Raw,
+			Account: secret.Account,
+		})
+	}
+	for _, identity := range identities {
+		if _, ok := matched[identity]; ok {
+			continue
+		}
+		refs = append(refs, audit.SecretRef{Ref: identity.ref, Account: identity.account})
+	}
+	return refs
+}
+
+func pendingIdentities(ordered []secretIdentity, pending map[secretIdentity]struct{}) []secretIdentity {
+	identities := make([]secretIdentity, 0, len(pending))
+	for _, identity := range ordered {
+		if _, ok := pending[identity]; ok {
+			identities = append(identities, identity)
+		}
+	}
+	return identities
 }
 
 func (b *Broker) cacheResolvedValues(

--- a/internal/daemon/broker_test.go
+++ b/internal/daemon/broker_test.go
@@ -203,6 +203,17 @@ func (r *blockingResolver) Resolve(ctx context.Context, _ string, _ string) (str
 	return "", ctx.Err()
 }
 
+type contextIgnoringResolver struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (r *contextIgnoringResolver) Resolve(ctx context.Context, _ string, _ string) (string, error) {
+	close(r.started)
+	<-r.release
+	return "", ctx.Err()
+}
+
 type advancingResolver struct {
 	value   string
 	advance func()
@@ -692,6 +703,71 @@ func TestBrokerRequestDeadlineCancelsSlowSecretFetch(t *testing.T) {
 	}
 	if err := broker.MarkPayloadDelivered("req_1"); !errors.Is(err, ErrUnknownRequest) {
 		t.Fatalf("request should not become active after fetch deadline expiry, got %v", err)
+	}
+}
+
+func TestBrokerRequestDeadlineReturnsWhenResolverIgnoresCancellation(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	now := time.Now()
+	req := testExecRequestAt(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+	req.TTL = 50 * time.Millisecond
+	req.ExpiresAt = req.ReceivedAt.Add(req.TTL)
+	resolver := &contextIgnoringResolver{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	defer close(resolver.release)
+	aud := &contextCheckingAudit{}
+	broker, err := NewBroker(BrokerOptions{
+		Now:      time.Now,
+		Approver: &mockApprover{decision: ApprovalDecision{Approved: true}},
+		Resolver: resolver,
+		Audit:    aud,
+	})
+	if err != nil {
+		t.Fatalf("NewBroker returned error: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := broker.HandleExec(context.Background(), "req_1", "nonce_1", req)
+		errCh <- err
+	}()
+	receiveBrokerSignal(t, resolver.started, "secret resolution did not start before request deadline")
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrRequestExpired) {
+			t.Fatalf("HandleExec error = %v, want request expired", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HandleExec did not return after request deadline when resolver ignored cancellation")
+	}
+
+	events := aud.Events()
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventSecretFetchFailed,
+	}
+	if got := auditEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+	failure := events[len(events)-1]
+	if failure.ErrorCode != "context_deadline_exceeded" {
+		t.Fatalf("fetch failure error code = %q", failure.ErrorCode)
+	}
+	if len(failure.SecretRefs) != 1 || failure.SecretRefs[0].Alias != "TOKEN" || failure.SecretRefs[0].Ref != ref {
+		t.Fatalf("fetch failure refs = %+v", failure.SecretRefs)
+	}
+	if containsAuditEvent(events, audit.EventCommandStarting) {
+		t.Fatal("command_starting was audited after hung resolver crossed request deadline")
+	}
+	if err := broker.MarkPayloadDelivered("req_1"); !errors.Is(err, ErrUnknownRequest) {
+		t.Fatalf("request should not become active after hung resolver deadline, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #236.

- make secret-resolution fan-in return as soon as the request/fetch context is done
- stop waiting for every resolver goroutine before returning after the first failure or request expiry
- audit context-driven fetch failures for the unresolved secret identities
- add a regression with a resolver that ignores cancellation until explicitly released

## Verification

- `mise exec -- go test ./internal/daemon -run 'TestBrokerRequestDeadline(ReturnsWhenResolverIgnoresCancellation|CancelsSlowSecretFetch)|TestBrokerCancelsOutstandingFetchesAfterFirstFailure|TestBrokerStopCancelsSecretResolution' -count=1`
- `mise exec -- go test ./internal/daemon -count=1`
- `mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5`
- `GOFLAGS=-p=1 mise run test`
- `mise exec -- go test -race ./internal/daemon -run 'TestBrokerRequestDeadlineReturnsWhenResolverIgnoresCancellation|TestBrokerCancelsOutstandingFetchesAfterFirstFailure|TestBrokerStopCancelsSecretResolution' -count=1`
- `GOFLAGS=-p=1 mise run lint`
- `mise run build`
- `mise run test:smoke`
- `git diff --check`

Note: an initial un-serialized `mise run test` hit the known local `TestProcessApproverLauncherHealthCheck` timeout flake; the isolated health check and serialized full test run both passed.
