### PR TITLE
ASR-101: guard bundle build mise reexec

### DIFF
--- a/scripts/build-app-bundle.sh
+++ b/scripts/build-app-bundle.sh
@@ -15,6 +15,34 @@ Flags:
 USAGE
 }
 
+release_signing_env_present() {
+  local name=""
+  local value=""
+
+  for name in \
+    AGENT_SECRET_CODESIGN_CERT_P12_BASE64 \
+    AGENT_SECRET_CODESIGN_CERT_P12_PATH \
+    AGENT_SECRET_CODESIGN_CERT_PASSWORD \
+    AGENT_SECRET_CODESIGN_ENTITLEMENTS \
+    AGENT_SECRET_NOTARY_ISSUER_ID \
+    AGENT_SECRET_NOTARY_KEY \
+    AGENT_SECRET_NOTARY_KEY_ID; do
+    if [[ "${!name:-}" != "" ]]; then
+      return 0
+    fi
+  done
+
+  value="${AGENT_SECRET_CODESIGN_IDENTITY:-}"
+  if [[ "$value" != "" && "$value" != "-" ]]; then
+    return 0
+  fi
+  if [[ "${AGENT_SECRET_NOTARIZE:-}" == "1" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 script_path="${BASH_SOURCE[0]}"
 script_dir_part="${script_path%/*}"
 if [[ "$script_dir_part" == "$script_path" ]]; then
@@ -27,6 +55,11 @@ project_root="$(cd -- "$script_dir/.." && pwd)"
 source "$project_root/scripts/bundle-metadata.sh"
 
 if [[ "${AGENT_SECRET_IN_MISE:-}" != "1" ]]; then
+  if release_signing_env_present; then
+    echo "build-app-bundle: refusing to re-exec PATH-discovered mise while release signing environment is present" >&2
+    echo "build-app-bundle: run from a trusted toolchain context with AGENT_SECRET_IN_MISE=1" >&2
+    exit 1
+  fi
   if command -v mise >/dev/null 2>&1; then
     export AGENT_SECRET_IN_MISE=1
     exec mise exec -- "$0" "$@"
@@ -93,34 +126,6 @@ resolve_path_tool() {
   fi
   require_tool "$name" "$path"
   printf '%s\n' "$path"
-}
-
-release_signing_env_present() {
-  local name=""
-  local value=""
-
-  for name in \
-    AGENT_SECRET_CODESIGN_CERT_P12_BASE64 \
-    AGENT_SECRET_CODESIGN_CERT_P12_PATH \
-    AGENT_SECRET_CODESIGN_CERT_PASSWORD \
-    AGENT_SECRET_CODESIGN_ENTITLEMENTS \
-    AGENT_SECRET_NOTARY_ISSUER_ID \
-    AGENT_SECRET_NOTARY_KEY \
-    AGENT_SECRET_NOTARY_KEY_ID; do
-    if [[ "${!name:-}" != "" ]]; then
-      return 0
-    fi
-  done
-
-  value="${AGENT_SECRET_CODESIGN_IDENTITY:-}"
-  if [[ "$value" != "" && "$value" != "-" ]]; then
-    return 0
-  fi
-  if [[ "${AGENT_SECRET_NOTARIZE:-}" == "1" ]]; then
-    return 0
-  fi
-
-  return 1
 }
 
 require_release_go_toolchain() {

--- a/scripts/test-release-signing-env.sh
+++ b/scripts/test-release-signing-env.sh
@@ -109,6 +109,15 @@ expect_failure "refusing to re-exec PATH-discovered mise while release signing e
   "$build_release" v0.0.0 --require-production-signing --output "$tmp_dir/mise-trap-out"
 assert_path_trap_clean "$trap_log"
 
+expect_failure "refusing to re-exec PATH-discovered mise while release signing environment is present" \
+  env -i \
+  "PATH=$trap_dir:$test_path" \
+  AGENT_SECRET_PATH_TRAP_LOG="$trap_log" \
+  "${release_env[@]}" \
+  AGENT_SECRET_NOTARIZE=1 \
+  "$project_root/scripts/build-app-bundle.sh" --version v0.0.0 --output "$tmp_dir/bundle-mise-trap-out"
+assert_path_trap_clean "$trap_log"
+
 unsafe_keychain="$tmp_dir/unrelated-user-file"
 dummy_cert="$tmp_dir/dummy.p12"
 printf 'keep\n' >"$unsafe_keychain"


### PR DESCRIPTION
## Summary
- detect release signing/notarization environment before bundle-builder mise re-exec
- refuse PATH-discovered `mise` when release-sensitive env is present outside trusted mise context
- add a fake-PATH regression for direct `build-app-bundle.sh` invocations

Closes #255.

## Verification
- `mise run lint:shell`
- `AGENT_SECRET_IN_MISE=1 scripts/test-release-signing-env.sh`
- `mise run test:smoke`
- `GOFLAGS=-p=1 mise run lint`
- `mise run build`
- `git diff --check`