### PR TITLE
ASR-103: Make distribution smoke value-free

### DIFF
--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -420,7 +420,7 @@ agent-secret doctor
 agent-secret exec \
   --reason "Install smoke" \
   --secret TOKEN=op://Example/Item/token \
-  -- env
+  -- sh -c 'test -n "${TOKEN:-}" && printf "TOKEN present\n"'
 ```
 
 The smoke should use a real test-only ref locally and must not print the secret

--- a/scripts/test-public-docs.sh
+++ b/scripts/test-public-docs.sh
@@ -33,4 +33,17 @@ for term in "${private_terms[@]}"; do
   fi
 done
 
+secret_print_examples=(
+  "-- env"
+  "-- printenv"
+  "-- /usr/bin/env"
+)
+
+for pattern in "${secret_print_examples[@]}"; do
+  matches="$(grep -n -F -- "$pattern" "${scan_files[@]}" || true)"
+  if [ -n "$matches" ]; then
+    fail "public docs contain secret-printing exec example '$pattern': $matches"
+  fi
+done
+
 echo "test-public-docs: ok"


### PR DESCRIPTION
## Summary
- replace the distribution acceptance smoke's wrapped env command with a value-free TOKEN presence check
- add public-docs smoke coverage rejecting wrapped env/printenv examples that would print approved secrets

Closes #257

## Verification
- npx --yes markdownlint-cli docs/macos-distribution-plan.md
- AGENT_SECRET_IN_MISE=1 scripts/test-public-docs.sh
- mise run lint:shell
- mise run test:smoke
- GOFLAGS=-p=1 mise run lint
- GOFLAGS=-p=1 mise run test
- mise run build
- git diff --check