### PR TITLE
ASR-096: sanitize Swift protocol errors

### DIFF
--- a/approver/Sources/AgentSecretApprover/SocketDaemonClient.swift
+++ b/approver/Sources/AgentSecretApprover/SocketDaemonClient.swift
@@ -18,7 +18,7 @@ public final class SocketDaemonClient: ApprovalDaemonClient {
 
             throw DecodingError.dataCorruptedError(
                 in: container,
-                debugDescription: "invalid ISO8601 date: \(value)"
+                debugDescription: "invalid ISO8601 date"
             )
         }
     }
@@ -88,22 +88,47 @@ public final class SocketDaemonClient: ApprovalDaemonClient {
         nonce: String? = nil
     ) throws -> DaemonEnvelope<Payload> {
         let data: Data = try transport.readLine()
-        let header: DaemonHeader = try decoder.decode(DaemonHeader.self, from: data)
+        let header: DaemonHeader = try decodeHeader(from: data)
         try validateHeader(header)
         if header.type == Self.typeError {
-            let response: DaemonEnvelope<DaemonErrorPayload> = try decoder.decode(
+            let response: DaemonEnvelope<DaemonErrorPayload> = try decodeEnvelope(
                 DaemonEnvelope<DaemonErrorPayload>.self,
-                from: data
+                from: data,
+                invalidMessage: "malformed daemon error response"
             )
             try validateCorrelationIfNeeded(response, requestID: requestID, nonce: nonce)
             throw daemonError(from: response)
         }
         guard header.type == Self.typeOK else {
-            throw SocketDaemonClientError.invalidResponse("unexpected response type \(header.type)")
+            throw SocketDaemonClientError.invalidResponse("unexpected response type")
         }
-        let response: DaemonEnvelope<Payload> = try decoder.decode(DaemonEnvelope<Payload>.self, from: data)
+        let response: DaemonEnvelope<Payload> = try decodeEnvelope(
+            DaemonEnvelope<Payload>.self,
+            from: data,
+            invalidMessage: "malformed daemon response payload"
+        )
         try validateCorrelationIfNeeded(response, requestID: requestID, nonce: nonce)
         return response
+    }
+
+    private func decodeHeader(from data: Data) throws -> DaemonHeader {
+        do {
+            return try decoder.decode(DaemonHeader.self, from: data)
+        } catch {
+            throw SocketDaemonClientError.invalidResponse("malformed daemon response header")
+        }
+    }
+
+    private func decodeEnvelope<Payload: Codable>(
+        _ type: DaemonEnvelope<Payload>.Type,
+        from data: Data,
+        invalidMessage: String
+    ) throws -> DaemonEnvelope<Payload> {
+        do {
+            return try decoder.decode(type, from: data)
+        } catch {
+            throw SocketDaemonClientError.invalidResponse(invalidMessage)
+        }
     }
 
     private func validateHeader(_ header: DaemonHeader) throws {

--- a/approver/Tests/AgentSecretApproverTests/SocketDaemonClientErrorSanitizationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/SocketDaemonClientErrorSanitizationTests.swift
@@ -42,6 +42,48 @@ final class SocketDaemonClientErrorSanitizationTests: XCTestCase {
         return try encoder.encode(envelope)
     }
 
+    private static func rawResponse(type: String, expiresAt: String = "2030-01-01T00:00:00Z") throws -> Data {
+        let object: [String: Any] = [
+            "nonce": "nonce_456",
+            "payload": [
+                "command": ["/usr/bin/env", "echo"],
+                "cwd": "/tmp/project",
+                "expiresAt": expiresAt,
+                "nonce": "nonce_456",
+                "reason": "Run deployment",
+                "requestID": "req_123",
+                "resolvedExecutable": "/usr/bin/env",
+                "secrets": [
+                    [
+                        "account": "prod-account-123",
+                        "alias": "SECRET_ALIAS_CANARY",
+                        "ref": "op://Example Vault/Deploy/token"
+                    ]
+                ]
+            ] as [String: Any],
+            "request_id": "req_123",
+            "type": type,
+            "version": expectedProtocolVersion
+        ]
+        return try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    }
+
+    private func assertDisplayedError(
+        from expression: () throws -> Void,
+        equals expected: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try expression(), file: file, line: line) { error in
+            let displayed = String(describing: error)
+            XCTAssertEqual(displayed, expected, file: file, line: line)
+            XCTAssertFalse(displayed.contains("op://"), file: file, line: line)
+            XCTAssertFalse(displayed.contains("SECRET_ALIAS_CANARY"), file: file, line: line)
+            XCTAssertFalse(displayed.contains("prod-account-123"), file: file, line: line)
+            XCTAssertFalse(displayed.contains(Self.secretCanary), file: file, line: line)
+        }
+    }
+
     func testDaemonErrorDisplayRedactsDaemonSuppliedMessageText() throws {
         let message = """
         failed op://Example Vault/Deploy/token for alias SECRET_ALIAS_CANARY \
@@ -80,6 +122,30 @@ final class SocketDaemonClientErrorSanitizationTests: XCTestCase {
             XCTAssertFalse(displayed.contains("op://"))
             XCTAssertFalse(displayed.contains(Self.secretCanary))
         }
+    }
+
+    func testUnexpectedResponseTypeDoesNotEchoDaemonText() throws {
+        let response = try Self.rawResponse(type: Self.secretCanary)
+        let client = SocketDaemonClient(
+            transport: MemoryLineTransport(reads: [response])
+        )
+
+        assertDisplayedError(
+            from: { _ = try client.fetchPendingRequest() },
+            equals: "invalid daemon response: unexpected response type"
+        )
+    }
+
+    func testInvalidPayloadDecodeErrorDoesNotEchoDaemonText() throws {
+        let response = try Self.rawResponse(type: "ok", expiresAt: Self.secretCanary)
+        let client = SocketDaemonClient(
+            transport: MemoryLineTransport(reads: [response])
+        )
+
+        assertDisplayedError(
+            from: { _ = try client.fetchPendingRequest() },
+            equals: "invalid daemon response: malformed daemon response payload"
+        )
     }
 
     deinit {

--- a/approver/Tests/AgentSecretApproverTests/SocketDaemonClientTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/SocketDaemonClientTests.swift
@@ -155,7 +155,7 @@ final class SocketDaemonClientTests: XCTestCase {
             )
         )
 
-        assertInvalidResponse("unexpected response type approval.pending") {
+        assertInvalidResponse("unexpected response type") {
             _ = try client.fetchPendingRequest()
         }
     }


### PR DESCRIPTION
## Summary

- stop echoing daemon-controlled response types in Swift invalid-response errors
- map malformed daemon headers, error payloads, and OK payloads to fixed value-free messages
- remove raw invalid date strings from the custom date decoder and cover unexpected-type/date failures with redaction tests

Closes #246.

## Verification

- `cd approver && swift test --filter SocketDaemonClient`
- `mise run lint:swift`
- `GOFLAGS=-p=1 mise run test`
- `GOFLAGS=-p=1 mise run lint`
- `mise run build`
- `mise run test:smoke`
- `git diff --check`
