### PR TITLE
ASR-095: require pinned Go for signed releases

### DIFF
--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -95,6 +95,55 @@ resolve_path_tool() {
   printf '%s\n' "$path"
 }
 
+release_signing_env_present() {
+  local name=""
+  local value=""
+
+  for name in \
+    AGENT_SECRET_CODESIGN_CERT_P12_BASE64 \
+    AGENT_SECRET_CODESIGN_CERT_P12_PATH \
+    AGENT_SECRET_CODESIGN_CERT_PASSWORD \
+    AGENT_SECRET_CODESIGN_ENTITLEMENTS \
+    AGENT_SECRET_NOTARY_ISSUER_ID \
+    AGENT_SECRET_NOTARY_KEY \
+    AGENT_SECRET_NOTARY_KEY_ID; do
+    if [[ "${!name:-}" != "" ]]; then
+      return 0
+    fi
+  done
+
+  value="${AGENT_SECRET_CODESIGN_IDENTITY:-}"
+  if [[ "$value" != "" && "$value" != "-" ]]; then
+    return 0
+  fi
+  if [[ "${AGENT_SECRET_NOTARIZE:-}" == "1" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+require_release_go_toolchain() {
+  if ! release_signing_env_present; then
+    return
+  fi
+
+  if [[ "${GOROOT:-}" == "" ]]; then
+    echo "build-app-bundle: release signing requires inherited GOROOT from trusted mise toolchain" >&2
+    echo "build-app-bundle: run from the trusted mise context without overriding GOROOT" >&2
+    exit 1
+  fi
+  if [[ "$GOROOT" != /* ]]; then
+    echo "build-app-bundle: inherited GOROOT must be absolute for release signing" >&2
+    exit 1
+  fi
+  if [[ "$tool_go" != "$GOROOT/bin/go" ]]; then
+    echo "build-app-bundle: inherited GOROOT does not match selected Go toolchain" >&2
+    echo "build-app-bundle: run from the trusted mise context without overriding PATH or GOROOT" >&2
+    exit 1
+  fi
+}
+
 tool_go="$(resolve_path_tool go)"
 tool_swift="/usr/bin/swift"
 tool_mktemp="/usr/bin/mktemp"
@@ -115,6 +164,7 @@ require_tool cp "$tool_cp"
 require_tool sips "$tool_sips"
 require_tool iconutil "$tool_iconutil"
 require_tool codesign "$tool_codesign"
+require_release_go_toolchain
 
 run_go() (
   unset GOROOT

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -182,11 +182,15 @@ fi
 if [[ "$trusted_go" == "" || "$trusted_go" != /* ]]; then
   fail "could not locate trusted go for GOROOT trap test"
 fi
+trusted_goroot="$(GOROOT='' "$trusted_go" env GOROOT || true)"
+if [[ "$trusted_goroot" == "" || "$trusted_goroot" != /* ]]; then
+  fail "could not locate trusted GOROOT for release toolchain test"
+fi
 trusted_go_path="${trusted_go%/*}:$test_path"
 mkdir -p "$fake_goroot/bin"
 cat >"$fake_goroot/bin/go" <<'BASH'
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 printf '%s\n' "fake-goroot-go $*" >>"$AGENT_SECRET_FAKE_GOROOT_LOG"
 exit 44
 BASH
@@ -204,6 +208,39 @@ expect_failure "inherited GOROOT does not match selected Go toolchain" \
   "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/goroot-trap-out"
 if [[ -s "$fake_goroot_log" ]]; then
   fail "release script executed fake GOROOT go: $(cat "$fake_goroot_log")"
+fi
+
+expect_failure "release signing requires inherited GOROOT from trusted mise toolchain" \
+  env -i \
+  "PATH=$trusted_go_path" \
+  "${release_env[@]}" \
+  AGENT_SECRET_NOTARIZE=1 \
+  AGENT_SECRET_IN_MISE=1 \
+  "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/missing-goroot-out"
+
+fake_path_go_dir="$tmp_dir/fake-path-go-bin"
+fake_path_go_log="$tmp_dir/fake-path-go.log"
+mkdir -p "$fake_path_go_dir"
+cat >"$fake_path_go_dir/go" <<'BASH'
+#!/bin/sh
+set -eu
+printf '%s\n' "fake-path-go $*" >>"$AGENT_SECRET_FAKE_PATH_GO_LOG"
+exit 44
+BASH
+chmod 755 "$fake_path_go_dir/go"
+: >"$fake_path_go_log"
+
+expect_failure "inherited GOROOT does not match selected Go toolchain" \
+  env -i \
+  "PATH=$fake_path_go_dir:$trusted_go_path" \
+  AGENT_SECRET_FAKE_PATH_GO_LOG="$fake_path_go_log" \
+  "${release_env[@]}" \
+  AGENT_SECRET_NOTARIZE=1 \
+  AGENT_SECRET_IN_MISE=1 \
+  GOROOT="$trusted_goroot" \
+  "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/path-go-trap-out"
+if [[ -s "$fake_path_go_log" ]]; then
+  fail "release script executed fake PATH go: $(cat "$fake_path_go_log")"
 fi
 
 release_sensitive_scripts=(


### PR DESCRIPTION
## Summary

- require release-signing builds to inherit a trusted absolute `GOROOT`
- reject signed release builds when `go` from `PATH` is not exactly `$GOROOT/bin/go` before executing any Go command
- add release-signing regressions for missing `GOROOT` and fake PATH `go` that must not execute

Closes #245.

## Verification

- `AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh`
- `mise run lint:shell`
- `mise exec -- scripts/test-release-version.sh`
- `GOFLAGS=-p=1 mise run test`
- `GOFLAGS=-p=1 mise run lint`
- `mise run build`
- `mise run test:smoke`
- `git diff --check`
