### PR TITLE
ASR-097: Add full approval scope inspector

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalPanelContextRow.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalPanelContextRow.swift
@@ -24,6 +24,7 @@ import Foundation
                                 .buttonStyle(.plain)
                                 .font(.system(size: Metric.detailSubtitleFontSize, weight: .medium))
                                 .foregroundStyle(Color.green)
+                                .accessibilityLabel("View full \(title)")
                         }
                     }
                     Text(value)

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestContextSection.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestContextSection.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+#if canImport(AppKit) && canImport(SwiftUI)
+    import SwiftUI
+
+    struct ApprovalRequestContextSection: View {
+        private typealias Metric = ApprovalPanelStyle.Metric
+
+        let viewModel: ApprovalRequestViewModel
+        @Binding var textInspection: ApprovalPanelTextInspection?
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: Metric.contextRowSpacing) {
+                ApprovalPanelContextRow(
+                    icon: "bubble.left",
+                    title: "Reason",
+                    value: viewModel.reason,
+                    valueLineLimit: nil
+                )
+                ApprovalPanelContextRow(
+                    icon: "terminal",
+                    title: "Command",
+                    value: viewModel.command,
+                    inspectAction: commandInspectionAction
+                )
+                ApprovalPanelContextRow(
+                    icon: "folder",
+                    title: "Project folder",
+                    value: viewModel.projectFolder,
+                    inspectAction: requestScopeInspectionAction
+                )
+                ApprovalPanelContextRow(
+                    icon: "scope",
+                    title: "Scope",
+                    value: viewModel.scopeSummary,
+                    inspectAction: requestScopeInspectionAction
+                )
+            }
+        }
+
+        private var commandInspectionAction: (() -> Void)? {
+            guard viewModel.commandNeedsInspector else {
+                return nil
+            }
+            return {
+                textInspection = ApprovalPanelTextInspection(
+                    title: "Command arguments",
+                    text: viewModel.commandInspectionText
+                )
+            }
+        }
+
+        private var requestScopeInspectionAction: () -> Void {
+            {
+                textInspection = ApprovalPanelTextInspection(
+                    title: "Full request scope",
+                    text: viewModel.requestInspectionText
+                )
+            }
+        }
+    }
+#endif

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestPanelView.swift
@@ -108,34 +108,7 @@ import Foundation
         }
 
         private var requestContext: some View {
-            VStack(alignment: .leading, spacing: Metric.contextRowSpacing) {
-                ApprovalPanelContextRow(
-                    icon: "bubble.left",
-                    title: "Reason",
-                    value: viewModel.reason,
-                    valueLineLimit: nil
-                )
-                ApprovalPanelContextRow(
-                    icon: "terminal",
-                    title: "Command",
-                    value: viewModel.command,
-                    inspectAction: commandInspectionAction
-                )
-                ApprovalPanelContextRow(icon: "folder", title: "Project folder", value: viewModel.projectFolder)
-                ApprovalPanelContextRow(icon: "scope", title: "Scope", value: viewModel.scopeSummary)
-            }
-        }
-
-        private var commandInspectionAction: (() -> Void)? {
-            guard viewModel.commandNeedsInspector else {
-                return nil
-            }
-            return {
-                textInspection = ApprovalPanelTextInspection(
-                    title: "Command arguments",
-                    text: viewModel.commandInspectionText
-                )
-            }
+            ApprovalRequestContextSection(viewModel: viewModel, textInspection: $textInspection)
         }
 
         private var caution: some View {

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Inspection.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Inspection.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+extension ApprovalRequestViewModel {
+    /// Full approval scope text for reviewing truncated request fields.
+    var requestInspectionText: String {
+        Self.requestInspectionText(
+            RequestInspectionInput(
+                reason: reason,
+                commandArgumentRows: commandArguments.map(\.inspectorLine),
+                cwd: cwd,
+                resolvedExecutable: resolvedExecutable,
+                secretRows: secretRows,
+                scopeSummary: scopeSummary,
+                timeRemaining: timeRemaining
+            )
+        )
+    }
+}
+
+extension ApprovalRequestViewModel {
+    private struct RequestInspectionInput {
+        let reason: String
+        let commandArgumentRows: [String]
+        let cwd: String
+        let resolvedExecutable: String?
+        let secretRows: [String]
+        let scopeSummary: String
+        let timeRemaining: String
+    }
+
+    private static func requestInspectionText(_ input: RequestInspectionInput) -> String {
+        var lines: [String] = [
+            "Reason: \(input.reason)",
+            "Command argv:"
+        ]
+        lines.append(contentsOf: input.commandArgumentRows)
+        lines.append("Working directory: \(input.cwd)")
+        lines.append("Resolved binary: \(input.resolvedExecutable ?? "not resolved")")
+        lines.append("Scope: \(input.scopeSummary)")
+        lines.append("Secrets:")
+        lines.append(contentsOf: input.secretRows)
+        lines.append("Time remaining: \(input.timeRemaining)")
+        return lines.joined(separator: "\n")
+    }
+}

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
@@ -67,6 +67,39 @@ final class ApprovalControllerTests: XCTestCase {
         ]
     }
 
+    private static var longScopeRequest: ApprovalRequest {
+        ApprovalRequest(
+            requestID: "req_long_scope",
+            nonce: "nonce_long_scope",
+            reason: "Run deployment with account-qualified references",
+            command: [
+                "/tmp/project/bin/deploy-with-secrets",
+                "--environment",
+                "production"
+            ],
+            cwd: "/tmp/project/services/release/with/a/very/long/path/component/that/must/stay-visible",
+            expiresAt: Date(timeIntervalSince1970: sampleExpiration),
+            secrets: [
+                RequestedSecret(
+                    alias: "SERVICE_TOKEN",
+                    ref: "op://Very Long Production Vault/Service Token With Shared Prefix/token-ending-a",
+                    account: "production-east-account-with-long-suffix-a"
+                ),
+                RequestedSecret(
+                    alias: "SERVICE_TOKEN_BACKUP",
+                    ref: "op://Very Long Production Vault/Service Token With Shared Prefix/token-ending-b",
+                    account: "production-east-account-with-long-suffix-b"
+                ),
+                RequestedSecret(
+                    alias: "DEPLOY_KEY",
+                    ref: "op://Very Long Production Vault/Deploy Key/private-key",
+                    account: "production-security-account"
+                )
+            ],
+            resolvedExecutable: "/tmp/project/bin/deploy-with-secrets"
+        )
+    }
+
     private static func fixtureData(_ name: String) throws -> Data {
         let url: URL = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: "json"))
         return try Data(contentsOf: url)
@@ -205,6 +238,30 @@ final class ApprovalControllerTests: XCTestCase {
         XCTAssertEqual(viewModel.requestedSecrets.first?.symbolName, "person")
         XCTAssertTrue(viewModel.footerMessage.contains("The secrets are injected"))
         XCTAssertFalse(viewModel.renderedText.contains(Self.canarySecretValue))
+    }
+
+    func testRequestInspectionTextContainsFullScopeValues() {
+        let request: ApprovalRequest = Self.longScopeRequest
+        let viewModel = ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: Self.viewModelNow)
+        )
+        let inspection: String = viewModel.requestInspectionText
+
+        XCTAssertTrue(inspection.contains(request.cwd))
+        XCTAssertTrue(inspection.contains("/tmp/project/bin/deploy-with-secrets"))
+        XCTAssertTrue(
+            inspection.contains("op://Very Long Production Vault/Service Token With Shared Prefix/token-ending-a")
+        )
+        XCTAssertTrue(
+            inspection.contains("op://Very Long Production Vault/Service Token With Shared Prefix/token-ending-b")
+        )
+        XCTAssertTrue(inspection.contains("Account: production-east-account-with-long-suffix-a"))
+        XCTAssertTrue(inspection.contains("Account: production-east-account-with-long-suffix-b"))
+        XCTAssertTrue(inspection.contains("DEPLOY_KEY [Account: production-security-account]"))
+        XCTAssertFalse(inspection.contains(Self.canarySecretValue))
+        XCTAssertFalse(inspection.contains(request.requestID))
+        XCTAssertFalse(inspection.contains(request.nonce))
     }
 
     func testMutableExecutableWarningIsVisibleOutsideCollapsedDetails() {


### PR DESCRIPTION
## Summary
- add a full request-scope inspector for truncated approval context fields
- keep command inspection focused on argv while project folder and scope open the full request view
- cover long account-qualified secret scopes without exposing request IDs, nonces, or secret values

## Verification
- cd approver && swift test --filter ApprovalControllerTests/testRequestInspectionTextContainsFullScopeValues
- cd approver && swift test --filter ApprovalRequestPanelLayoutTests
- mise run lint:swift
- GOFLAGS=-p=1 mise run test
- GOFLAGS=-p=1 mise run lint
- mise run build
- mise run test:smoke
- git diff --check

Closes #247