### PR TITLE
ASR-092: forward repeated interrupts

### DIFF
--- a/internal/execwrap/execwrap.go
+++ b/internal/execwrap/execwrap.go
@@ -209,7 +209,6 @@ func forwardInterrupts(done <-chan struct{}, process *os.Process, interrupts <-c
 		return
 	}
 
-	seen := 0
 	for {
 		select {
 		case <-done:
@@ -219,12 +218,7 @@ func forwardInterrupts(done <-chan struct{}, process *os.Process, interrupts <-c
 				return
 			}
 			if sig != nil {
-				seen++
-				if seen == 1 {
-					_ = signalChild(process, sig)
-				} else {
-					terminateChildUntilDone(done, process)
-				}
+				_ = signalChild(process, sig)
 			}
 		}
 	}

--- a/internal/execwrap/execwrap_test.go
+++ b/internal/execwrap/execwrap_test.go
@@ -371,6 +371,38 @@ func TestRunForwardsInterruptToChild(t *testing.T) {
 	}
 }
 
+func TestRunForwardsRepeatedInterruptsToChild(t *testing.T) {
+	t.Parallel()
+
+	interrupts := make(chan os.Signal, 2)
+	var stdout bytes.Buffer
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		interrupts <- syscall.SIGINT
+		time.Sleep(100 * time.Millisecond)
+		interrupts <- syscall.SIGINT
+	}()
+
+	result, err := Run(context.Background(), Spec{
+		Path:                   os.Args[0],
+		PathIdentity:           currentExecutableIdentity(t),
+		AllowMutableExecutable: true,
+		Args:                   []string{"-test.run=TestExecHelperProcess", "--", "wait-two-signals"},
+		Env:                    helperEnv(),
+		Stdout:                 &stdout,
+	}, interrupts)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.ExitCode != 130 {
+		t.Fatalf("exit code = %d, want 130; stdout=%q", result.ExitCode, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "signal-1") || !strings.Contains(stdout.String(), "signal-2") {
+		t.Fatalf("child did not observe both forwarded signals; stdout=%q", stdout.String())
+	}
+}
+
 func TestRunTerminatesChildOnContextCancel(t *testing.T) {
 	t.Parallel()
 
@@ -468,6 +500,15 @@ func TestExecHelperProcess(t *testing.T) {
 		fmt.Println("ready")
 		<-signals
 		fmt.Println("signal-ok")
+		os.Exit(130)
+	case "wait-two-signals":
+		signals := make(chan os.Signal, 2)
+		signalNotify(signals, syscall.SIGINT)
+		fmt.Println("ready")
+		<-signals
+		fmt.Println("signal-1")
+		<-signals
+		fmt.Println("signal-2")
 		os.Exit(130)
 	case "sleep-long":
 		time.Sleep(10 * time.Second)


### PR DESCRIPTION
## Summary
- forward every user interrupt signal to the supervised child process
- keep SIGTERM/SIGKILL escalation reserved for context cancellation and daemon cleanup
- add a regression helper that proves a child sees two SIGINTs before exiting

Fixes #237

## Verification
- mise exec -- go test ./internal/execwrap -run 'TestRunForwards(InterruptToChild|RepeatedInterruptsToChild)|TestRunTerminatesChildOnContextCancel' -count=1\n- mise exec -- go test -race ./internal/execwrap -run 'TestRunForwardsRepeatedInterruptsToChild|TestRunTerminatesChildOnContextCancel' -count=1\n- mise run test\n- GOFLAGS=-p=1 mise run lint\n- mise run build\n- mise run test:smoke\n- git diff --check