### PR TITLE
ASR-098: bound exec payload delivery window

### DIFF
--- a/internal/daemon/broker.go
+++ b/internal/daemon/broker.go
@@ -73,6 +73,7 @@ type ExecGrant struct {
 	ApprovalID         string
 	reusableMutationID string
 	approvalExpiresAt  time.Time
+	deliveryExpiresAt  time.Time
 }
 
 type activeExec struct {
@@ -172,6 +173,7 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 	if err := b.reusableApprovalActive(grant.ApprovalID, grant.approvalExpiresAt); err != nil {
 		return ExecGrant{}, err
 	}
+	grant.deliveryExpiresAt = grantDeliveryExpiresAt(req, grant.approvalExpiresAt)
 
 	event := audit.FromExecRequest(audit.EventCommandStarting, requestID, req)
 	if err := b.recordRequiredAudit(execCtx, event); err != nil {
@@ -196,6 +198,13 @@ func (b *Broker) HandleExec(ctx context.Context, requestID string, nonce string,
 	b.mu.Unlock()
 
 	return grant, nil
+}
+
+func grantDeliveryExpiresAt(req request.ExecRequest, approvalExpiresAt time.Time) time.Time {
+	if !approvalExpiresAt.IsZero() && approvalExpiresAt.Before(req.ExpiresAt) {
+		return approvalExpiresAt
+	}
+	return req.ExpiresAt
 }
 
 func (b *Broker) requestContext(ctx context.Context, req request.ExecRequest) (context.Context, context.CancelFunc) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -38,23 +38,25 @@ func (SameUIDValidator) Validate(conn *net.UnixConn) error {
 }
 
 type Server struct {
-	broker        *Broker
-	approvals     ApprovalEndpoint
-	validator     PeerValidator
-	execValidator ExecPeerValidator
-	maxFrameBytes int64
-	readTimeout   time.Duration
-	stopOnce      sync.Once
-	stop          chan struct{}
+	broker                  *Broker
+	approvals               ApprovalEndpoint
+	validator               PeerValidator
+	execValidator           ExecPeerValidator
+	maxFrameBytes           int64
+	readTimeout             time.Duration
+	beforeExecResponseWrite func()
+	stopOnce                sync.Once
+	stop                    chan struct{}
 }
 
 type ServerOptions struct {
-	Broker        *Broker
-	Approvals     ApprovalEndpoint
-	Validator     PeerValidator
-	ExecValidator ExecPeerValidator
-	MaxFrameBytes int64
-	ReadTimeout   time.Duration
+	Broker                  *Broker
+	Approvals               ApprovalEndpoint
+	Validator               PeerValidator
+	ExecValidator           ExecPeerValidator
+	MaxFrameBytes           int64
+	ReadTimeout             time.Duration
+	beforeExecResponseWrite func()
 }
 
 const DefaultProtocolReadTimeout = 30 * time.Second
@@ -80,13 +82,14 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		readTimeout = DefaultProtocolReadTimeout
 	}
 	return &Server{
-		broker:        opts.Broker,
-		approvals:     opts.Approvals,
-		validator:     validator,
-		execValidator: execValidator,
-		maxFrameBytes: maxFrameBytes,
-		readTimeout:   readTimeout,
-		stop:          make(chan struct{}),
+		broker:                  opts.Broker,
+		approvals:               opts.Approvals,
+		validator:               validator,
+		execValidator:           execValidator,
+		maxFrameBytes:           maxFrameBytes,
+		readTimeout:             readTimeout,
+		beforeExecResponseWrite: opts.beforeExecResponseWrite,
+		stop:                    make(chan struct{}),
 	}, nil
 }
 
@@ -311,6 +314,16 @@ func (s *Server) handleRequestExec(
 		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(ErrDaemonStopped), ErrDaemonStopped)
 		return ""
 	}
+	if s.beforeExecResponseWrite != nil {
+		s.beforeExecResponseWrite()
+	}
+	clearWriteDeadline, err := s.setExecResponseWriteDeadline(conn, grant.deliveryExpiresAt)
+	if err != nil {
+		s.broker.MarkPayloadDeliveryFailed(env.RequestID)
+		_ = writeErrorEncoder(encoder, env.RequestID, env.Nonce, codeForError(err), err)
+		return ""
+	}
+	defer clearWriteDeadline()
 	if err := writeOK(encoder, env.RequestID, env.Nonce, ExecResponsePayload{
 		Env:           grant.Env,
 		SecretAliases: grant.SecretAliases,
@@ -322,6 +335,20 @@ func (s *Server) handleRequestExec(
 		return ""
 	}
 	return env.RequestID
+}
+
+func (s *Server) setExecResponseWriteDeadline(conn *net.UnixConn, expiresAt time.Time) (func(), error) {
+	if expiresAt.IsZero() {
+		return func() {}, nil
+	}
+	remaining := expiresAt.Sub(s.broker.now())
+	if remaining <= 0 {
+		return func() {}, ErrRequestExpired
+	}
+	if err := conn.SetWriteDeadline(time.Now().Add(remaining)); err != nil {
+		return func() {}, fmt.Errorf("set exec response write deadline: %w", err)
+	}
+	return func() { _ = conn.SetWriteDeadline(time.Time{}) }, nil
 }
 
 func (s *Server) handleCommandStarted(

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kovyrin/agent-secret/internal/audit"
 	"github.com/kovyrin/agent-secret/internal/peercred"
+	"github.com/kovyrin/agent-secret/internal/policy"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
 
@@ -431,6 +432,77 @@ func TestServerFailedExecResponseWriteDoesNotConsumeReusableUse(t *testing.T) {
 		if event.Type == audit.EventExecClientDisconnectedAfterPayload && event.RequestID == "req_1" {
 			t.Fatalf("failed response write produced post-payload disconnect audit: %+v", event)
 		}
+	}
+}
+
+func TestServerRejectsExecPayloadWriteAfterDeliveryExpiry(t *testing.T) {
+	t.Parallel()
+
+	daemonNow := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
+	now := daemonNow
+	ref := "op://Example/Item/token"
+	cache := policy.NewSecretCache()
+	approver := &mockApprover{decision: ApprovalDecision{Approved: true, Reusable: true, ReusableUses: 1}}
+	broker := newTestBroker(t, BrokerOptions{
+		Now:      func() time.Time { return now },
+		Cache:    cache,
+		Approver: approver,
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+		Audit:    &memoryAudit{},
+	})
+	var hookOnce sync.Once
+	var approvalMu sync.Mutex
+	var approvalID string
+	path, stop := startRawServerWithOptions(t, ServerOptions{
+		Broker:        broker,
+		Validator:     allowPeerValidator{},
+		ExecValidator: NewTrustedExecutableValidator(CurrentExecutableTrustedClientPaths()),
+		beforeExecResponseWrite: func() {
+			hookOnce.Do(func() {
+				broker.mu.Lock()
+				if active := broker.active["req_1"]; active != nil {
+					approvalMu.Lock()
+					approvalID = active.approvalID
+					approvalMu.Unlock()
+				}
+				broker.mu.Unlock()
+				now = daemonNow.Add(request.DefaultExecTTL + time.Second)
+			})
+		},
+	})
+	defer stop()
+
+	conn, err := Dial(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	client := NewClient(conn)
+	defer func() { _ = client.Close() }()
+	req := testExecRequestAt(t, daemonNow, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}})
+
+	if _, err := client.RequestExec(context.Background(), "req_1", "nonce_1", req); !IsProtocolError(err, "request_expired") {
+		t.Fatalf("RequestExec error = %v, want request_expired", err)
+	}
+	waitForInactiveRequest(t, broker, "req_1")
+	approvalMu.Lock()
+	gotApprovalID := approvalID
+	approvalMu.Unlock()
+	if gotApprovalID == "" {
+		t.Fatal("server did not create a reusable approval before payload delivery")
+	}
+	if _, ok := cache.Get(gotApprovalID, ref, "Work"); ok {
+		t.Fatal("expired reusable approval cache scope remained after failed payload delivery")
+	}
+
+	payload, err := client.RequestExec(context.Background(), "req_2", "nonce_2", req)
+	if err != nil {
+		t.Fatalf("second RequestExec returned error: %v", err)
+	}
+	if payload.Env["TOKEN"] != "value" {
+		t.Fatalf("second payload env = %+v", payload.Env)
+	}
+	if approver.calls != 2 {
+		t.Fatalf("expired payload write reused stale approval; approver calls = %d, want 2", approver.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- carry the effective secret-payload delivery deadline on exec grants
- reject expired deliveries before writing `request.exec` OK payloads
- set a socket write deadline for secret-bearing exec responses and preserve reusable rollback on pre-payload failure

Closes #252.

## Verification
- `GOFLAGS=-p=1 mise exec -- go test ./internal/daemon -run 'TestServerRejectsExecPayloadWriteAfterDeliveryExpiry|TestServerFailedExecResponseWriteDoesNotConsumeReusableUse|TestBrokerRejectsReusableApprovalThatExpiresBeforePayloadDelivery' -count=1`\n- `GOFLAGS=-p=1 mise run test`\n- `GOFLAGS=-p=1 mise run lint`\n- `mise run build`\n- `mise run test:smoke`\n- `GOFLAGS=-p=1 mise exec -- go test -race ./internal/daemon -run 'TestServerRejectsExecPayloadWriteAfterDeliveryExpiry|TestServerFailedExecResponseWriteDoesNotConsumeReusableUse' -count=1`\n- `git diff --check`