### PR TITLE
ASR-094: harden release script bootstrap

### DIFF
--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 usage() {
@@ -15,7 +15,12 @@ Flags:
 USAGE
 }
 
-script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+script_path="${BASH_SOURCE[0]}"
+script_dir_part="${script_path%/*}"
+if [[ "$script_dir_part" == "$script_path" ]]; then
+  script_dir_part="."
+fi
+script_dir="$(cd -- "$script_dir_part" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 # shellcheck source=scripts/bundle-metadata.sh
 # shellcheck disable=SC1091

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 usage() {
@@ -15,7 +15,12 @@ Flags:
 USAGE
 }
 
-script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+script_path="${BASH_SOURCE[0]}"
+script_dir_part="${script_path%/*}"
+if [[ "$script_dir_part" == "$script_path" ]]; then
+  script_dir_part="."
+fi
+script_dir="$(cd -- "$script_dir_part" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 output_dir="$project_root/dist"
 require_production_signing=0

--- a/scripts/check-bundle-metadata.sh
+++ b/scripts/check-bundle-metadata.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 usage() {
@@ -10,9 +10,15 @@ Verify generated Agent Secret app bundle Info.plist metadata.
 USAGE
 }
 
-script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+script_path="${BASH_SOURCE[0]}"
+script_dir_part="${script_path%/*}"
+if [[ "$script_dir_part" == "$script_path" ]]; then
+  script_dir_part="."
+fi
+script_dir="$(cd -- "$script_dir_part" && pwd)"
 project_root="$(cd -- "$script_dir/.." && pwd)"
 # shellcheck source=scripts/bundle-metadata.sh
+# shellcheck disable=SC1091
 source "$project_root/scripts/bundle-metadata.sh"
 
 app_only=0

--- a/scripts/check-release-signing-env.sh
+++ b/scripts/check-release-signing-env.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 missing=0

--- a/scripts/import-codesign-certificate.sh
+++ b/scripts/import-codesign-certificate.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 usage() {

--- a/scripts/publish-draft-release.sh
+++ b/scripts/publish-draft-release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 fail() {

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -43,11 +43,11 @@ write_path_trap_tools() {
   local tool=""
 
   mkdir -p "$trap_dir"
-  for tool in base64 security uuidgen codesign xcrun ditto hdiutil shasum \
+  for tool in bash dirname base64 security uuidgen codesign xcrun ditto hdiutil shasum \
     mktemp rm mkdir ln chmod install cp sips iconutil go swift uname mise; do
     cat >"$trap_dir/$tool" <<'BASH'
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 printf '%s\n' "${0##*/} $*" >>"$AGENT_SECRET_PATH_TRAP_LOG"
 exit 44
 BASH
@@ -204,6 +204,27 @@ expect_failure "inherited GOROOT does not match selected Go toolchain" \
   "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/goroot-trap-out"
 if [[ -s "$fake_goroot_log" ]]; then
   fail "release script executed fake GOROOT go: $(cat "$fake_goroot_log")"
+fi
+
+release_sensitive_scripts=(
+  "$build_release"
+  "$project_root/scripts/build-app-bundle.sh"
+  "$project_root/scripts/check-bundle-metadata.sh"
+  "$project_root/scripts/check-release-signing-env.sh"
+  "$import_certificate"
+  "$project_root/scripts/publish-draft-release.sh"
+)
+for script in "${release_sensitive_scripts[@]}"; do
+  read -r shebang <"$script"
+  if [[ "$shebang" != "#!/bin/bash" ]]; then
+    fail "$script must use fixed /bin/bash shebang"
+  fi
+done
+if grep -En 'dirname[[:space:]]+--[[:space:]]+"\$\{BASH_SOURCE\[0\]\}"' \
+  "$build_release" \
+  "$project_root/scripts/build-app-bundle.sh" \
+  "$project_root/scripts/check-bundle-metadata.sh"; then
+  fail "release bootstrap scripts must not use PATH-selected dirname"
 fi
 
 if grep -En '(^|[|;&][[:space:]]*)(base64|security|uuidgen|mktemp|rm|chmod)([[:space:]]|$)' "$import_certificate"; then


### PR DESCRIPTION
## Summary

- switch release-sensitive scripts to fixed `/bin/bash` shebangs so PATH cannot select the interpreter while release credentials are present
- remove PATH-selected `dirname` from release bootstrap path resolution
- extend the release signing regression to trap `bash` and `dirname`, and statically require fixed shebangs for release-sensitive entrypoints

Closes #244.

## Verification

- `AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh`
- `mise run lint:shell`
- `mise exec -- scripts/test-release-version.sh`
- `AGENT_SECRET_IN_MISE=1 scripts/test-release-publish.sh`
- `GOFLAGS=-p=1 mise run test`
- `GOFLAGS=-p=1 mise run lint`
- `mise run build`
- `mise run test:smoke`
- `git diff --check`
