### PR TITLE
ASR-104: Surface override-env scope in approver

### DIFF
--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Caution.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Caution.swift
@@ -17,14 +17,16 @@ extension ApprovalRequestViewModel {
         highScopeWarning: Bool
     ) -> WarningPresentation {
         let printsEnvironment: Bool = environmentWarning(for: request)
+        let override: String? = overrideWarning(for: request)
         let mutableExecutable: String? = mutableExecutableWarning(for: request)
         return WarningPresentation(
             printsEnvironment: printsEnvironment,
-            override: overrideWarning(for: request),
+            override: override,
             mutableExecutable: mutableExecutable,
             cautionMessages: cautionMessages(
                 printsEnvironmentWarning: printsEnvironment,
                 highScopeWarning: highScopeWarning,
+                overrideWarning: override,
                 mutableExecutableWarning: mutableExecutable
             )
         )
@@ -48,11 +50,15 @@ extension ApprovalRequestViewModel {
     private static func cautionMessages(
         printsEnvironmentWarning: Bool,
         highScopeWarning: Bool,
+        overrideWarning: String?,
         mutableExecutableWarning: String?
     ) -> [String] {
         var messages: [String] = []
         if printsEnvironmentWarning, !highScopeWarning {
             messages.append(environmentWarningText)
+        }
+        if let overrideWarning {
+            messages.append(overrideWarning)
         }
         if let mutableExecutableWarning {
             messages.append(mutableExecutableWarning)

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Inspection.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel+Inspection.swift
@@ -9,6 +9,8 @@ extension ApprovalRequestViewModel {
                 commandArgumentRows: commandArguments.map(\.inspectorLine),
                 cwd: cwd,
                 resolvedExecutable: resolvedExecutable,
+                overrideEnv: overrideEnv,
+                overriddenAliases: overriddenAliases,
                 secretRows: secretRows,
                 scopeSummary: scopeSummary,
                 timeRemaining: timeRemaining
@@ -23,6 +25,8 @@ extension ApprovalRequestViewModel {
         let commandArgumentRows: [String]
         let cwd: String
         let resolvedExecutable: String?
+        let overrideEnv: Bool
+        let overriddenAliases: [String]
         let secretRows: [String]
         let scopeSummary: String
         let timeRemaining: String
@@ -36,6 +40,13 @@ extension ApprovalRequestViewModel {
         lines.append(contentsOf: input.commandArgumentRows)
         lines.append("Working directory: \(input.cwd)")
         lines.append("Resolved binary: \(input.resolvedExecutable ?? "not resolved")")
+        lines.append("Override existing environment: \(input.overrideEnv ? "yes" : "no")")
+        if input.overriddenAliases.isEmpty {
+            lines.append("Overridden aliases: none")
+        } else {
+            lines.append("Overridden aliases:")
+            lines.append(contentsOf: input.overriddenAliases.map { "- \($0)" })
+        }
         lines.append("Scope: \(input.scopeSummary)")
         lines.append("Secrets:")
         lines.append(contentsOf: input.secretRows)

--- a/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/ApprovalRequestViewModel.swift
@@ -20,7 +20,6 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         let resolvedExecutable: String?
         let secretRows: [String]
         let timeRemaining: String
-        let overrideWarning: String?
         let cautionMessages: [String]
     }
 
@@ -78,6 +77,10 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
     public let allowReusableTitle: String
     /// True when the command commonly prints its environment.
     public let printsEnvironmentWarning: Bool
+    /// True when approved aliases replace existing child environment variables.
+    public let overrideEnv: Bool
+    /// Sanitized aliases that replace existing child environment variables.
+    public let overriddenAliases: [String]
     /// Environment override warning when applicable.
     public let overrideWarning: String?
     /// Mutable executable opt-in warning when applicable.
@@ -116,11 +119,12 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
         compactTimeRemaining = timeRemaining
         let reusableUseLimit: Int = request.reusableUses
         reusableUses = reusableUseLimit
-        let remainingText: String = compactTimeRemaining
-        scopeSummary = Self.scopeSummary(uses: reusableUseLimit, remaining: remainingText, expired: isExpired)
-        allowReusableTitle = Self.reuseTitle(uses: reusableUseLimit, remaining: remainingText, expired: isExpired)
+        scopeSummary = Self.scopeSummary(uses: reusableUseLimit, remaining: timeRemaining, expired: isExpired)
+        allowReusableTitle = Self.reuseTitle(uses: reusableUseLimit, remaining: timeRemaining, expired: isExpired)
         let warnings: WarningPresentation = Self.warningPresentation(for: request, highScopeWarning: highScopeWarning)
         printsEnvironmentWarning = warnings.printsEnvironment
+        overrideEnv = request.overrideEnv
+        overriddenAliases = request.overriddenAliases.map(Self.sanitizedDisplayText)
         overrideWarning = warnings.override
         mutableExecutableWarning = warnings.mutableExecutable
         cautionMessages = warnings.cautionMessages
@@ -137,7 +141,6 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
                 resolvedExecutable: resolvedExecutable,
                 secretRows: secretRows,
                 timeRemaining: timeRemaining,
-                overrideWarning: overrideWarning,
                 cautionMessages: cautionMessages
             )
         )
@@ -208,9 +211,6 @@ public struct ApprovalRequestViewModel: Equatable, Sendable {
             "Reusable approval keeps values in daemon memory for this window " +
                 "and is limited to \(request.reusableUses) uses."
         )
-        if let overrideWarning: String = viewModel.overrideWarning {
-            lines.append(overrideWarning)
-        }
         lines.append(contentsOf: viewModel.cautionMessages)
         return lines.joined(separator: "\n")
     }

--- a/approver/Tests/AgentSecretApproverTests/ApprovalCautionWarningTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalCautionWarningTests.swift
@@ -1,0 +1,92 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class ApprovalCautionWarningTests: XCTestCase {
+    private static let expectedReusableUses: Int = 3
+    private static let sampleExpiration: TimeInterval = 1_800_000_000
+    private static let viewModelNow: TimeInterval = 1_799_999_880
+
+    private static var sampleRequest: ApprovalRequest {
+        ApprovalRequest(
+            requestID: "req_caution_override",
+            nonce: "nonce_caution_override",
+            reason: "Run Terraform plan for staging",
+            command: ["/opt/homebrew/bin/terraform", "plan"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: sampleExpiration),
+            secrets: [
+                RequestedSecret(
+                    alias: "EXAMPLE_TOKEN",
+                    ref: "op://Example Vault/Example Item/token",
+                    account: "Work"
+                )
+            ],
+            resolvedExecutable: "/opt/homebrew/bin/terraform",
+            reusableUses: expectedReusableUses
+        )
+    }
+
+    private static var multiSecretRequest: ApprovalRequest {
+        ApprovalRequest(
+            requestID: "req_caution_multi",
+            nonce: "nonce_caution_multi",
+            reason: "Run integration checks",
+            command: ["/usr/bin/env"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: sampleExpiration),
+            secrets: multiSecrets,
+            resolvedExecutable: "/usr/bin/env",
+            reusableUses: expectedReusableUses
+        )
+    }
+
+    private static var multiSecrets: [RequestedSecret] {
+        [
+            RequestedSecret(alias: "LOGIN", ref: "op://Private/Github/username"),
+            RequestedSecret(alias: "GITHUB_TOKEN", ref: "op://Private/Github/token"),
+            RequestedSecret(alias: "GITHUB_EMAIL", ref: "op://Private/Github/email"),
+            RequestedSecret(alias: "DB_HOST", ref: "op://Database/App/host"),
+            RequestedSecret(alias: "DB_USER", ref: "op://Database/App/user"),
+            RequestedSecret(alias: "DB_PASSWORD", ref: "op://Database/App/password"),
+            RequestedSecret(alias: "DB_NAME", ref: "op://Database/App/name"),
+            RequestedSecret(alias: "OPENAI_API_KEY", ref: "op://OpenAI/Platform/api_key"),
+            RequestedSecret(alias: "OPENAI_ORG_ID", ref: "op://OpenAI/Platform/org_id"),
+            RequestedSecret(alias: "OPENAI_PROJECT_ID", ref: "op://OpenAI/Platform/project_id")
+        ]
+    }
+
+    func testOverrideWarningIsVisibleOutsideCollapsedDetails() {
+        var request: ApprovalRequest = Self.sampleRequest
+        request.overrideEnv = true
+        request.overriddenAliases = ["EXAMPLE_TOKEN", "PATH"]
+        let viewModel = ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: Self.viewModelNow)
+        )
+
+        XCTAssertTrue(viewModel.overrideEnv)
+        XCTAssertEqual(viewModel.overriddenAliases, ["EXAMPLE_TOKEN", "PATH"])
+        XCTAssertTrue(viewModel.cautionMessages.contains { message in
+            message.contains("Will replace existing variables: EXAMPLE_TOKEN, PATH")
+        })
+    }
+
+    func testMutableExecutableWarningIsVisibleOutsideCollapsedDetails() {
+        var request: ApprovalRequest = Self.multiSecretRequest
+        request.allowMutableExecutable = true
+        let viewModel = ApprovalRequestViewModel(
+            request: request,
+            now: Date(timeIntervalSince1970: Self.viewModelNow)
+        )
+
+        XCTAssertTrue(viewModel.highScopeWarning)
+        XCTAssertTrue(viewModel.printsEnvironmentWarning)
+        XCTAssertEqual(viewModel.cautionMessages.count, 1)
+        XCTAssertTrue(viewModel.cautionMessages[0].contains("Mutable executable opt-in"))
+    }
+
+    deinit {
+        /* Required by SwiftLint. */
+    }
+}

--- a/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalControllerTests.swift
@@ -206,6 +206,9 @@ final class ApprovalControllerTests: XCTestCase {
         XCTAssertTrue(viewModel.renderedText.contains("Will replace existing variables: EXAMPLE_TOKEN"))
         XCTAssertTrue(viewModel.renderedText.contains("Mutable executable opt-in"))
         XCTAssertTrue(viewModel.cautionMessages.contains { message in
+            message.contains("Will replace existing variables: EXAMPLE_TOKEN")
+        })
+        XCTAssertTrue(viewModel.cautionMessages.contains { message in
             message.contains("Mutable executable opt-in")
         })
         XCTAssertEqual(viewModel.executable, "terraform")
@@ -241,7 +244,9 @@ final class ApprovalControllerTests: XCTestCase {
     }
 
     func testRequestInspectionTextContainsFullScopeValues() {
-        let request: ApprovalRequest = Self.longScopeRequest
+        var request: ApprovalRequest = Self.longScopeRequest
+        request.overrideEnv = true
+        request.overriddenAliases = ["SERVICE_TOKEN", "DEPLOY_KEY"]
         let viewModel = ApprovalRequestViewModel(
             request: request,
             now: Date(timeIntervalSince1970: Self.viewModelNow)
@@ -250,6 +255,9 @@ final class ApprovalControllerTests: XCTestCase {
 
         XCTAssertTrue(inspection.contains(request.cwd))
         XCTAssertTrue(inspection.contains("/tmp/project/bin/deploy-with-secrets"))
+        XCTAssertTrue(inspection.contains("Override existing environment: yes"))
+        XCTAssertTrue(inspection.contains("- SERVICE_TOKEN"))
+        XCTAssertTrue(inspection.contains("- DEPLOY_KEY"))
         XCTAssertTrue(
             inspection.contains("op://Very Long Production Vault/Service Token With Shared Prefix/token-ending-a")
         )
@@ -262,20 +270,6 @@ final class ApprovalControllerTests: XCTestCase {
         XCTAssertFalse(inspection.contains(Self.canarySecretValue))
         XCTAssertFalse(inspection.contains(request.requestID))
         XCTAssertFalse(inspection.contains(request.nonce))
-    }
-
-    func testMutableExecutableWarningIsVisibleOutsideCollapsedDetails() {
-        var request: ApprovalRequest = Self.multiSecretRequest
-        request.allowMutableExecutable = true
-        let viewModel = ApprovalRequestViewModel(
-            request: request,
-            now: Date(timeIntervalSince1970: Self.viewModelNow)
-        )
-
-        XCTAssertTrue(viewModel.highScopeWarning)
-        XCTAssertTrue(viewModel.printsEnvironmentWarning)
-        XCTAssertEqual(viewModel.cautionMessages.count, 1)
-        XCTAssertTrue(viewModel.cautionMessages[0].contains("Mutable executable opt-in"))
     }
 
     deinit {

--- a/approver/Tests/AgentSecretApproverTests/ApprovalMetadataSanitizationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/ApprovalMetadataSanitizationTests.swift
@@ -61,6 +61,10 @@ final class ApprovalMetadataSanitizationTests: XCTestCase {
             viewModel.overrideWarning,
             "Will replace existing variables: DEPLOY_TOKEN\\nROOT, API\\u202EKEY"
         )
+        XCTAssertTrue(viewModel.requestInspectionText.contains("- DEPLOY_TOKEN\\nROOT"))
+        XCTAssertTrue(viewModel.requestInspectionText.contains("- API\\u202EKEY"))
+        XCTAssertFalse(viewModel.requestInspectionText.contains("\u{202E}"))
+        XCTAssertFalse(viewModel.requestInspectionText.contains("\nROOT"))
         XCTAssertEqual(viewModel.command, "'/bin/echo' $'safe\\u202Etxt'")
         XCTAssertFalse(viewModel.renderedText.contains("\u{202E}"))
         XCTAssertFalse(viewModel.renderedText.contains("\u{200D}"))


### PR DESCRIPTION
## Summary
- include override mode and overridden aliases in the full request scope inspector
- promote override replacement warnings into the primary caution message list
- add Swift regressions for override caution visibility and sanitized override aliases in inspection text

Closes #258

## Verification
- swift test --filter ApprovalControllerTests
- swift test --filter ApprovalCautionWarningTests
- swift test --filter ApprovalMetadataSanitizationTests
- mise run lint:swift
- GOFLAGS=-p=1 mise run test
- GOFLAGS=-p=1 mise run lint
- mise run build
- git diff --check