### PR TITLE
ASR-106: Require payloads for payload-bearing daemon responses

### DIFF
--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/kovyrin/agent-secret/internal/peercred"
@@ -75,40 +76,86 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) Status(ctx context.Context) (StatusPayload, error) {
-	return roundTrip[StatusPayload](ctx, c, TypeDaemonStatus, "", "", nil)
+	payload, err := roundTripPayload[StatusPayload](ctx, c, TypeDaemonStatus, "", "", nil)
+	if err != nil {
+		return StatusPayload{}, err
+	}
+	if err := validateStatusPayload(TypeDaemonStatus, payload); err != nil {
+		return StatusPayload{}, err
+	}
+	return payload, nil
 }
 
 func (c *Client) Stop(ctx context.Context) (StatusPayload, error) {
-	return roundTrip[StatusPayload](ctx, c, TypeDaemonStop, "", "", nil)
+	payload, err := roundTripPayload[StatusPayload](ctx, c, TypeDaemonStop, "", "", nil)
+	if err != nil {
+		return StatusPayload{}, err
+	}
+	if err := validateStatusPayload(TypeDaemonStop, payload); err != nil {
+		return StatusPayload{}, err
+	}
+	return payload, nil
 }
 
 func (c *Client) FetchPendingApproval(ctx context.Context) (ApprovalRequestPayload, error) {
-	return roundTrip[ApprovalRequestPayload](ctx, c, TypeApprovalPending, "", "", nil)
+	payload, err := roundTripPayload[ApprovalRequestPayload](ctx, c, TypeApprovalPending, "", "", nil)
+	if err != nil {
+		return ApprovalRequestPayload{}, err
+	}
+	if err := validateApprovalRequestPayload(payload); err != nil {
+		return ApprovalRequestPayload{}, err
+	}
+	return payload, nil
 }
 
 func (c *Client) SubmitApprovalDecision(ctx context.Context, decision ApprovalDecisionPayload) error {
-	_, err := roundTrip[struct{}](ctx, c, TypeApprovalDecision, decision.RequestID, decision.Nonce, decision)
-	return err
+	return roundTripAck(ctx, c, TypeApprovalDecision, decision.RequestID, decision.Nonce, decision)
 }
 
 func (c *Client) RequestExec(ctx context.Context, requestID string, nonce string, req request.ExecRequest) (ExecResponsePayload, error) {
-	return roundTrip[ExecResponsePayload](ctx, c, TypeRequestExec, requestID, nonce, req)
+	payload, err := roundTripPayload[ExecResponsePayload](ctx, c, TypeRequestExec, requestID, nonce, req)
+	if err != nil {
+		return ExecResponsePayload{}, err
+	}
+	if err := validateExecResponsePayload(payload, req); err != nil {
+		return ExecResponsePayload{}, err
+	}
+	return payload, nil
 }
 
 func (c *Client) ReportStarted(ctx context.Context, requestID string, nonce string, childPID int) error {
-	_, err := roundTrip[struct{}](ctx, c, TypeCommandStarted, requestID, nonce, CommandStartedPayload{ChildPID: childPID})
-	return err
+	return roundTripAck(ctx, c, TypeCommandStarted, requestID, nonce, CommandStartedPayload{ChildPID: childPID})
 }
 
 func (c *Client) ReportCompleted(ctx context.Context, requestID string, nonce string, exitCode int, signal string) error {
-	_, err := roundTrip[struct{}](ctx, c, TypeCommandCompleted, requestID, nonce, CommandCompletedPayload{
+	return roundTripAck(ctx, c, TypeCommandCompleted, requestID, nonce, CommandCompletedPayload{
 		ExitCode: exitCode,
 		Signal:   signal,
 	})
-	return err
 }
 
 func roundTrip[T any](ctx context.Context, c *Client, messageType string, requestID string, nonce string, payload any) (T, error) {
+	return roundTripResponse[T](ctx, c, messageType, requestID, nonce, payload, false)
+}
+
+func roundTripPayload[T any](ctx context.Context, c *Client, messageType string, requestID string, nonce string, payload any) (T, error) {
+	return roundTripResponse[T](ctx, c, messageType, requestID, nonce, payload, true)
+}
+
+func roundTripAck(ctx context.Context, c *Client, messageType string, requestID string, nonce string, payload any) error {
+	_, err := roundTripResponse[struct{}](ctx, c, messageType, requestID, nonce, payload, false)
+	return err
+}
+
+func roundTripResponse[T any](
+	ctx context.Context,
+	c *Client,
+	messageType string,
+	requestID string,
+	nonce string,
+	payload any,
+	requirePayload bool,
+) (T, error) {
 	var zero T
 	ctx, cancel := c.contextWithDefaultDeadline(ctx, messageType, payload)
 	defer cancel()
@@ -160,6 +207,9 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 		return zero, fmt.Errorf("%w: response type %s", ErrProtocolType, resp.Type)
 	}
 	if len(resp.Payload) == 0 {
+		if requirePayload {
+			return zero, fmt.Errorf("%w: %s response missing payload", ErrMalformedEnvelope, messageType)
+		}
 		return zero, nil
 	}
 	var out T
@@ -167,6 +217,64 @@ func roundTrip[T any](ctx context.Context, c *Client, messageType string, reques
 		return zero, fmt.Errorf("%w: %w", ErrMalformedEnvelope, err)
 	}
 	return out, nil
+}
+
+func validateStatusPayload(messageType string, payload StatusPayload) error {
+	if payload.PID <= 0 {
+		return fmt.Errorf("%w: %s response has invalid pid", ErrMalformedEnvelope, messageType)
+	}
+	return nil
+}
+
+func validateApprovalRequestPayload(payload ApprovalRequestPayload) error {
+	if payload.RequestID == "" {
+		return fmt.Errorf("%w: approval.pending response missing request id", ErrMalformedEnvelope)
+	}
+	if payload.Nonce == "" {
+		return fmt.Errorf("%w: approval.pending response missing nonce", ErrMalformedEnvelope)
+	}
+	if len(payload.Command) == 0 {
+		return fmt.Errorf("%w: approval.pending response missing command", ErrMalformedEnvelope)
+	}
+	if payload.ExpiresAt.IsZero() {
+		return fmt.Errorf("%w: approval.pending response missing expiry", ErrMalformedEnvelope)
+	}
+	if len(payload.Secrets) == 0 {
+		return fmt.Errorf("%w: approval.pending response missing secrets", ErrMalformedEnvelope)
+	}
+	return nil
+}
+
+func validateExecResponsePayload(payload ExecResponsePayload, req request.ExecRequest) error {
+	expectedAliases := secretAliases(req.Secrets)
+	if !slices.Equal(payload.SecretAliases, expectedAliases) {
+		return fmt.Errorf("%w: request.exec response secret aliases do not match request", ErrMalformedEnvelope)
+	}
+	if payload.Env == nil {
+		return fmt.Errorf("%w: request.exec response missing env", ErrMalformedEnvelope)
+	}
+	if gotAliases := envAliases(payload.Env); !slices.Equal(gotAliases, expectedAliases) {
+		return fmt.Errorf("%w: request.exec response env aliases do not match request", ErrMalformedEnvelope)
+	}
+	return nil
+}
+
+func secretAliases(secrets []request.Secret) []string {
+	aliases := make([]string, 0, len(secrets))
+	for _, secret := range secrets {
+		aliases = append(aliases, secret.Alias)
+	}
+	slices.Sort(aliases)
+	return aliases
+}
+
+func envAliases(env map[string]string) []string {
+	aliases := make([]string, 0, len(env))
+	for alias := range env {
+		aliases = append(aliases, alias)
+	}
+	slices.Sort(aliases)
+	return aliases
 }
 
 func (c *Client) contextWithDefaultDeadline(

--- a/internal/daemon/protocol_test.go
+++ b/internal/daemon/protocol_test.go
@@ -251,6 +251,190 @@ func TestClientRequestExecDefaultDeadlineAllowsApprovalWaitUntilRequestExpiry(t 
 	}
 }
 
+func TestClientRejectsMissingPayloadForPayloadOKResponses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		wantType string
+		call     func(*testing.T, context.Context, *Client) error
+	}{
+		{
+			name:     "status",
+			wantType: TypeDaemonStatus,
+			call: func(_ *testing.T, ctx context.Context, client *Client) error {
+				_, err := client.Status(ctx)
+				return err
+			},
+		},
+		{
+			name:     "stop",
+			wantType: TypeDaemonStop,
+			call: func(_ *testing.T, ctx context.Context, client *Client) error {
+				_, err := client.Stop(ctx)
+				return err
+			},
+		},
+		{
+			name:     "fetch pending approval",
+			wantType: TypeApprovalPending,
+			call: func(_ *testing.T, ctx context.Context, client *Client) error {
+				_, err := client.FetchPendingApproval(ctx)
+				return err
+			},
+		},
+		{
+			name:     "request exec",
+			wantType: TypeRequestExec,
+			call: func(t *testing.T, ctx context.Context, client *Client) error {
+				t.Helper()
+
+				req := testExecRequest(t, []request.SecretSpec{
+					{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"},
+				})
+				_, err := client.RequestExec(ctx, "req_1", "nonce_1", req)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, cleanup := startRespondingDaemonClient(t, func(env Envelope) []byte {
+				if env.Type != tc.wantType {
+					t.Fatalf("request type = %s, want %s", env.Type, tc.wantType)
+				}
+				return emptyOKResponseFrame(t, env)
+			})
+			defer cleanup()
+
+			err := tc.call(t, context.Background(), client)
+			if !errors.Is(err, ErrMalformedEnvelope) {
+				t.Fatalf("expected malformed empty OK response error, got %v", err)
+			}
+			if !strings.Contains(err.Error(), "missing payload") {
+				t.Fatalf("error %q does not mention missing payload", err)
+			}
+		})
+	}
+}
+
+func TestClientValidatesPayloadOKResponseShape(t *testing.T) {
+	t.Parallel()
+
+	execReq := testExecRequest(t, []request.SecretSpec{
+		{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"},
+	})
+	tests := []struct {
+		name       string
+		frame      func(t *testing.T, env Envelope) []byte
+		call       func(context.Context, *Client) error
+		wantErrMsg string
+	}{
+		{
+			name: "status pid",
+			frame: func(t *testing.T, env Envelope) []byte {
+				t.Helper()
+
+				return okResponseFrame(t, env, StatusPayload{})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.Status(ctx)
+				return err
+			},
+			wantErrMsg: "invalid pid",
+		},
+		{
+			name: "pending request id",
+			frame: func(t *testing.T, env Envelope) []byte {
+				t.Helper()
+
+				return okResponseFrame(t, env, ApprovalRequestPayload{
+					Nonce:     "nonce_1",
+					Command:   []string{"terraform", "plan"},
+					ExpiresAt: time.Now().Add(time.Minute),
+					Secrets: []ApprovalRequestedSecret{
+						{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"},
+					},
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.FetchPendingApproval(ctx)
+				return err
+			},
+			wantErrMsg: "missing request id",
+		},
+		{
+			name: "exec aliases",
+			frame: func(t *testing.T, env Envelope) []byte {
+				t.Helper()
+
+				return execResponseFrame(t, env, ExecResponsePayload{
+					Env:           map[string]string{"OTHER": "value"},
+					SecretAliases: []string{"OTHER"},
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.RequestExec(ctx, "req_1", "nonce_1", execReq)
+				return err
+			},
+			wantErrMsg: "secret aliases do not match",
+		},
+		{
+			name: "exec env",
+			frame: func(t *testing.T, env Envelope) []byte {
+				t.Helper()
+
+				return execResponseFrame(t, env, ExecResponsePayload{
+					Env:           map[string]string{"TOKEN": "value", "OTHER": "value"},
+					SecretAliases: []string{"TOKEN"},
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.RequestExec(ctx, "req_1", "nonce_1", execReq)
+				return err
+			},
+			wantErrMsg: "env aliases do not match",
+		},
+		{
+			name: "exec missing env",
+			frame: func(t *testing.T, env Envelope) []byte {
+				t.Helper()
+
+				return execResponseFrame(t, env, ExecResponsePayload{
+					SecretAliases: []string{"TOKEN"},
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.RequestExec(ctx, "req_1", "nonce_1", execReq)
+				return err
+			},
+			wantErrMsg: "missing env",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, cleanup := startRespondingDaemonClient(t, func(env Envelope) []byte {
+				return tc.frame(t, env)
+			})
+			defer cleanup()
+
+			err := tc.call(context.Background(), client)
+			if !errors.Is(err, ErrMalformedEnvelope) {
+				t.Fatalf("expected malformed response error, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrMsg) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErrMsg)
+			}
+		})
+	}
+}
+
 func TestClientRejectsOversizedDaemonResponseFrame(t *testing.T) {
 	t.Parallel()
 
@@ -392,6 +576,36 @@ func boundedPaddingResponseFrame(t *testing.T, padding string) []byte {
 	}
 	if int64(len(frame)+1) > DefaultMaxProtocolFrameBytes {
 		t.Fatalf("test frame size %d exceeds max %d", len(frame)+1, DefaultMaxProtocolFrameBytes)
+	}
+	return append(frame, '\n')
+}
+
+func emptyOKResponseFrame(t *testing.T, request Envelope) []byte {
+	t.Helper()
+
+	env := Envelope{
+		Version:   ProtocolVersion,
+		Type:      TypeOK,
+		RequestID: request.RequestID,
+		Nonce:     request.Nonce,
+	}
+	frame, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal empty OK response: %v", err)
+	}
+	return append(frame, '\n')
+}
+
+func okResponseFrame(t *testing.T, request Envelope, payload any) []byte {
+	t.Helper()
+
+	env, err := NewEnvelope(TypeOK, request.RequestID, request.Nonce, payload)
+	if err != nil {
+		t.Fatalf("NewEnvelope returned error: %v", err)
+	}
+	frame, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal OK response: %v", err)
 	}
 	return append(frame, '\n')
 }


### PR DESCRIPTION
## Summary
- require non-empty OK payloads for daemon status, daemon stop, pending approval fetch, and request.exec responses
- validate basic status and pending approval response shape before callers use the payload
- validate request.exec secret aliases and env keys exactly match the approved request aliases

## Verification
- mise exec -- go test ./internal/daemon -run 'TestClientRejectsMissingPayloadForPayloadOKResponses|TestClientValidatesPayloadOKResponseShape|TestClientRequestExecDefaultDeadlineAllowsApprovalWaitUntilRequestExpiry|TestServerExecProtocolLifecycle' -count=1\n- mise exec -- go test ./internal/daemon -count=1\n- GOFLAGS=-p=1 mise run test\n- GOFLAGS=-p=1 mise run lint\n- mise run build\n- git diff --check\n\nCloses #260