### PR TITLE
ASR-102: Preserve unrelated installer symlinks

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -177,14 +177,11 @@ func replaceSymlink(linkPath string, targetPath string, force bool) error {
 		}
 		return fmt.Errorf("inspect link path %s: %w", linkPath, err)
 	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		if !force {
-			return fmt.Errorf("%w: %s exists and is not a symlink", ErrRefuseOverwrite, linkPath)
-		}
-		if info.IsDir() {
-			return fmt.Errorf("%w: %s is a directory", ErrRefuseOverwrite, linkPath)
-		}
-	} else if currentTarget, err := os.Readlink(linkPath); err == nil && currentTarget == targetPath {
+	replace, err := shouldReplaceLinkPath(linkPath, targetPath, info, force)
+	if err != nil {
+		return err
+	}
+	if !replace {
 		return nil
 	}
 
@@ -195,4 +192,31 @@ func replaceSymlink(linkPath string, targetPath string, force bool) error {
 		return fmt.Errorf("create symlink %s -> %s: %w", linkPath, targetPath, err)
 	}
 	return nil
+}
+
+func shouldReplaceLinkPath(linkPath string, targetPath string, info os.FileInfo, force bool) (bool, error) {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return shouldReplaceSymlink(linkPath, targetPath, force)
+	}
+	if !force {
+		return false, fmt.Errorf("%w: %s exists and is not a symlink", ErrRefuseOverwrite, linkPath)
+	}
+	if info.IsDir() {
+		return false, fmt.Errorf("%w: %s is a directory", ErrRefuseOverwrite, linkPath)
+	}
+	return true, nil
+}
+
+func shouldReplaceSymlink(linkPath string, targetPath string, force bool) (bool, error) {
+	currentTarget, err := os.Readlink(linkPath)
+	if err != nil {
+		return false, fmt.Errorf("read existing symlink %s: %w", linkPath, err)
+	}
+	if currentTarget == targetPath {
+		return false, nil
+	}
+	if !force {
+		return false, fmt.Errorf("%w: %s points to %s", ErrRefuseOverwrite, linkPath, currentTarget)
+	}
+	return true, nil
 }

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -160,7 +160,7 @@ func TestInstallCLIKeepsExistingMatchingSymlink(t *testing.T) {
 	}
 }
 
-func TestInstallCLIReplacesExistingDifferentSymlink(t *testing.T) {
+func TestInstallCLIRefusesExistingDifferentSymlinkWithoutForce(t *testing.T) {
 	t.Parallel()
 
 	binDir := t.TempDir()
@@ -171,7 +171,31 @@ func TestInstallCLIReplacesExistingDifferentSymlink(t *testing.T) {
 		t.Fatalf("create existing symlink: %v", err)
 	}
 
-	if _, err := InstallCLI(CLIOptions{BinDir: binDir, ExecutablePath: executable}); err != nil {
+	_, err := InstallCLI(CLIOptions{BinDir: binDir, ExecutablePath: executable})
+	if !errors.Is(err, ErrRefuseOverwrite) {
+		t.Fatalf("InstallCLI error = %v, want ErrRefuseOverwrite", err)
+	}
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("read preserved symlink: %v", err)
+	}
+	if target != oldExecutable {
+		t.Fatalf("preserved symlink target = %q, want old executable %q", target, oldExecutable)
+	}
+}
+
+func TestInstallCLIForceReplacesExistingDifferentSymlink(t *testing.T) {
+	t.Parallel()
+
+	binDir := t.TempDir()
+	executable := writeInstallTestExecutable(t, t.TempDir())
+	oldExecutable := writeInstallTestExecutable(t, t.TempDir())
+	linkPath := filepath.Join(binDir, CommandName)
+	if err := os.Symlink(oldExecutable, linkPath); err != nil {
+		t.Fatalf("create existing symlink: %v", err)
+	}
+
+	if _, err := InstallCLI(CLIOptions{BinDir: binDir, ExecutablePath: executable, Force: true}); err != nil {
 		t.Fatalf("InstallCLI returned error: %v", err)
 	}
 	target, err := os.Readlink(linkPath)
@@ -295,7 +319,7 @@ func TestInstallSkillForceReplacesExistingRegularFile(t *testing.T) {
 	}
 }
 
-func TestInstallSkillReplacesExistingDifferentSymlink(t *testing.T) {
+func TestInstallSkillRefusesExistingDifferentSymlinkWithoutForce(t *testing.T) {
 	t.Parallel()
 
 	skillsDir := t.TempDir()
@@ -306,7 +330,31 @@ func TestInstallSkillReplacesExistingDifferentSymlink(t *testing.T) {
 		t.Fatalf("create existing symlink: %v", err)
 	}
 
-	if _, err := InstallSkill(SkillOptions{SkillsDir: skillsDir, SourcePath: source}); err != nil {
+	_, err := InstallSkill(SkillOptions{SkillsDir: skillsDir, SourcePath: source})
+	if !errors.Is(err, ErrRefuseOverwrite) {
+		t.Fatalf("InstallSkill error = %v, want ErrRefuseOverwrite", err)
+	}
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("read preserved symlink: %v", err)
+	}
+	if target != oldSource {
+		t.Fatalf("preserved symlink target = %q, want old source %q", target, oldSource)
+	}
+}
+
+func TestInstallSkillForceReplacesExistingDifferentSymlink(t *testing.T) {
+	t.Parallel()
+
+	skillsDir := t.TempDir()
+	source := writeInstallTestSkill(t, t.TempDir())
+	oldSource := writeInstallTestSkill(t, t.TempDir())
+	linkPath := filepath.Join(skillsDir, SkillName)
+	if err := os.Symlink(oldSource, linkPath); err != nil {
+		t.Fatalf("create existing symlink: %v", err)
+	}
+
+	if _, err := InstallSkill(SkillOptions{SkillsDir: skillsDir, SourcePath: source, Force: true}); err != nil {
 		t.Fatalf("InstallSkill returned error: %v", err)
 	}
 	target, err := os.Readlink(linkPath)


### PR DESCRIPTION
## Summary
- refuse to replace non-matching installer symlinks unless force is set
- keep idempotent same-target symlinks as-is
- cover CLI and skill install behavior for preserve-without-force and replace-with-force

Closes #256

## Verification
- GOFLAGS=-p=1 mise exec -- go test ./internal/install -count=1
- GOFLAGS=-p=1 mise run test
- GOFLAGS=-p=1 mise run lint
- mise run build
- git diff --check