### PR TITLE
Fix release-blocking review items

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "Agent Secret gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Ignored local desloppify tool state"
+paths = ['''^\.desloppify/''']

--- a/approver/Sources/AgentSecretApprover/Runtime/ApprovalController.swift
+++ b/approver/Sources/AgentSecretApprover/Runtime/ApprovalController.swift
@@ -5,25 +5,29 @@ public final class ApprovalController {
     private let client: ApprovalDaemonClientWorker
     private let presenter: ApprovalPresenter
     private let logger: ApprovalLogger
+    private let now: () -> Date
 
     /// Use for in-memory clients; socket clients should prefer the factory initializer.
     public convenience init(
         client: ApprovalDaemonClient,
         presenter: ApprovalPresenter,
-        logger: ApprovalLogger = UnifiedApprovalLogger(category: "decisions")
+        logger: ApprovalLogger = UnifiedApprovalLogger(category: "decisions"),
+        now: @escaping () -> Date = Date.init
     ) {
-        self.init(clientFactory: { client }, presenter: presenter, logger: logger)
+        self.init(clientFactory: { client }, presenter: presenter, logger: logger, now: now)
     }
 
     /// Creates a controller that builds the daemon client on the background worker queue.
     public init(
         clientFactory: @escaping () throws -> ApprovalDaemonClient,
         presenter: ApprovalPresenter,
-        logger: ApprovalLogger = UnifiedApprovalLogger(category: "decisions")
+        logger: ApprovalLogger = UnifiedApprovalLogger(category: "decisions"),
+        now: @escaping () -> Date = Date.init
     ) {
         client = ApprovalDaemonClientWorker(clientFactory: clientFactory)
         self.presenter = presenter
         self.logger = logger
+        self.now = now
     }
 
     /// Runs on the main actor because presenters may open AppKit UI.
@@ -34,7 +38,9 @@ public final class ApprovalController {
         let request: ApprovalRequest = try await client.fetchPendingRequest()
         logger.record("approval_request_loaded", requestID: request.requestID)
 
-        let decisionKind: ApprovalDecisionKind = presenter.decide(for: request)
+        let presentedDecisionKind: ApprovalDecisionKind = presenter.decide(for: request)
+        let decisionKind: ApprovalDecisionKind = ApprovalPromptExpiration(expiresAt: request.expiresAt)
+            .guardDecision(presentedDecisionKind, at: now())
         let decision: ApprovalDecision = decision(for: decisionKind, request: request)
 
         try await client.submit(decision)

--- a/approver/Tests/AgentSecretApproverTests/Runtime/ApprovalControllerExpirationTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/Runtime/ApprovalControllerExpirationTests.swift
@@ -1,0 +1,87 @@
+@testable import AgentSecretApprover
+import Foundation
+import XCTest
+
+final class ApprovalControllerExpirationTests: XCTestCase {
+    private struct NoopApprovalLogger: ApprovalLogger {
+        func record(_: String, requestID _: String?) {
+            /* Intentionally ignored. */
+        }
+    }
+
+    private static let sampleExpiration: TimeInterval = 1_800_000_000
+
+    private static var request: ApprovalRequest {
+        ApprovalRequest(
+            requestID: "req_expired",
+            nonce: "nonce_expired",
+            reason: "Run expired approval test",
+            command: ["/usr/bin/env", "true"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: sampleExpiration),
+            secrets: [
+                RequestedSecret(
+                    alias: "EXAMPLE_TOKEN",
+                    ref: "op://Example Vault/Example Item/token",
+                    account: "Work"
+                )
+            ],
+            resolvedExecutable: "/usr/bin/env"
+        )
+    }
+
+    @MainActor
+    func testSubmitsTimeoutWhenApproveOnceRequestExpired() async throws {
+        let request: ApprovalRequest = Self.request
+        let client = RecordingDaemonClient(request: request)
+        let controller = ApprovalController(
+            client: client,
+            presenter: FixedDecisionPresenter(decision: .approveOnce),
+            logger: NoopApprovalLogger()
+        ) {
+            Date(timeIntervalSince1970: Self.sampleExpiration)
+        }
+
+        let decision: ApprovalDecision = try await controller.run()
+
+        XCTAssertEqual(decision, .timeout(for: request))
+        XCTAssertEqual(client.submittedDecision, decision)
+    }
+
+    @MainActor
+    func testSubmitsTimeoutWhenReusableRequestExpired() async throws {
+        let request: ApprovalRequest = Self.request
+        let client = RecordingDaemonClient(request: request)
+        let controller = ApprovalController(
+            client: client,
+            presenter: FixedDecisionPresenter(decision: .approveReusable),
+            logger: NoopApprovalLogger()
+        ) {
+            Date(timeIntervalSince1970: Self.sampleExpiration + 1)
+        }
+
+        let decision: ApprovalDecision = try await controller.run()
+
+        XCTAssertEqual(decision, .timeout(for: request))
+        XCTAssertNil(decision.reusableUses)
+        XCTAssertEqual(client.submittedDecision, decision)
+    }
+
+    @MainActor
+    func testSubmitsDenyWhenExpiredRequestDenied() async throws {
+        let request: ApprovalRequest = Self.request
+        let client = RecordingDaemonClient(request: request)
+        let controller = ApprovalController(
+            client: client,
+            presenter: FixedDecisionPresenter(decision: .deny),
+            logger: NoopApprovalLogger()
+        ) {
+            Date(timeIntervalSince1970: Self.sampleExpiration + 1)
+        }
+
+        let decision: ApprovalDecision = try await controller.run()
+
+        XCTAssertEqual(decision, .deny(for: request))
+        XCTAssertEqual(client.submittedDecision, decision)
+    }
+}

--- a/internal/daemon/approval/approval_contracts.go
+++ b/internal/daemon/approval/approval_contracts.go
@@ -26,7 +26,7 @@ type ApprovalEndpoint interface {
 }
 
 type ApproverLauncher interface {
-	Launch(ctx context.Context, socketPath string, payload ApprovalRequestPayload) (ExpectedApprover, error)
+	Launch(ctx context.Context, socketPath string) (ExpectedApprover, error)
 }
 
 type ApproverIdentityPolicy interface {

--- a/internal/daemon/approval/approval_launcher.go
+++ b/internal/daemon/approval/approval_launcher.go
@@ -79,7 +79,7 @@ func (processHealthCheckRunner) RunHealthCheck(ctx context.Context, executablePa
 	return strings.TrimSpace(stdout.String()), nil
 }
 
-func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string, _ ApprovalRequestPayload) (ExpectedApprover, error) {
+func (l ProcessApproverLauncher) Launch(ctx context.Context, socketPath string) (ExpectedApprover, error) {
 	executable, err := l.executablePath()
 	if err != nil {
 		return ExpectedApprover{}, err

--- a/internal/daemon/approval/approval_launcher_test.go
+++ b/internal/daemon/approval/approval_launcher_test.go
@@ -389,7 +389,7 @@ func TestBundleApproverIdentityPolicyValidatesBundleMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ValidateApproverExecutable returned error: %v", err)
 	}
-	wantExecutable, err := comparableApproverPath(executable)
+	wantExecutable, err := comparableApproverPath(executable, ErrApproverIdentity)
 	if err != nil {
 		t.Fatalf("comparableApproverPath returned error: %v", err)
 	}

--- a/internal/daemon/approval/approval_launcher_test.go
+++ b/internal/daemon/approval/approval_launcher_test.go
@@ -171,7 +171,6 @@ func TestProcessApproverLauncherLaunchesBinary(t *testing.T) {
 	}).Launch(
 		context.Background(),
 		"/tmp/agent-secret-test.sock",
-		ApprovalRequestPayload{},
 	)
 	if err != nil {
 		t.Fatalf("Launch returned error: %v", err)
@@ -198,7 +197,6 @@ func TestProcessApproverLauncherExposesEarlyProcessExit(t *testing.T) {
 	}).Launch(
 		context.Background(),
 		"/tmp/agent-secret-test.sock",
-		ApprovalRequestPayload{},
 	)
 	if err != nil {
 		t.Fatalf("Launch returned error: %v", err)
@@ -233,7 +231,6 @@ func TestProcessApproverLauncherCarriesSignaturePolicyToExpectedPeer(t *testing.
 	}).Launch(
 		context.Background(),
 		"/tmp/agent-secret-test.sock",
-		ApprovalRequestPayload{},
 	)
 	if err != nil {
 		t.Fatalf("Launch returned error: %v", err)
@@ -337,7 +334,6 @@ func TestProcessApproverLauncherRejectsBareBinaryByDefault(t *testing.T) {
 	_, err := (ProcessApproverLauncher{AppPath: helper}).Launch(
 		context.Background(),
 		"/tmp/agent-secret-test.sock",
-		ApprovalRequestPayload{},
 	)
 	if !errors.Is(err, ErrApproverIdentity) {
 		t.Fatalf("expected approver identity error, got %v", err)
@@ -379,7 +375,6 @@ func TestProcessApproverLauncherWrapsStartFailure(t *testing.T) {
 	}).Launch(
 		context.Background(),
 		"/tmp/agent-secret-test.sock",
-		ApprovalRequestPayload{},
 	)
 	if !errors.Is(err, ErrApproverLaunchFailed) {
 		t.Fatalf("expected launch failure, got %v", err)

--- a/internal/daemon/approval/approval_peer.go
+++ b/internal/daemon/approval/approval_peer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kovyrin/agent-secret/internal/daemon/trust"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 )
 
@@ -42,11 +43,11 @@ func ValidateApproverPeer(expected ExpectedApprover, got peercred.Info) error {
 		}
 		return nil
 	}
-	expectedPath, err := comparableApproverPath(expected.ExecutablePath)
+	expectedPath, err := comparableApproverPath(expected.ExecutablePath, ErrApproverPeerMismatch)
 	if err != nil {
 		return err
 	}
-	gotPath, err := comparableApproverPath(got.ExecutablePath)
+	gotPath, err := comparableApproverPath(got.ExecutablePath, ErrApproverPeerMismatch)
 	if err != nil {
 		return err
 	}
@@ -67,15 +68,15 @@ func ValidateApproverPeer(expected ExpectedApprover, got peercred.Info) error {
 	return nil
 }
 
-func comparableApproverPath(path string) (string, error) {
-	abs, err := filepath.Abs(path)
+func comparableApproverPath(path string, errKind error) (string, error) {
+	resolved, err := pathresolve.Strict(path)
 	if err != nil {
-		return "", fmt.Errorf("normalize approver path: %w", err)
+		if errKind == nil {
+			errKind = ErrApproverIdentity
+		}
+		return "", fmt.Errorf("%w: normalize approver path %q: %w", errKind, path, err)
 	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved, nil
-	}
-	return abs, nil
+	return resolved, nil
 }
 
 func defaultApproverPath() (string, error) {
@@ -104,7 +105,7 @@ func defaultApproverPath() (string, error) {
 
 func approverCandidatesForExecutable(executable string) []string {
 	executables := []string{executable}
-	if resolved, err := filepath.EvalSymlinks(executable); err == nil && resolved != executable {
+	if resolved := pathresolve.BestEffort(executable); resolved != executable {
 		executables = append(executables, resolved)
 	}
 

--- a/internal/daemon/approval/approval_peer_test.go
+++ b/internal/daemon/approval/approval_peer_test.go
@@ -62,6 +62,7 @@ func TestValidateApproverPeer(t *testing.T) {
 	t.Parallel()
 
 	exe := currentExecutable(t)
+	other := writeApproverPeerTestExecutable(t)
 	tests := []struct {
 		name     string
 		expected ExpectedApprover
@@ -87,7 +88,7 @@ func TestValidateApproverPeer(t *testing.T) {
 		{
 			name:     "rejects executable mismatch",
 			expected: ExpectedApprover{PID: os.Getpid(), ExecutablePath: exe},
-			got:      peerInfoForTest(t, os.Getpid(), filepath.Join(t.TempDir(), "other")),
+			got:      peerInfoForTest(t, os.Getpid(), other),
 			wantErr:  "executable",
 		},
 	}
@@ -113,5 +114,35 @@ func TestValidateApproverPeer(t *testing.T) {
 				t.Fatalf("ValidateApproverPeer returned error: %v", err)
 			}
 		})
+	}
+}
+
+func writeApproverPeerTestExecutable(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "other")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: approver peer tests need executable fixtures.
+		t.Fatalf("write executable: %v", err)
+	}
+	return path
+}
+
+func TestValidateApproverPeerRejectsBrokenSymlinkEvenWhenPathsMatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	broken := filepath.Join(dir, "Agent Secret")
+	if err := os.Symlink(filepath.Join(dir, "missing"), broken); err != nil {
+		t.Fatalf("create broken symlink: %v", err)
+	}
+
+	err := ValidateApproverPeer(
+		ExpectedApprover{PID: os.Getpid(), ExecutablePath: broken},
+		peerInfoForTest(t, os.Getpid(), broken),
+	)
+	if !errors.Is(err, ErrApproverPeerMismatch) {
+		t.Fatalf("ValidateApproverPeer error = %v, want ErrApproverPeerMismatch", err)
+	}
+	if !strings.Contains(err.Error(), "normalize approver path") {
+		t.Fatalf("ValidateApproverPeer error = %q, want path normalization context", err.Error())
 	}
 }

--- a/internal/daemon/approval/approver_identity.go
+++ b/internal/daemon/approval/approver_identity.go
@@ -38,7 +38,7 @@ func expectedTeamIDForSignatureValidation(expectedTeamID string, errKind error) 
 }
 
 func (p BundleApproverIdentityPolicy) ValidateApproverExecutable(path string) (ApproverIdentity, error) {
-	path, err := comparableApproverPath(path)
+	path, err := comparableApproverPath(path, ErrApproverIdentity)
 	if err != nil {
 		return ApproverIdentity{}, err
 	}
@@ -72,7 +72,7 @@ func (p BundleApproverIdentityPolicy) ValidateApproverExecutable(path string) (A
 		return ApproverIdentity{}, fmt.Errorf("%w: executable %q != %q", ErrApproverIdentity, executableName, expectedExecutable)
 	}
 	bundleExecutable := filepath.Join(bundlePath, "Contents", "MacOS", executableName)
-	bundleExecutable, err = comparableApproverPath(bundleExecutable)
+	bundleExecutable, err = comparableApproverPath(bundleExecutable, ErrApproverIdentity)
 	if err != nil {
 		return ApproverIdentity{}, err
 	}
@@ -111,7 +111,7 @@ func appBundleForExecutable(path string) (string, error) {
 	dir := filepath.Dir(path)
 	for {
 		if filepath.Ext(dir) == ".app" {
-			bundlePath, err := comparableApproverPath(dir)
+			bundlePath, err := comparableApproverPath(dir, ErrApproverIdentity)
 			if err != nil {
 				return "", err
 			}

--- a/internal/daemon/approval/approver_identity_test.go
+++ b/internal/daemon/approval/approver_identity_test.go
@@ -67,7 +67,7 @@ func TestAppBundleForExecutableFindsContainingBundle(t *testing.T) {
 
 	executable := appbundle.WriteApproverBundle(t, t.TempDir(), DefaultApproverBundleID, DefaultApproverExecutable)
 	bundlePath := filepath.Clean(filepath.Join(filepath.Dir(executable), "..", ".."))
-	bundlePath, err := comparableApproverPath(bundlePath)
+	bundlePath, err := comparableApproverPath(bundlePath, ErrApproverIdentity)
 	if err != nil {
 		t.Fatalf("canonicalize bundle path: %v", err)
 	}

--- a/internal/daemon/approval/socket_approver.go
+++ b/internal/daemon/approval/socket_approver.go
@@ -184,7 +184,7 @@ func (a *SocketApprover) promoteNext() {
 		return
 	}
 	launchCtx := job.launchContext()
-	expected, err := a.launcher.Launch(launchCtx, a.socketPath, job.payload)
+	expected, err := a.launcher.Launch(launchCtx, a.socketPath)
 	if err != nil {
 		if job.canceled() {
 			a.cancel(job, context.Canceled)

--- a/internal/daemon/approval/socket_approver_test.go
+++ b/internal/daemon/approval/socket_approver_test.go
@@ -32,7 +32,7 @@ func testApprovalPayload(correlation protocol.Correlation, req request.ExecReque
 type recordingLauncher struct {
 	launches launchWatcher
 	mu       sync.Mutex
-	launched []approval.ApprovalRequestPayload
+	count    int
 	expected approval.ExpectedApprover
 	err      error
 }
@@ -50,7 +50,7 @@ type exitingLauncher struct {
 type sequenceLauncher struct {
 	launches launchWatcher
 	mu       sync.Mutex
-	launched []approval.ApprovalRequestPayload
+	count    int
 	expected []approval.ExpectedApprover
 }
 
@@ -94,11 +94,10 @@ func (v *recordingSignatureVerifier) VerifyProcess(pid int) (string, error) {
 func (l *recordingLauncher) Launch(
 	_ context.Context,
 	_ string,
-	payload approval.ApprovalRequestPayload,
 ) (approval.ExpectedApprover, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.launched = append(l.launched, payload)
+	l.count++
 	if l.err != nil {
 		return approval.ExpectedApprover{}, l.err
 	}
@@ -109,7 +108,7 @@ func (l *recordingLauncher) Launch(
 func (l *recordingLauncher) Count() int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return len(l.launched)
+	return l.count
 }
 
 func (l *recordingLauncher) waitForLaunch(ctx context.Context, count int) error {
@@ -125,7 +124,6 @@ func newBlockingLauncher() *blockingLauncher {
 func (l *blockingLauncher) Launch(
 	ctx context.Context,
 	_ string,
-	_ approval.ApprovalRequestPayload,
 ) (approval.ExpectedApprover, error) {
 	close(l.started)
 	<-ctx.Done()
@@ -135,7 +133,6 @@ func (l *blockingLauncher) Launch(
 func (l *exitingLauncher) Launch(
 	_ context.Context,
 	_ string,
-	_ approval.ApprovalRequestPayload,
 ) (approval.ExpectedApprover, error) {
 	l.launches.record()
 	expected := l.expected
@@ -150,12 +147,11 @@ func (l *exitingLauncher) waitForLaunch(ctx context.Context, count int) error {
 func (l *sequenceLauncher) Launch(
 	_ context.Context,
 	_ string,
-	payload approval.ApprovalRequestPayload,
 ) (approval.ExpectedApprover, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.launched = append(l.launched, payload)
-	index := len(l.launched) - 1
+	l.count++
+	index := l.count - 1
 	if index >= len(l.expected) {
 		index = len(l.expected) - 1
 	}
@@ -170,7 +166,6 @@ func (l *sequenceLauncher) waitForLaunch(ctx context.Context, count int) error {
 func (l *contextObservingLauncher) Launch(
 	ctx context.Context,
 	_ string,
-	_ approval.ApprovalRequestPayload,
 ) (approval.ExpectedApprover, error) {
 	l.launches.record()
 	go func() {

--- a/internal/daemon/peertrust/client.go
+++ b/internal/daemon/peertrust/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kovyrin/agent-secret/internal/daemon/trust"
 	"github.com/kovyrin/agent-secret/internal/fileidentity"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 )
 
@@ -73,7 +74,12 @@ func newExecutableSetWithVerifier(
 		if path == "" {
 			continue
 		}
-		path = comparablePath(path)
+		rawPath := path
+		path, err := pathresolve.Strict(rawPath)
+		if err != nil {
+			candidateErrs = append(candidateErrs, fmt.Errorf("canonicalize trusted executable %q: %w", rawPath, err))
+			continue
+		}
 		if _, ok := seen[path]; ok {
 			continue
 		}
@@ -213,7 +219,10 @@ func (v executableSet) validatePeer(info peercred.Info) error {
 		}
 		return fmt.Errorf("%w: no trusted executables configured", v.err)
 	}
-	got := comparablePath(info.ExecutablePath)
+	got, err := pathresolve.Strict(info.ExecutablePath)
+	if err != nil {
+		return fmt.Errorf("%w: normalize peer executable %q: %w", v.err, info.ExecutablePath, err)
+	}
 	for _, entry := range v.entries {
 		if entry.path != got {
 			continue
@@ -265,15 +274,4 @@ func (e executable) isBundledPath(path string) bool {
 	}
 	_, ok := containingAppBundlePath(path)
 	return ok
-}
-
-func comparablePath(path string) string {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return path
-	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved
-	}
-	return abs
 }

--- a/internal/daemon/peertrust/client_test.go
+++ b/internal/daemon/peertrust/client_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/approval"
 	"github.com/kovyrin/agent-secret/internal/daemon/trust"
 	"github.com/kovyrin/agent-secret/internal/fileidentity"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/testsupport/appbundle"
 )
@@ -89,6 +90,46 @@ func TestExecutableValidatorRejectsUnlistedExecutable(t *testing.T) {
 	}
 }
 
+func TestExecutableValidatorRejectsBrokenPeerExecutablePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	trusted := writeExecutableAt(t, dir, "agent-secret")
+	broken := filepath.Join(dir, "broken")
+	if err := os.Symlink(filepath.Join(dir, "missing"), broken); err != nil {
+		t.Fatalf("create broken symlink: %v", err)
+	}
+
+	validator := NewExecutableValidator([]string{trusted})
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: broken})
+	if !errors.Is(err, ErrUntrustedClient) {
+		t.Fatalf("ValidateExecPeer error = %v, want ErrUntrustedClient", err)
+	}
+	if !strings.Contains(err.Error(), "normalize peer executable") {
+		t.Fatalf("ValidateExecPeer error = %q, want normalization context", err.Error())
+	}
+}
+
+func TestExecutableValidatorRejectsBrokenTrustedExecutablePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	trusted := writeExecutableAt(t, dir, "agent-secret")
+	broken := filepath.Join(dir, "broken")
+	if err := os.Symlink(filepath.Join(dir, "missing"), broken); err != nil {
+		t.Fatalf("create broken symlink: %v", err)
+	}
+
+	validator := NewExecutableValidator([]string{broken})
+	err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted})
+	if !errors.Is(err, ErrUntrustedClient) {
+		t.Fatalf("ValidateExecPeer error = %v, want ErrUntrustedClient", err)
+	}
+	if !strings.Contains(err.Error(), "canonicalize trusted executable") {
+		t.Fatalf("ValidateExecPeer error = %q, want trusted executable context", err.Error())
+	}
+}
+
 func TestExecutableValidatorRejectsExecutableReplacedAfterStartup(t *testing.T) {
 	t.Parallel()
 
@@ -151,7 +192,10 @@ func TestExecutableValidatorVerifiesPeerProcessSignature(t *testing.T) {
 	if err := validator.ValidateExecPeer(peercred.Info{ExecutablePath: trusted, PID: 4321}); err != nil {
 		t.Fatalf("ValidateExecPeer returned error: %v", err)
 	}
-	wantPath := comparablePath(trusted)
+	wantPath, err := pathresolve.Strict(trusted)
+	if err != nil {
+		t.Fatalf("resolve trusted path: %v", err)
+	}
 	if !slices.Equal(verifier.paths, []string{wantPath}) {
 		t.Fatalf("verified paths = %v, want [%s]", verifier.paths, wantPath)
 	}
@@ -175,7 +219,10 @@ func TestExecutableValidatorRejectsPeerProcessSignatureMismatch(t *testing.T) {
 	if !errors.Is(err, ErrUntrustedClient) {
 		t.Fatalf("expected ErrUntrustedClient, got %v", err)
 	}
-	wantPath := comparablePath(trusted)
+	wantPath, resolveErr := pathresolve.Strict(trusted)
+	if resolveErr != nil {
+		t.Fatalf("resolve trusted path: %v", resolveErr)
+	}
 	if !slices.Equal(verifier.paths, []string{wantPath}) {
 		t.Fatalf("verified paths = %v, want [%s]", verifier.paths, wantPath)
 	}

--- a/internal/daemon/peertrust/daemon_test.go
+++ b/internal/daemon/peertrust/daemon_test.go
@@ -87,7 +87,7 @@ func TestDaemonValidatorReportsSkippedTrustedPathReasons(t *testing.T) {
 	if !errors.Is(err, ErrUntrustedDaemon) {
 		t.Fatalf("ValidateDaemonPeer error = %v, want %v", err, ErrUntrustedDaemon)
 	}
-	if !strings.Contains(err.Error(), missingPath) || !strings.Contains(err.Error(), "stat trusted executable") {
+	if !strings.Contains(err.Error(), missingPath) || !strings.Contains(err.Error(), "canonicalize trusted executable") {
 		t.Fatalf("ValidateDaemonPeer error = %q, want skipped candidate context", err.Error())
 	}
 }

--- a/internal/daemon/process/process_unix.go
+++ b/internal/daemon/process/process_unix.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"syscall"
+
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 )
 
 func ConfigureDaemonProcess(cmd *exec.Cmd) {
@@ -74,7 +76,7 @@ func DefaultDaemonAppPath() (string, bool) {
 
 func daemonAppPathForExecutable(executable string) (string, bool) {
 	candidates := []string{executable}
-	if resolved, err := filepath.EvalSymlinks(executable); err == nil && resolved != executable {
+	if resolved := pathresolve.BestEffort(executable); resolved != executable {
 		candidates = append(candidates, resolved)
 	}
 	for _, candidate := range candidates {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -77,6 +77,7 @@ const DefaultProtocolReadTimeout = 30 * time.Second
 var (
 	ErrRequestAlreadyActive        = errors.New("connection already has an active exec request")
 	ErrOnePasswordCheckUnavailable = errors.New("1Password desktop integration check unavailable")
+	errExecValidatorRequired       = errors.New("exec validator is required")
 )
 
 type connectionState struct {
@@ -145,11 +146,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 	}
 	execValidator := opts.ExecValidator
 	if execValidator == nil {
-		defaultClientPaths, err := peertrust.DefaultClientPaths()
-		if err != nil {
-			return nil, fmt.Errorf("default exec validator trusted clients: %w", err)
-		}
-		execValidator = peertrust.NewExecutableValidator(defaultClientPaths)
+		return nil, errExecValidatorRequired
 	}
 	onePasswordCheck := opts.OnePasswordCheck
 	if onePasswordCheck == nil {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -58,6 +58,27 @@ func trustedCurrentPeer(t *testing.T) (PeerValidator, peertrust.ExecValidator) {
 	return staticPeerValidator{info: peer}, peertrust.NewExecutableValidator([]string{peer.ExecutablePath})
 }
 
+func trustedCurrentExecValidator(t *testing.T) peertrust.ExecValidator {
+	t.Helper()
+	_, execValidator := trustedCurrentPeer(t)
+	return execValidator
+}
+
+func TestNewServerRequiresExecValidator(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewServer(ServerOptions{
+		Broker: newTestBroker(t, daemonbroker.Options{
+			Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
+			Audit:    &memoryAudit{},
+		}),
+	})
+	if !errors.Is(err, errExecValidatorRequired) {
+		t.Fatalf("NewServer error = %v, want %v", err, errExecValidatorRequired)
+	}
+}
+
 func TestServerExecProtocolLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -827,6 +848,7 @@ func TestServerServeStopsWhenServerStops(t *testing.T) {
 			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
 			Audit:    aud,
 		}),
+		ExecValidator: trustedCurrentExecValidator(t),
 	})
 	if err != nil {
 		t.Fatalf("NewServer returned error: %v", err)
@@ -862,6 +884,7 @@ func TestServerServeReturnsAcceptErrors(t *testing.T) {
 			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
 			Audit:    &memoryAudit{},
 		}),
+		ExecValidator: trustedCurrentExecValidator(t),
 	})
 	if err != nil {
 		t.Fatalf("NewServer returned error: %v", err)
@@ -881,6 +904,7 @@ func TestServerListenAndServeStopsInjectedListenerOnContextCancel(t *testing.T) 
 			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
 			Audit:    aud,
 		}),
+		ExecValidator: trustedCurrentExecValidator(t),
 	})
 	if err != nil {
 		t.Fatalf("NewServer returned error: %v", err)
@@ -915,6 +939,7 @@ func TestServerListenAndServeReturnsListenErrors(t *testing.T) {
 			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
 			Audit:    &memoryAudit{},
 		}),
+		ExecValidator: trustedCurrentExecValidator(t),
 	})
 	if err != nil {
 		t.Fatalf("NewServer returned error: %v", err)
@@ -1629,6 +1654,9 @@ func startRawServerWithBrokerAndExecValidator(
 
 func startRawServerConnWithOptions(t *testing.T, opts ServerOptions) (*net.UnixConn, func()) {
 	t.Helper()
+	if opts.ExecValidator == nil {
+		opts.ExecValidator = trustedCurrentExecValidator(t)
+	}
 	server, err := NewServer(opts)
 	if err != nil {
 		t.Fatalf("NewServer returned error: %v", err)
@@ -1654,6 +1682,9 @@ func startRawServerConnWithOptions(t *testing.T, opts ServerOptions) (*net.UnixC
 
 func startRawServerWithOptions(t *testing.T, opts ServerOptions) (string, func()) {
 	t.Helper()
+	if opts.ExecValidator == nil {
+		opts.ExecValidator = trustedCurrentExecValidator(t)
+	}
 	dir, err := os.MkdirTemp("/tmp", "agent-secret-test-")
 	if err != nil {
 		t.Fatalf("MkdirTemp returned error: %v", err)

--- a/internal/daemon/test_helpers_test.go
+++ b/internal/daemon/test_helpers_test.go
@@ -60,18 +60,17 @@ func (r *recordingApprover) ApproveExec(
 type recordingLauncher struct {
 	launches launchWatcher
 	mu       sync.Mutex
-	launched []approval.ApprovalRequestPayload
+	count    int
 	expected approval.ExpectedApprover
 }
 
 func (l *recordingLauncher) Launch(
 	_ context.Context,
 	_ string,
-	payload approval.ApprovalRequestPayload,
 ) (approval.ExpectedApprover, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.launched = append(l.launched, payload)
+	l.count++
 	l.launches.record()
 	return l.expected, nil
 }

--- a/internal/daemon/test_helpers_test.go
+++ b/internal/daemon/test_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"slices"
 	"sync"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/peertrust"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 	"github.com/kovyrin/agent-secret/internal/fileidentity"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
@@ -269,14 +271,31 @@ func testExecRequestAt(t *testing.T, now time.Time, secrets []request.SecretSpec
 		reqSecrets = append(reqSecrets, request.Secret{Alias: spec.Alias, Ref: ref, Account: spec.Account})
 	}
 
+	cwd, err := pathresolve.Strict(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize cwd: %v", err)
+	}
+	executableDir := filepath.Join(cwd, "bin")
+	if err := os.Mkdir(executableDir, 0o750); err != nil {
+		t.Fatalf("mkdir executable dir: %v", err)
+	}
+	executable := filepath.Join(executableDir, "terraform")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: daemon tests need a runnable fixture executable.
+		t.Fatalf("write executable: %v", err)
+	}
+	executableIdentity, err := fileidentity.Capture(executable)
+	if err != nil {
+		t.Fatalf("capture executable identity: %v", err)
+	}
+
 	return request.ExecRequest{
 		Reason:             "Run Terraform plan",
 		Command:            []string{"terraform", "plan"},
-		ResolvedExecutable: "/opt/homebrew/bin/terraform",
-		ExecutableIdentity: fileidentity.Identity{Device: 1, Inode: 1, Mode: 0o755},
-		CWD:                "/tmp/project",
+		ResolvedExecutable: executable,
+		ExecutableIdentity: executableIdentity,
+		CWD:                cwd,
 		EnvironmentFingerprint: request.EnvironmentFingerprint([]string{
-			"PATH=/opt/homebrew/bin",
+			"PATH=" + executableDir,
 			"NODE_OPTIONS=--require ./safe.js",
 		}),
 		Secrets:    reqSecrets,

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 )
 
 const CommandName = "agent-secret"
@@ -69,9 +71,11 @@ func InstallCLI(options CLIOptions) (CLIResult, error) {
 		}
 		targetPath = executable
 	}
-	if resolved, err := filepath.EvalSymlinks(targetPath); err == nil {
-		targetPath = resolved
+	resolvedTargetPath, err := canonicalInstallPath("executable", targetPath)
+	if err != nil {
+		return CLIResult{}, err
 	}
+	targetPath = resolvedTargetPath
 	if err := validateExecutable(targetPath); err != nil {
 		return CLIResult{}, err
 	}
@@ -104,9 +108,11 @@ func InstallSkill(options SkillOptions) (SkillResult, error) {
 			return SkillResult{}, err
 		}
 	}
-	if resolved, err := filepath.EvalSymlinks(sourcePath); err == nil {
-		sourcePath = resolved
+	resolvedSourcePath, err := canonicalInstallPath("skill source", sourcePath)
+	if err != nil {
+		return SkillResult{}, err
 	}
+	sourcePath = resolvedSourcePath
 	if err := validateSkillDir(sourcePath); err != nil {
 		return SkillResult{}, err
 	}
@@ -132,6 +138,14 @@ func validateExecutable(path string) error {
 	return nil
 }
 
+func canonicalInstallPath(name string, path string) (string, error) {
+	resolved, err := pathresolve.Strict(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s %s: %w", name, path, err)
+	}
+	return resolved, nil
+}
+
 func bundledSkillPath(executablePath string) (string, error) {
 	if executablePath == "" {
 		executable, err := os.Executable()
@@ -140,9 +154,11 @@ func bundledSkillPath(executablePath string) (string, error) {
 		}
 		executablePath = executable
 	}
-	if resolved, err := filepath.EvalSymlinks(executablePath); err == nil {
-		executablePath = resolved
+	resolvedExecutablePath, err := canonicalInstallPath("executable", executablePath)
+	if err != nil {
+		return "", err
 	}
+	executablePath = resolvedExecutablePath
 	path := filepath.Clean(filepath.Join(filepath.Dir(executablePath), "..", "skills", SkillName))
 	if err := validateSkillDir(path); err != nil {
 		return "", fmt.Errorf("find bundled skill relative to %s: %w", executablePath, err)

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -137,6 +137,23 @@ func TestInstallCLIRejectsDirectoryTarget(t *testing.T) {
 	}
 }
 
+func TestInstallCLIRejectsBrokenExecutableSymlink(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "agent-secret")
+	if err := os.Symlink("missing", target); err != nil {
+		t.Fatalf("create broken executable symlink: %v", err)
+	}
+
+	_, err := InstallCLI(CLIOptions{BinDir: filepath.Join(t.TempDir(), "bin"), ExecutablePath: target})
+	if err == nil {
+		t.Fatal("InstallCLI succeeded with broken executable symlink")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("InstallCLI error = %v, want os.ErrNotExist", err)
+	}
+}
+
 func TestInstallCLIKeepsExistingMatchingSymlink(t *testing.T) {
 	t.Parallel()
 
@@ -386,6 +403,23 @@ func TestInstallSkillRejectsFileSource(t *testing.T) {
 	_, err := InstallSkill(SkillOptions{SkillsDir: filepath.Join(t.TempDir(), "skills"), SourcePath: source})
 	if err == nil {
 		t.Fatal("InstallSkill succeeded with file source")
+	}
+}
+
+func TestInstallSkillRejectsBrokenSourceSymlink(t *testing.T) {
+	t.Parallel()
+
+	source := filepath.Join(t.TempDir(), SkillName)
+	if err := os.Symlink("missing", source); err != nil {
+		t.Fatalf("create broken source symlink: %v", err)
+	}
+
+	_, err := InstallSkill(SkillOptions{SkillsDir: filepath.Join(t.TempDir(), "skills"), SourcePath: source})
+	if err == nil {
+		t.Fatal("InstallSkill succeeded with broken source symlink")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("InstallSkill error = %v, want os.ErrNotExist", err)
 	}
 }
 

--- a/internal/pathresolve/pathresolve.go
+++ b/internal/pathresolve/pathresolve.go
@@ -1,0 +1,30 @@
+package pathresolve
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+func Strict(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("make path absolute: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("resolve symlinks for %q: %w", abs, err)
+	}
+	return resolved, nil
+}
+
+func BestEffort(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return abs
+	}
+	return resolved
+}

--- a/internal/pathresolve/pathresolve_test.go
+++ b/internal/pathresolve/pathresolve_test.go
@@ -60,3 +60,26 @@ func TestBestEffortFallsBackToAbsolutePath(t *testing.T) {
 		t.Fatalf("BestEffort path = %q, want unresolved absolute path %q", got, link)
 	}
 }
+
+func TestBestEffortResolvesSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.WriteFile(target, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	got := BestEffort(link)
+	want, err := Strict(target)
+	if err != nil {
+		t.Fatalf("Strict target returned error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("BestEffort path = %q, want %q", got, want)
+	}
+}

--- a/internal/pathresolve/pathresolve_test.go
+++ b/internal/pathresolve/pathresolve_test.go
@@ -1,0 +1,62 @@
+package pathresolve
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStrictResolvesSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.WriteFile(target, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	got, err := Strict(link)
+	if err != nil {
+		t.Fatalf("Strict returned error: %v", err)
+	}
+	want, err := Strict(target)
+	if err != nil {
+		t.Fatalf("Strict target returned error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Strict path = %q, want %q", got, want)
+	}
+}
+
+func TestStrictRejectsBrokenSymlink(t *testing.T) {
+	t.Parallel()
+
+	link := filepath.Join(t.TempDir(), "broken")
+	if err := os.Symlink("missing", link); err != nil {
+		t.Fatalf("create broken symlink: %v", err)
+	}
+
+	_, err := Strict(link)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Strict error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestBestEffortFallsBackToAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	link := filepath.Join(t.TempDir(), "broken")
+	if err := os.Symlink("missing", link); err != nil {
+		t.Fatalf("create broken symlink: %v", err)
+	}
+
+	got := BestEffort(link)
+	if got != link {
+		t.Fatalf("BestEffort path = %q, want unresolved absolute path %q", got, link)
+	}
+}

--- a/internal/peercred/peercred.go
+++ b/internal/peercred/peercred.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
+
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 )
 
 var (
@@ -75,11 +76,11 @@ func Validate(info Info, expected Expected) error {
 
 	exe, err := comparablePath(info.ExecutablePath)
 	if err != nil {
-		return fmt.Errorf("normalize peer executable: %w", err)
+		return fmt.Errorf("%w: normalize peer executable: %w", ErrPolicyMismatch, err)
 	}
 	wantExe, err := comparablePath(expected.ExecutablePath)
 	if err != nil {
-		return fmt.Errorf("normalize expected executable: %w", err)
+		return fmt.Errorf("%w: normalize expected executable: %w", ErrPolicyMismatch, err)
 	}
 	if exe != wantExe {
 		return fmt.Errorf("%w: executable %q != %q", ErrPolicyMismatch, exe, wantExe)
@@ -87,11 +88,11 @@ func Validate(info Info, expected Expected) error {
 
 	cwd, err := comparablePath(info.CWD)
 	if err != nil {
-		return fmt.Errorf("normalize peer cwd: %w", err)
+		return fmt.Errorf("%w: normalize peer cwd: %w", ErrPolicyMismatch, err)
 	}
 	wantCWD, err := comparablePath(expected.CWD)
 	if err != nil {
-		return fmt.Errorf("normalize expected cwd: %w", err)
+		return fmt.Errorf("%w: normalize expected cwd: %w", ErrPolicyMismatch, err)
 	}
 	if cwd != wantCWD {
 		return fmt.Errorf("%w: cwd %q != %q", ErrPolicyMismatch, cwd, wantCWD)
@@ -133,14 +134,5 @@ func requireComplete(info Info) error {
 }
 
 func comparablePath(path string) (string, error) {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved, nil
-	}
-
-	return abs, nil
+	return pathresolve.Strict(path)
 }

--- a/internal/peercred/peercred_test.go
+++ b/internal/peercred/peercred_test.go
@@ -149,6 +149,32 @@ func TestComparablePathResolvesSymlinks(t *testing.T) {
 	}
 }
 
+func TestPeerCredRejectsBrokenSymlinkEvenWhenPathsMatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	broken := filepath.Join(dir, "broken")
+	if err := os.Symlink(filepath.Join(dir, "missing"), broken); err != nil {
+		t.Fatalf("create broken symlink: %v", err)
+	}
+	expected := Expected{
+		UID:            os.Getuid(),
+		GID:            os.Getgid(),
+		PID:            os.Getpid(),
+		ExecutablePath: broken,
+		CWD:            t.TempDir(),
+	}
+	info := Info(expected)
+
+	err := Validate(info, expected)
+	if !errors.Is(err, ErrPolicyMismatch) {
+		t.Fatalf("Validate error = %v, want ErrPolicyMismatch", err)
+	}
+	if !strings.Contains(err.Error(), "normalize peer executable") {
+		t.Fatalf("Validate error = %q, want executable normalization context", err.Error())
+	}
+}
+
 func TestCurrentExpectedWrapsOSErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kovyrin/agent-secret/internal/fileidentity"
 	"github.com/kovyrin/agent-secret/internal/opref"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 )
 
 const (
@@ -293,19 +294,19 @@ func normalizeCWD(cwd string) (string, error) {
 		}
 	}
 
-	abs, err := filepath.Abs(cwd)
+	resolved, err := pathresolve.Strict(cwd)
 	if err != nil {
 		return "", fmt.Errorf("resolve cwd: %w", err)
 	}
-	info, err := os.Stat(abs)
+	info, err := os.Stat(resolved)
 	if err != nil {
-		return "", fmt.Errorf("stat cwd %q: %w", abs, err)
+		return "", fmt.Errorf("stat cwd %q: %w", resolved, err)
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("cwd %q is not a directory", abs)
+		return "", fmt.Errorf("cwd %q is not a directory", resolved)
 	}
 
-	return evalPath(abs), nil
+	return resolved, nil
 }
 
 func resolveCommand(cwd string, env []string, command []string) ([]string, string, error) {
@@ -349,18 +350,18 @@ func resolveCommand(cwd string, env []string, command []string) ([]string, strin
 }
 
 func validateExecutable(path string) (string, error) {
-	abs, err := filepath.Abs(path)
+	resolved, err := pathresolve.Strict(path)
 	if err != nil {
 		return "", fmt.Errorf("%w: resolve executable %q: %w", ErrInvalidCommand, path, err)
 	}
-	info, err := os.Stat(abs)
+	info, err := os.Stat(resolved)
 	if err != nil {
-		return "", fmt.Errorf("%w: stat executable %q: %w", ErrInvalidCommand, abs, err)
+		return "", fmt.Errorf("%w: stat executable %q: %w", ErrInvalidCommand, resolved, err)
 	}
 	if info.IsDir() || info.Mode().Perm()&0111 == 0 {
-		return "", fmt.Errorf("%w: %q is not executable", ErrInvalidCommand, abs)
+		return "", fmt.Errorf("%w: %q is not executable", ErrInvalidCommand, resolved)
 	}
-	return evalPath(abs), nil
+	return resolved, nil
 }
 
 func validateDaemonPath(name string, path string, executable bool) error {
@@ -375,6 +376,13 @@ func validateDaemonPath(name string, path string, executable bool) error {
 	}
 	if executable && strings.HasSuffix(path, string(os.PathSeparator)) {
 		return fmt.Errorf("%w: %s must name a file", ErrInvalidCommand, name)
+	}
+	resolved, err := pathresolve.Strict(path)
+	if err != nil {
+		return fmt.Errorf("%w: %s must resolve without symlink errors: %w", ErrInvalidRequest, name, err)
+	}
+	if resolved != path {
+		return fmt.Errorf("%w: %s must be canonical", ErrInvalidRequest, name)
 	}
 	return nil
 }
@@ -538,12 +546,4 @@ func canonicalEnv(env []string) []string {
 		out = append(out, "malformed:"+entry)
 	}
 	return out
-}
-
-func evalPath(path string) string {
-	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return path
-	}
-	return resolved
 }

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -372,6 +372,54 @@ func TestExecRequestValidateForDaemonRejectsFabricatedMetadata(t *testing.T) {
 	}
 }
 
+func TestExecRequestValidateForDaemonRejectsSymlinkMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeExecutable(t, dir)
+	req, err := NewExec(baseOptions(dir, "reason"))
+	if err != nil {
+		t.Fatalf("NewExec returned error: %v", err)
+	}
+	req = req.WithReceiptTime(time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC))
+	req.Secrets[0].Account = "Work"
+
+	cwdLink := filepath.Join(t.TempDir(), "cwd-link")
+	if err := os.Symlink(req.CWD, cwdLink); err != nil {
+		t.Fatalf("create cwd symlink: %v", err)
+	}
+	executableLink := filepath.Join(t.TempDir(), "tool-link")
+	if err := os.Symlink(req.ResolvedExecutable, executableLink); err != nil {
+		t.Fatalf("create executable symlink: %v", err)
+	}
+	brokenLink := filepath.Join(t.TempDir(), "broken-link")
+	if err := os.Symlink(filepath.Join(t.TempDir(), "missing"), brokenLink); err != nil {
+		t.Fatalf("create broken symlink: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*ExecRequest)
+	}{
+		{name: "cwd symlink", mutate: func(r *ExecRequest) { r.CWD = cwdLink }},
+		{name: "executable symlink", mutate: func(r *ExecRequest) { r.ResolvedExecutable = executableLink }},
+		{name: "broken cwd symlink", mutate: func(r *ExecRequest) { r.CWD = brokenLink }},
+		{name: "broken executable symlink", mutate: func(r *ExecRequest) { r.ResolvedExecutable = brokenLink }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := cloneRequest(req)
+			tt.mutate(&got)
+			if err := got.ValidateForDaemon(); !errors.Is(err, ErrInvalidRequest) {
+				t.Fatalf("ValidateForDaemon error = %v, want ErrInvalidRequest", err)
+			}
+		})
+	}
+}
+
 func TestExecRequestExpiryUsesDaemonReceiptTTL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- enforce approval expiration in `ApprovalController` before submitting decisions
- require production daemon wiring to pass an explicit exec validator into `daemon.NewServer`
- split strict vs best-effort symlink canonicalization and fail closed on trust/validation paths
- keep ignored `.desloppify/` tool state out of gitleaks scans while preserving default rules

Updates #271.

## Validation

- `mise run lint`
- `mise run build`
