### PR TITLE
ASR-105: Fail approval when approver exits

### DIFF
--- a/internal/daemon/approval.go
+++ b/internal/daemon/approval.go
@@ -507,10 +507,10 @@ func (a *SocketApprover) markExpectedUsed(job *approvalJob) bool {
 func (a *SocketApprover) monitorExpectedApprover(job *approvalJob, exited <-chan error) {
 	select {
 	case err := <-exited:
-		if !a.expectedApproverExitShouldFail(job) {
+		message, shouldFail := a.expectedApproverExitFailure(job)
+		if !shouldFail {
 			return
 		}
-		message := "approver exited before fetching pending approval"
 		if err != nil {
 			message = fmt.Sprintf("%s: %v", message, err)
 		}
@@ -519,10 +519,16 @@ func (a *SocketApprover) monitorExpectedApprover(job *approvalJob, exited <-chan
 	}
 }
 
-func (a *SocketApprover) expectedApproverExitShouldFail(job *approvalJob) bool {
+func (a *SocketApprover) expectedApproverExitFailure(job *approvalJob) (string, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.active == job && job.expectedReady && !job.expectedUsed
+	if a.active != job || !job.expectedReady {
+		return "", false
+	}
+	if job.expectedUsed {
+		return "approver exited before submitting an approval decision", true
+	}
+	return "approver exited before fetching pending approval", true
 }
 
 func (a *SocketApprover) activeWhenExpectedReady(ctx context.Context) (*approvalJob, error) {

--- a/internal/daemon/approval_test.go
+++ b/internal/daemon/approval_test.go
@@ -34,6 +34,12 @@ type exitingLauncher struct {
 	exited   chan error
 }
 
+type sequenceLauncher struct {
+	mu       sync.Mutex
+	launched []ApprovalRequestPayload
+	expected []ExpectedApprover
+}
+
 type contextObservingLauncher struct {
 	expected ExpectedApprover
 	canceled chan struct{}
@@ -89,6 +95,17 @@ func (l *exitingLauncher) Launch(_ context.Context, _ string, _ ApprovalRequestP
 	expected := l.expected
 	expected.exited = l.exited
 	return expected, nil
+}
+
+func (l *sequenceLauncher) Launch(_ context.Context, _ string, payload ApprovalRequestPayload) (ExpectedApprover, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.launched = append(l.launched, payload)
+	index := len(l.launched) - 1
+	if index >= len(l.expected) {
+		index = len(l.expected) - 1
+	}
+	return l.expected[index], nil
 }
 
 func (l *contextObservingLauncher) Launch(ctx context.Context, _ string, _ ApprovalRequestPayload) (ExpectedApprover, error) {
@@ -474,7 +491,7 @@ func TestSocketApproverFailsWhenExpectedApproverExitsBeforeFetch(t *testing.T) {
 	}
 }
 
-func TestSocketApproverIgnoresExpectedApproverExitAfterFetch(t *testing.T) {
+func TestSocketApproverFailsWhenExpectedApproverExitsAfterFetch(t *testing.T) {
 	t.Parallel()
 
 	exe := currentExecutable(t)
@@ -503,23 +520,92 @@ func TestSocketApproverIgnoresExpectedApproverExitAfterFetch(t *testing.T) {
 	exited <- errors.New("exit status 64")
 	close(exited)
 
+	if err := receiveApprovalError(t, errCh, "ApproveExec did not observe post-fetch approver exit"); !errors.Is(err, ErrApproverLaunchFailed) {
+		t.Fatalf("ApproveExec error = %v, want launch failure", err)
+	}
 	err := approver.SubmitDecision(context.Background(), peerInfoForTest(t, os.Getpid(), exe), ApprovalDecisionPayload{
 		RequestID: "req_1",
 		Nonce:     "nonce_1",
 		Decision:  "approve_once",
 	})
-	if err != nil {
-		t.Fatalf("SubmitDecision returned error: %v", err)
+	if !errors.Is(err, ErrNoPendingApproval) {
+		t.Fatalf("SubmitDecision after approver exit = %v, want no pending approval", err)
 	}
 	select {
 	case decision := <-resultCh:
-		if !decision.Approved {
-			t.Fatalf("unexpected approval result: %+v", decision)
+		t.Fatalf("ApproveExec returned decision after approver exit: %+v", decision)
+	default:
+	}
+}
+
+func TestSocketApproverPromotesNextRequestWhenApproverExitsAfterFetch(t *testing.T) {
+	t.Parallel()
+
+	exe := currentExecutable(t)
+	firstExited := make(chan error, 1)
+	launcher := &sequenceLauncher{
+		expected: []ExpectedApprover{
+			{PID: os.Getpid(), ExecutablePath: exe, exited: firstExited},
+			{PID: os.Getpid(), ExecutablePath: exe},
+		},
+	}
+	approver := newSocketApproverForTest(t, launcher, time.Now)
+	firstReq := approvalTestRequest(t, time.Now().Add(time.Minute))
+	secondReq := approvalTestRequest(t, time.Now().Add(time.Minute))
+	firstErr := make(chan error, 1)
+	secondResult := make(chan ApprovalDecision, 1)
+	secondErr := make(chan error, 1)
+	go func() {
+		_, err := approver.ApproveExec(context.Background(), "req_1", "nonce_1", firstReq)
+		firstErr <- err
+	}()
+	waitForPending(t, approver)
+	go func() {
+		decision, err := approver.ApproveExec(context.Background(), "req_2", "nonce_2", secondReq)
+		if err != nil {
+			secondErr <- err
+			return
 		}
-	case err := <-errCh:
-		t.Fatalf("ApproveExec returned error after fetch: %v", err)
+		secondResult <- decision
+	}()
+
+	payload, err := approver.FetchPending(context.Background(), peerInfoForTest(t, os.Getpid(), exe))
+	if err != nil {
+		t.Fatalf("FetchPending first request returned error: %v", err)
+	}
+	if payload.RequestID != "req_1" {
+		t.Fatalf("first payload request ID = %q, want req_1", payload.RequestID)
+	}
+	firstExited <- errors.New("exit status 64")
+	close(firstExited)
+	if err := receiveApprovalError(t, firstErr, "first ApproveExec did not observe approver exit"); !errors.Is(err, ErrApproverLaunchFailed) {
+		t.Fatalf("first ApproveExec error = %v, want launch failure", err)
+	}
+
+	waitForPending(t, approver)
+	payload, err = approver.FetchPending(context.Background(), peerInfoForTest(t, os.Getpid(), exe))
+	if err != nil {
+		t.Fatalf("FetchPending second request returned error: %v", err)
+	}
+	if payload.RequestID != "req_2" {
+		t.Fatalf("second payload request ID = %q, want req_2", payload.RequestID)
+	}
+	if err := approver.SubmitDecision(context.Background(), peerInfoForTest(t, os.Getpid(), exe), ApprovalDecisionPayload{
+		RequestID: "req_2",
+		Nonce:     "nonce_2",
+		Decision:  "approve_once",
+	}); err != nil {
+		t.Fatalf("SubmitDecision second request returned error: %v", err)
+	}
+	select {
+	case decision := <-secondResult:
+		if !decision.Approved {
+			t.Fatalf("unexpected second approval result: %+v", decision)
+		}
+	case err := <-secondErr:
+		t.Fatalf("second ApproveExec returned error: %v", err)
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for approval result")
+		t.Fatal("timed out waiting for second approval result")
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep monitoring the launched approver after it fetches the request
- fail the active approval if that approver exits before submitting a valid decision
- cover post-fetch exit failure and promotion of the next queued request

Closes #259

## Verification
- GOFLAGS=-p=1 mise exec -- go test ./internal/daemon -run 'TestSocketApprover(FailsWhenExpectedApproverExitsBeforeFetch|FailsWhenExpectedApproverExitsAfterFetch|PromotesNextRequestWhenApproverExitsAfterFetch|LaunchesAndAcceptsExpectedPeerDecision|FIFOAndQueuedExpiry|LaunchContextLivesUntilApprovalCompletes)' -count=1
- GOFLAGS=-p=1 mise exec -- go test -race ./internal/daemon -run 'TestSocketApprover(FailsWhenExpectedApproverExitsAfterFetch|PromotesNextRequestWhenApproverExitsAfterFetch)' -count=1
- GOFLAGS=-p=1 mise run test
- GOFLAGS=-p=1 mise run lint
- mise run build
- git diff --check