### PR TITLE
Address Go desloppify findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ node_modules/
 .env
 
 # Local scratch data
+.desloppify/
 tmp/
 scratch/
 

--- a/cmd/agent-secret/main.go
+++ b/cmd/agent-secret/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/kovyrin/agent-secret/internal/cli"
@@ -11,16 +12,24 @@ import (
 )
 
 func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout io.Writer, stderr io.Writer) int {
 	if err := processhardening.DisableCoreDumps(); err != nil {
-		fmt.Fprintf(os.Stderr, "agent-secret: harden process: %v\n", err)
-		os.Exit(1)
+		writeErrorf(stderr, "agent-secret: harden process: %v\n", err)
+		return 1
 	}
 
 	manager, err := daemon.NewManager("")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "agent-secret: initialize daemon manager: %v\n", err)
-		os.Exit(1)
+		writeErrorf(stderr, "agent-secret: initialize daemon manager: %v\n", err)
+		return 1
 	}
-	app := cli.NewApp(manager, os.Stdout, os.Stderr)
-	os.Exit(app.Run(context.Background(), os.Args[1:]))
+	app := cli.NewApp(manager, stdout, stderr)
+	return app.Run(context.Background(), args)
+}
+
+func writeErrorf(stderr io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(stderr, format, args...)
 }

--- a/cmd/agent-secret/main_test.go
+++ b/cmd/agent-secret/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunHelpWritesUsage(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run help exit code = %d, want 0; stderr = %q", code, stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "agent-secret controls short-lived local access") ||
+		!strings.Contains(got, "Commands:") {
+		t.Fatalf("stdout = %q, want help text", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunRejectsUnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"no-such-command"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("run unknown command exit code = %d, want 2", code)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "unknown command") {
+		t.Fatalf("stderr = %q, want unknown command error", got)
+	}
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +17,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/execwrap"
 	"github.com/kovyrin/agent-secret/internal/install"
 	"github.com/kovyrin/agent-secret/internal/opresolver"
+	"github.com/kovyrin/agent-secret/internal/randid"
 )
 
 type App struct {
@@ -360,16 +360,5 @@ func isFatalCommandStartedAuditFailure(err error) bool {
 }
 
 func (a App) randomID(prefix string) (string, error) {
-	return randomID(a.RandomReader, prefix)
-}
-
-func randomID(reader io.Reader, prefix string) (string, error) {
-	if reader == nil {
-		reader = rand.Reader
-	}
-	var data [16]byte
-	if _, err := io.ReadFull(reader, data[:]); err != nil {
-		return "", fmt.Errorf("generate random id: %w", err)
-	}
-	return prefix + "_" + hex.EncodeToString(data[:]), nil
+	return randid.Generate(a.RandomReader, prefix)
 }

--- a/internal/daemon/approver_identity_test.go
+++ b/internal/daemon/approver_identity_test.go
@@ -1,0 +1,122 @@
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpectedTeamIDForSignatureValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		teamID      string
+		wantTeamID  string
+		wantEnforce bool
+		wantErr     bool
+	}{
+		{
+			name:    "missing team id",
+			wantErr: true,
+		},
+		{
+			name:       "development sentinel",
+			teamID:     developmentExpectedTeamID,
+			wantTeamID: developmentExpectedTeamID,
+		},
+		{
+			name:        "developer id team",
+			teamID:      "  ABC123XYZ9  ",
+			wantTeamID:  "ABC123XYZ9",
+			wantEnforce: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotTeamID, gotEnforce, err := expectedTeamIDForSignatureValidation(tt.teamID, ErrApproverIdentity)
+			if tt.wantErr {
+				if !errors.Is(err, ErrApproverIdentity) {
+					t.Fatalf("error = %v, want ErrApproverIdentity", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expectedTeamIDForSignatureValidation returned error: %v", err)
+			}
+			if gotTeamID != tt.wantTeamID {
+				t.Fatalf("team id = %q, want %q", gotTeamID, tt.wantTeamID)
+			}
+			if gotEnforce != tt.wantEnforce {
+				t.Fatalf("enforce = %v, want %v", gotEnforce, tt.wantEnforce)
+			}
+		})
+	}
+}
+
+func TestAppBundleForExecutableFindsContainingBundle(t *testing.T) {
+	t.Parallel()
+
+	executable := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, DefaultApproverExecutable)
+	bundlePath := filepath.Clean(filepath.Join(filepath.Dir(executable), "..", ".."))
+	bundlePath, err := comparableApproverPath(bundlePath)
+	if err != nil {
+		t.Fatalf("canonicalize bundle path: %v", err)
+	}
+
+	got, err := appBundleForExecutable(executable)
+	if err != nil {
+		t.Fatalf("appBundleForExecutable returned error: %v", err)
+	}
+	if got != bundlePath {
+		t.Fatalf("bundle path = %q, want %q", got, bundlePath)
+	}
+}
+
+func TestAppBundleForExecutableRejectsNonBundlePath(t *testing.T) {
+	t.Parallel()
+
+	_, err := appBundleForExecutable(filepath.Join(t.TempDir(), "approver"))
+	if !errors.Is(err, ErrApproverIdentity) {
+		t.Fatalf("error = %v, want ErrApproverIdentity", err)
+	}
+}
+
+func TestPlistStringReadsBundleMetadata(t *testing.T) {
+	t.Parallel()
+
+	executable := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, DefaultApproverExecutable)
+	infoPath := filepath.Join(filepath.Dir(executable), "..", "Info.plist")
+
+	got, err := plistString(infoPath, "CFBundleIdentifier")
+	if err != nil {
+		t.Fatalf("plistString returned error: %v", err)
+	}
+	if got != DefaultApproverBundleID {
+		t.Fatalf("bundle id = %q, want %q", got, DefaultApproverBundleID)
+	}
+}
+
+func TestPlistStringRejectsMissingKey(t *testing.T) {
+	t.Parallel()
+
+	executable := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, DefaultApproverExecutable)
+	infoPath := filepath.Join(filepath.Dir(executable), "..", "Info.plist")
+
+	_, err := plistString(infoPath, "MissingKey")
+	if !errors.Is(err, ErrApproverIdentity) {
+		t.Fatalf("error = %v, want ErrApproverIdentity", err)
+	}
+}
+
+func TestVerifyProcessCodeSignatureRejectsInvalidPID(t *testing.T) {
+	t.Parallel()
+
+	_, err := verifyProcessCodeSignature(0)
+	if !errors.Is(err, ErrApproverIdentity) {
+		t.Fatalf("error = %v, want ErrApproverIdentity", err)
+	}
+}

--- a/internal/daemon/process_other_test.go
+++ b/internal/daemon/process_other_test.go
@@ -1,0 +1,42 @@
+//go:build !unix
+
+package daemon
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestConfigureDaemonProcessLeavesCommandUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("agent-secretd")
+	configureDaemonProcess(cmd)
+	if cmd.SysProcAttr != nil {
+		t.Fatalf("SysProcAttr = %#v, want nil", cmd.SysProcAttr)
+	}
+}
+
+func TestDaemonStartCommandUsesDaemonPathDirectly(t *testing.T) {
+	t.Parallel()
+
+	cmd := daemonStartCommand(context.Background(), "agent-secretd", []string{"--socket", "agent.sock"})
+	wantArgs := []string{"agent-secretd", "--socket", "agent.sock"}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("args = %q, want %q", cmd.Args, wantArgs)
+	}
+	for i := range wantArgs {
+		if cmd.Args[i] != wantArgs[i] {
+			t.Fatalf("args = %q, want %q", cmd.Args, wantArgs)
+		}
+	}
+}
+
+func TestDefaultDaemonAppPathUnsupported(t *testing.T) {
+	t.Parallel()
+
+	if path, ok := defaultDaemonAppPath(); ok || path != "" {
+		t.Fatalf("defaultDaemonAppPath = %q, %v; want empty false", path, ok)
+	}
+}

--- a/internal/daemon/process_unix_test.go
+++ b/internal/daemon/process_unix_test.go
@@ -1,0 +1,58 @@
+//go:build unix
+
+package daemon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"slices"
+	"testing"
+)
+
+func TestConfigureDaemonProcessStartsNewSession(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.CommandContext(context.Background(), "agent-secretd")
+	configureDaemonProcess(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil, want session isolation")
+	}
+	if !cmd.SysProcAttr.Setsid {
+		t.Fatal("SysProcAttr.Setsid = false, want true")
+	}
+}
+
+func TestDaemonStartCommandUsesDirectBinaryForNonBundlePath(t *testing.T) {
+	t.Parallel()
+
+	cmd := daemonStartCommand(context.Background(), "/tmp/agent-secretd", []string{"--socket", "/tmp/d.sock"})
+	if cmd.Path != "/tmp/agent-secretd" {
+		t.Fatalf("command path = %q, want direct daemon path", cmd.Path)
+	}
+	wantArgs := []string{"/tmp/agent-secretd", "--socket", "/tmp/d.sock"}
+	if !slices.Equal(cmd.Args, wantArgs) {
+		t.Fatalf("args = %q, want %q", cmd.Args, wantArgs)
+	}
+}
+
+func TestDaemonAppEnvironmentForwardsOnlyAccountSettings(t *testing.T) {
+	t.Setenv("OP_ACCOUNT", "DefaultFixture")
+	t.Setenv("AGENT_SECRET_1PASSWORD_ACCOUNT", "Fixture")
+	t.Setenv("AGENT_SECRET_APPROVER_PATH", "/tmp/PoisonApprover.app")
+
+	env := daemonAppEnvironment()
+	for _, want := range []string{
+		"OP_ACCOUNT=DefaultFixture",
+		"AGENT_SECRET_1PASSWORD_ACCOUNT=Fixture",
+	} {
+		if !slices.Contains(env, want) {
+			t.Fatalf("env = %q, want %q", env, want)
+		}
+	}
+	for _, entry := range env {
+		if entry == "AGENT_SECRET_APPROVER_PATH="+os.Getenv("AGENT_SECRET_APPROVER_PATH") {
+			t.Fatalf("env forwarded approver override: %q", env)
+		}
+	}
+}

--- a/internal/daemon/trusted_daemon_test.go
+++ b/internal/daemon/trusted_daemon_test.go
@@ -1,0 +1,59 @@
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovyrin/agent-secret/internal/peercred"
+)
+
+func TestTrustedDaemonPathsForDirectExecutable(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "agent-secretd")
+	got := trustedDaemonPathsForPath("  " + path + "  ")
+	if len(got) != 1 || got[0] != path {
+		t.Fatalf("trusted daemon paths = %q, want [%q]", got, path)
+	}
+}
+
+func TestTrustedDaemonPathsRejectEmptyPath(t *testing.T) {
+	t.Parallel()
+
+	if got := trustedDaemonPathsForPath(" \t "); got != nil {
+		t.Fatalf("trusted daemon paths = %q, want nil", got)
+	}
+}
+
+func TestTrustedDaemonPathsForAppBundleUseBundleExecutable(t *testing.T) {
+	t.Parallel()
+
+	executable := writeApproverBundle(t, t.TempDir(), DefaultApproverBundleID, "AgentSecretDaemon")
+	bundlePath := filepath.Clean(filepath.Join(filepath.Dir(executable), "..", ".."))
+
+	got := trustedDaemonPathsForPath(bundlePath)
+	if len(got) != 1 || got[0] != executable {
+		t.Fatalf("trusted daemon paths = %q, want [%q]", got, executable)
+	}
+}
+
+func TestTrustedDaemonValidatorRejectsMissingPeerExecutable(t *testing.T) {
+	t.Parallel()
+
+	validator := NewTrustedDaemonValidator([]string{writeExecutableAt(t, t.TempDir(), "agent-secretd")})
+	err := validator.ValidateDaemonPeer(peercred.Info{})
+	if !errors.Is(err, ErrUntrustedDaemon) {
+		t.Fatalf("ValidateDaemonPeer error = %v, want ErrUntrustedDaemon", err)
+	}
+}
+
+func TestTrustedDaemonValidatorAllowsTrustedExecutable(t *testing.T) {
+	t.Parallel()
+
+	trusted := writeExecutableAt(t, t.TempDir(), "agent-secretd")
+	validator := newTrustedDaemonValidator([]string{trusted}, "")
+	if err := validator.ValidateDaemonPeer(peercred.Info{ExecutablePath: trusted}); err != nil {
+		t.Fatalf("ValidateDaemonPeer returned error: %v", err)
+	}
+}

--- a/internal/execwrap/process_darwin_test.go
+++ b/internal/execwrap/process_darwin_test.go
@@ -1,0 +1,66 @@
+//go:build darwin
+
+package execwrap
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestSetProcessGroupSetsChildProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.CommandContext(context.Background(), "agent-secret-test")
+	setProcessGroup(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil, want process group config")
+	}
+	if !cmd.SysProcAttr.Setpgid {
+		t.Fatal("SysProcAttr.Setpgid = false, want true")
+	}
+}
+
+func TestForegroundChildNoopsWithoutTerminalInputs(t *testing.T) {
+	t.Parallel()
+
+	restore, err := foregroundChild(nil, strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("foregroundChild returned error: %v", err)
+	}
+	if err := restore(); err != nil {
+		t.Fatalf("restore returned error: %v", err)
+	}
+}
+
+func TestSignalChildNoopsForNilInputs(t *testing.T) {
+	t.Parallel()
+
+	if err := signalChild(nil, syscall.SIGTERM); err != nil {
+		t.Fatalf("signalChild nil process returned error: %v", err)
+	}
+	if err := signalChild(&os.Process{}, nil); err != nil {
+		t.Fatalf("signalChild nil signal returned error: %v", err)
+	}
+}
+
+func TestFileDescriptorReturnsOpenFileDescriptor(t *testing.T) {
+	t.Parallel()
+
+	file, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open dev null: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	fd, err := fileDescriptor(file)
+	if err != nil {
+		t.Fatalf("fileDescriptor returned error: %v", err)
+	}
+	if fd < 0 {
+		t.Fatalf("file descriptor = %d, want non-negative", fd)
+	}
+}

--- a/internal/execwrap/process_other_test.go
+++ b/internal/execwrap/process_other_test.go
@@ -1,0 +1,45 @@
+//go:build !darwin
+
+package execwrap
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestSetProcessGroupNoopsOffDarwin(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.CommandContext(context.Background(), "agent-secret-test")
+	setProcessGroup(cmd)
+	if cmd.SysProcAttr != nil {
+		t.Fatalf("SysProcAttr = %#v, want nil", cmd.SysProcAttr)
+	}
+}
+
+func TestForegroundChildNoopsOffDarwin(t *testing.T) {
+	t.Parallel()
+
+	restore, err := foregroundChild(nil, strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("foregroundChild returned error: %v", err)
+	}
+	if err := restore(); err != nil {
+		t.Fatalf("restore returned error: %v", err)
+	}
+}
+
+func TestSignalChildNoopsForNilInputsOffDarwin(t *testing.T) {
+	t.Parallel()
+
+	if err := signalChild(nil, syscall.SIGTERM); err != nil {
+		t.Fatalf("signalChild nil process returned error: %v", err)
+	}
+	if err := signalChild(&os.Process{}, nil); err != nil {
+		t.Fatalf("signalChild nil signal returned error: %v", err)
+	}
+}

--- a/internal/execwrap/signal_notify_test.go
+++ b/internal/execwrap/signal_notify_test.go
@@ -1,0 +1,27 @@
+package execwrap
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSignalNotifyRegistersSignalChannel(t *testing.T) {
+	ch := make(chan os.Signal, 1)
+	signalNotify(ch, syscall.SIGUSR1)
+	t.Cleanup(func() { signal.Stop(ch) })
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGUSR1); err != nil {
+		t.Fatalf("send signal: %v", err)
+	}
+	select {
+	case got := <-ch:
+		if got != syscall.SIGUSR1 {
+			t.Fatalf("signal = %v, want SIGUSR1", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for SIGUSR1")
+	}
+}

--- a/internal/fileidentity/identity_darwin_test.go
+++ b/internal/fileidentity/identity_darwin_test.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package fileidentity
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAddPlatformIdentityDarwinCapturesStatMetadata(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecutable(t, path, "exit 0\n")
+	identity, err := Capture(path)
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	if identity.Device == 0 {
+		t.Fatal("Device = 0, want captured device")
+	}
+	if identity.Inode == 0 {
+		t.Fatal("Inode = 0, want captured inode")
+	}
+	if identity.ChangeTimeUnixNano == 0 {
+		t.Fatal("ChangeTimeUnixNano = 0, want captured change time")
+	}
+}

--- a/internal/fileidentity/identity_unix_test.go
+++ b/internal/fileidentity/identity_unix_test.go
@@ -1,0 +1,25 @@
+//go:build unix && !darwin
+
+package fileidentity
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAddPlatformIdentityUnixCapturesStatMetadata(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecutable(t, path, "exit 0\n")
+	identity, err := Capture(path)
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	if identity.Device == 0 {
+		t.Fatal("Device = 0, want captured device")
+	}
+	if identity.Inode == 0 {
+		t.Fatal("Inode = 0, want captured inode")
+	}
+}

--- a/internal/fileidentity/stability_unix_test.go
+++ b/internal/fileidentity/stability_unix_test.go
@@ -1,0 +1,23 @@
+//go:build unix
+
+package fileidentity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMutableByCurrentUserDetectsOwnedExecutable(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExecutable(t, path, "exit 0\n")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat executable: %v", err)
+	}
+	if !mutableByCurrentUser(path, info, false) {
+		t.Fatal("mutableByCurrentUser = false, want true for current-user-owned file")
+	}
+}

--- a/internal/opresolver/account_test.go
+++ b/internal/opresolver/account_test.go
@@ -1,0 +1,47 @@
+package opresolver
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDesktopAccountWithPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		accountOverride string
+		opAccount       string
+		want            string
+	}{
+		{
+			name:            "explicit override",
+			accountOverride: " Fixture ",
+			opAccount:       "FromEnv",
+			want:            "Fixture",
+		},
+		{
+			name:      "op account fallback",
+			opAccount: " EnvAccount ",
+			want:      "EnvAccount",
+		},
+		{
+			name: "sdk default",
+			want: DefaultDesktopAccount,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := desktopAccountWith(context.Background(), tt.accountOverride, tt.opAccount)
+			if err != nil {
+				t.Fatalf("desktopAccountWith returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("account = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/peercred/peercred_darwin_test.go
+++ b/internal/peercred/peercred_darwin_test.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package peercred
+
+import "testing"
+
+func TestInspectFDRejectsInvalidDescriptor(t *testing.T) {
+	t.Parallel()
+
+	_, err := inspectFD(^uintptr(0))
+	if err == nil {
+		t.Fatal("expected invalid descriptor error")
+	}
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -3,7 +3,6 @@ package policy
 import (
 	"context"
 	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kovyrin/agent-secret/internal/fileidentity"
+	"github.com/kovyrin/agent-secret/internal/randid"
 	"github.com/kovyrin/agent-secret/internal/request"
 	"github.com/kovyrin/agent-secret/internal/secretmem"
 )
@@ -439,16 +439,5 @@ func consumesUse(result DeliveryResult) bool {
 }
 
 func (s *Store) randomID(prefix string) (string, error) {
-	return randomID(s.random, prefix)
-}
-
-func randomID(reader io.Reader, prefix string) (string, error) {
-	if reader == nil {
-		reader = rand.Reader
-	}
-	var data [16]byte
-	if _, err := io.ReadFull(reader, data[:]); err != nil {
-		return "", fmt.Errorf("generate random id: %w", err)
-	}
-	return prefix + "_" + hex.EncodeToString(data[:]), nil
+	return randid.Generate(s.random, prefix)
 }

--- a/internal/processhardening/core_other_test.go
+++ b/internal/processhardening/core_other_test.go
@@ -1,0 +1,16 @@
+//go:build !darwin && !linux && !freebsd && !openbsd && !netbsd
+
+package processhardening
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDisableCoreDumpsUnsupportedPlatform(t *testing.T) {
+	t.Parallel()
+
+	if err := DisableCoreDumps(); !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Fatalf("DisableCoreDumps error = %v, want ErrUnsupportedPlatform", err)
+	}
+}

--- a/internal/profileconfig/profileconfig.go
+++ b/internal/profileconfig/profileconfig.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/kovyrin/agent-secret/internal/request"
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 const currentVersion = 1

--- a/internal/randid/randid.go
+++ b/internal/randid/randid.go
@@ -1,0 +1,19 @@
+package randid
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+)
+
+func Generate(reader io.Reader, prefix string) (string, error) {
+	if reader == nil {
+		reader = rand.Reader
+	}
+	var data [16]byte
+	if _, err := io.ReadFull(reader, data[:]); err != nil {
+		return "", fmt.Errorf("generate random id: %w", err)
+	}
+	return prefix + "_" + hex.EncodeToString(data[:]), nil
+}

--- a/internal/randid/randid_test.go
+++ b/internal/randid/randid_test.go
@@ -1,0 +1,54 @@
+package randid
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestGenerateUsesReaderBytes(t *testing.T) {
+	t.Parallel()
+
+	id, err := Generate(strings.NewReader("abcdefghijklmnop"), "req")
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if id != "req_6162636465666768696a6b6c6d6e6f70" {
+		t.Fatalf("id = %q, want deterministic hex id", id)
+	}
+}
+
+func TestGenerateWrapsReaderError(t *testing.T) {
+	t.Parallel()
+
+	_, err := Generate(errorReader{}, "req")
+	if !errors.Is(err, errReadFailed) {
+		t.Fatalf("error = %v, want wrapped reader error", err)
+	}
+}
+
+var errReadFailed = errors.New("read failed")
+
+type errorReader struct{}
+
+func (errorReader) Read(_ []byte) (int, error) {
+	return 0, errReadFailed
+}
+
+func TestGenerateAcceptsNilReader(t *testing.T) {
+	t.Parallel()
+
+	id, err := Generate(nil, "nonce")
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if !strings.HasPrefix(id, "nonce_") {
+		t.Fatalf("id = %q, want nonce prefix", id)
+	}
+	if len(id) != len("nonce_")+32 {
+		t.Fatalf("id length = %d, want prefix plus 32 hex chars", len(id))
+	}
+}
+
+var _ io.Reader = errorReader{}


### PR DESCRIPTION
## Summary
- add focused tests for Go entrypoints and platform support modules flagged by desloppify test-health heuristics
- extract duplicate random ID generation into internal/randid
- make yaml.v3 import alias explicit so tooling can match yaml usage

## Desloppify
- Go objective score moved from 90.9 to 98.5
- test health moved to 100.0
- remaining issues are subjective review placeholders plus larger structural/signature findings

## Validation
- mise exec -- go test ./...
- mise run lint:go
- mise run test:coverage
- mise run lint
- mise run build