### PR TITLE
ASR-093: pin release Go environment

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -188,7 +188,10 @@ Signed release builds must already be inside a trusted toolchain context. The
 release builder refuses to re-exec a `mise` binary discovered through `PATH`
 when signing or notarization environment variables are present; CI uses the
 pinned `jdx/mise-action` and invokes the release builder through `mise exec`
-with `AGENT_SECRET_IN_MISE=1`.
+with `AGENT_SECRET_IN_MISE=1`. The app bundle builder also rejects an inherited
+`GOROOT` that does not match the selected Go binary and runs Go commands with
+`GOROOT` unset, so caller environment variables cannot silently swap the
+compiler for signed artifacts.
 
 ## Failed Release Runs
 

--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -77,7 +77,20 @@ require_tool() {
   fi
 }
 
-tool_go="${GOROOT:-}/bin/go"
+resolve_path_tool() {
+  local name="$1"
+  local path=""
+
+  path="$(command -v "$name" || true)"
+  if [[ "$path" != /* ]]; then
+    echo "build-app-bundle: required command not found on trusted toolchain PATH: $name" >&2
+    exit 1
+  fi
+  require_tool "$name" "$path"
+  printf '%s\n' "$path"
+}
+
+tool_go="$(resolve_path_tool go)"
 tool_swift="/usr/bin/swift"
 tool_mktemp="/usr/bin/mktemp"
 tool_rm="/bin/rm"
@@ -88,7 +101,6 @@ tool_sips="/usr/bin/sips"
 tool_iconutil="/usr/bin/iconutil"
 tool_codesign="/usr/bin/codesign"
 
-require_tool go "$tool_go"
 require_tool swift "$tool_swift"
 require_tool mktemp "$tool_mktemp"
 require_tool rm "$tool_rm"
@@ -98,6 +110,21 @@ require_tool cp "$tool_cp"
 require_tool sips "$tool_sips"
 require_tool iconutil "$tool_iconutil"
 require_tool codesign "$tool_codesign"
+
+run_go() (
+  unset GOROOT
+  "$tool_go" "$@"
+)
+
+selected_goroot="$(run_go env GOROOT)" || {
+  echo "build-app-bundle: could not query selected Go toolchain GOROOT" >&2
+  exit 1
+}
+if [[ "${GOROOT:-}" != "" && "$GOROOT" != "$selected_goroot" ]]; then
+  echo "build-app-bundle: inherited GOROOT does not match selected Go toolchain" >&2
+  echo "build-app-bundle: run from the trusted mise context without overriding GOROOT" >&2
+  exit 1
+fi
 
 tmp_dir="$("$tool_mktemp" -d "${TMPDIR:-/tmp}/agent-secret-bundle.XXXXXX")"
 cleanup() {
@@ -224,8 +251,8 @@ if [[ "$codesign_identity" != "-" ]]; then
   }
 fi
 go_build_flags+=(-ldflags "-X github.com/kovyrin/agent-secret/internal/daemon.defaultDeveloperIDTeamID=$approver_team_id")
-"$tool_go" build "${go_build_flags[@]}" -o "$tmp_dir/agent-secret" ./cmd/agent-secret
-"$tool_go" build "${go_build_flags[@]}" -o "$tmp_dir/agent-secretd" ./cmd/agent-secretd
+run_go build "${go_build_flags[@]}" -o "$tmp_dir/agent-secret" ./cmd/agent-secret
+run_go build "${go_build_flags[@]}" -o "$tmp_dir/agent-secretd" ./cmd/agent-secretd
 
 echo "Building Swift app executable..."
 cd "$project_root/approver"

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -173,6 +173,39 @@ expect_failure "production release requires AGENT_SECRET_CODESIGN_IDENTITY" \
   "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/path-trap-out"
 assert_path_trap_clean "$trap_log"
 
+fake_goroot="$tmp_dir/fake-goroot"
+fake_goroot_log="$tmp_dir/fake-goroot.log"
+trusted_go="$(command -v go || true)"
+if [[ "$trusted_go" == "" ]] && command -v mise >/dev/null 2>&1; then
+  trusted_go="$(mise exec -- command -v go || true)"
+fi
+if [[ "$trusted_go" == "" || "$trusted_go" != /* ]]; then
+  fail "could not locate trusted go for GOROOT trap test"
+fi
+trusted_go_path="${trusted_go%/*}:$test_path"
+mkdir -p "$fake_goroot/bin"
+cat >"$fake_goroot/bin/go" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "fake-goroot-go $*" >>"$AGENT_SECRET_FAKE_GOROOT_LOG"
+exit 44
+BASH
+chmod 755 "$fake_goroot/bin/go"
+: >"$fake_goroot_log"
+
+expect_failure "inherited GOROOT does not match selected Go toolchain" \
+  env -i \
+  "PATH=$trusted_go_path" \
+  AGENT_SECRET_FAKE_GOROOT_LOG="$fake_goroot_log" \
+  "${release_env[@]}" \
+  AGENT_SECRET_NOTARIZE=1 \
+  AGENT_SECRET_IN_MISE=1 \
+  GOROOT="$fake_goroot" \
+  "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/goroot-trap-out"
+if [[ -s "$fake_goroot_log" ]]; then
+  fail "release script executed fake GOROOT go: $(cat "$fake_goroot_log")"
+fi
+
 if grep -En '(^|[|;&][[:space:]]*)(base64|security|uuidgen|mktemp|rm|chmod)([[:space:]]|$)' "$import_certificate"; then
   fail "import-codesign-certificate.sh contains bare secret-handling tool invocation"
 fi


### PR DESCRIPTION
## Summary
- select the Go compiler from the trusted toolchain PATH instead of inherited GOROOT
- reject inherited GOROOT values that do not match the selected Go binary and run Go with GOROOT unset
- add a production-signing regression that proves fake GOROOT/bin/go is not executed
- document the release-toolchain GOROOT guard

Fixes #238

## Verification
- AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh
- mise exec -- shellcheck scripts/build-app-bundle.sh scripts/test-release-signing-env.sh
- AGENT_SECRET_IN_MISE=1 scripts/test-release-docs.sh
- npx --yes markdownlint-cli docs/release-process.md
- mise exec -- go test ./internal/daemon -run TestProcessApproverLauncherHealthCheck -count=5
- GOFLAGS=-p=1 mise run test
- GOFLAGS=-p=1 mise run lint
- mise run build
- mise run test:smoke
- git diff --check

Note: an initial un-serialized `mise run test` hit the known local `TestProcessApproverLauncherHealthCheck` timeout; the isolated `-count=5` rerun and serialized full test pass were clean.