### PR TITLE
Improve CLI install PATH guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- markdownlint-disable MD024 -->
+
 All notable changes to Agent Secret are recorded here.
 
 This file follows the spirit of
@@ -17,6 +19,19 @@ version numbers for public releases.
   date in `YYYY-MM-DD` form as part of the release commit.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
+
+## [0.0.2] - 2026-05-04
+
+Follow-up macOS install UX release for clean-machine CLI setup.
+
+### Fixed
+
+- The setup app now finishes command-line tool installation with a one-button
+  confirmation instead of returning to the original setup dialog.
+- `agent-secret install-cli` now warns when the installed command directory is
+  not on `PATH` and shows a zsh one-liner for a clean macOS shell.
+- The unattended installer now bases that warning on the caller's original
+  `PATH`, not on the installer's sanitized tool `PATH`.
 
 ## [0.0.1] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ Human install flow:
 2. Open the DMG and drag `Agent Secret.app` into `/Applications`.
 3. Open `Agent Secret.app`.
 4. Click `Install Command Line Tool`.
-5. Run:
+5. If the app warns that `~/.local/bin` is not on `PATH`, add the shown
+   one-liner in Terminal.
+6. Run:
 
    ```bash
    agent-secret doctor

--- a/approver/Sources/AgentSecretApproverApp/SetupDialog.swift
+++ b/approver/Sources/AgentSecretApproverApp/SetupDialog.swift
@@ -24,10 +24,18 @@ func runSetupDialog() {
 
             switch alert.runModal() {
             case .alertFirstButtonReturn:
-                message = runBundledAgentSecret(arguments: ["install-cli"])
+                let result = runBundledAgentSecret(arguments: ["install-cli"])
+                showSetupResult(
+                    title: result.succeeded ? "Command Line Tool Installed" : "Command Line Tool Install Failed",
+                    message: result.output,
+                    style: result.succeeded ? .informational : .warning
+                )
+                if result.succeeded {
+                    shouldContinue = false
+                }
 
             case .alertSecondButtonReturn:
-                message = runBundledAgentSecret(arguments: ["doctor"])
+                message = runBundledAgentSecret(arguments: ["doctor"]).output
 
             default:
                 shouldContinue = false
@@ -48,13 +56,25 @@ private func setupIntroText() -> String {
     """
 }
 
-private func runBundledAgentSecret(arguments: [String]) -> String {
+#if canImport(AppKit)
+    @MainActor
+    private func showSetupResult(title: String, message: String, style: NSAlert.Style) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = style
+        alert.addButton(withTitle: "Close")
+        alert.runModal()
+    }
+#endif
+
+private func runBundledAgentSecret(arguments: [String]) -> (output: String, succeeded: Bool) {
     guard let cliPath = bundledAgentSecretPath() else {
-        return """
+        return ("""
         The bundled agent-secret command was not found inside this app.
 
         Reinstall Agent Secret.app, then open the app again.
-        """
+        """, false)
     }
 
     let process = Process()
@@ -69,18 +89,19 @@ private func runBundledAgentSecret(arguments: [String]) -> String {
         try process.run()
         process.waitUntilExit()
     } catch {
-        return "Could not run \(cliPath): \(error)"
+        return ("Could not run \(cliPath): \(error)", false)
     }
 
     let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
     let output = (String(bytes: data, encoding: .utf8) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     if process.terminationStatus == 0 {
-        return output.isEmpty ? "Command completed." : output
+        return (output.isEmpty ? "Command completed." : output, true)
     }
     if output.isEmpty {
-        return "agent-secret \(arguments.joined(separator: " ")) failed with exit \(process.terminationStatus)."
+        let command = arguments.joined(separator: " ")
+        return ("agent-secret \(command) failed with exit \(process.terminationStatus).", false)
     }
-    return output
+    return (output, false)
 }
 
 private func bundledAgentSecretPath() -> String? {

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -581,8 +581,8 @@ brew upgrade agent-secret
 
 - `/Applications` may require admin permissions on some managed machines. The
   installer should support `~/Applications` as a fallback.
-- Shell PATH setup is not solved by installing the symlink. The app and
-  installer should warn if the selected bin directory is not on PATH.
+- Shell PATH setup is not changed automatically. The app and installer warn if
+  the selected bin directory is not on PATH.
 - Signing requires careful GitHub Actions secret management, certificate
   import, and keychain cleanup.
 - Nested helper signing order matters. Release automation should make signing

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -eu
+caller_path="${PATH-}"
 PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 export PATH
 
@@ -446,7 +447,7 @@ rm -rf "$target_app"
 mv "$tmp_app" "$target_app"
 
 echo "Installing command symlink into $bin_dir"
-"$target_app/Contents/Resources/bin/agent-secret" install-cli --bin-dir "$bin_dir"
+PATH="$caller_path" "$target_app/Contents/Resources/bin/agent-secret" install-cli --bin-dir "$bin_dir"
 
 echo "Installing Agent Secret skill"
 "$target_app/Contents/Resources/bin/agent-secret" skill-install --skills-dir "$skills_dir" --force

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/kovyrin/agent-secret/internal/audit"
@@ -363,6 +365,7 @@ func (a App) runInstallCLI(command Command) int {
 		return 1
 	}
 	a.stdoutf("agent-secret command installed: %s -> %s\n", result.LinkPath, result.TargetPath)
+	a.warnIfCommandDirMissingFromPath(filepath.Dir(result.LinkPath))
 	return 0
 }
 
@@ -390,6 +393,76 @@ func (a App) stdoutln(args ...any) {
 
 func (a App) stderrf(format string, args ...any) {
 	_, _ = fmt.Fprintf(a.Stderr, format, args...)
+}
+
+func (a App) warnIfCommandDirMissingFromPath(binDir string) {
+	if pathContainsDir(os.Getenv("PATH"), binDir) {
+		return
+	}
+	a.stdoutf(
+		"\n%s is not on PATH, so `agent-secret` may not work by command name in Terminal.\n"+
+			"For zsh, run this one-liner:\n\n"+
+			"  %s\n",
+		displayHomePath(binDir),
+		zshPathSetupCommand(binDir),
+	)
+}
+
+func pathContainsDir(pathValue string, dir string) bool {
+	if pathValue == "" || dir == "" {
+		return false
+	}
+	want := filepath.Clean(dir)
+	for _, entry := range filepath.SplitList(pathValue) {
+		if entry != "" && filepath.Clean(entry) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func displayHomePath(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == home {
+		return "~"
+	}
+	prefix := home + string(os.PathSeparator)
+	if suffix, ok := strings.CutPrefix(path, prefix); ok {
+		return "~/" + suffix
+	}
+	return path
+}
+
+func shellPathPrefix(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == home {
+		return "$HOME"
+	}
+	prefix := home + string(os.PathSeparator)
+	if suffix, ok := strings.CutPrefix(path, prefix); ok {
+		return "$HOME/" + suffix
+	}
+	return path
+}
+
+func zshPathSetupCommand(binDir string) string {
+	exportLine := fmt.Sprintf("export PATH=\"%s:$PATH\"", shellPathPrefix(binDir))
+	quotedLine := shellSingleQuote(exportLine)
+	return fmt.Sprintf(
+		"grep -qxF %s \"$HOME/.zprofile\" 2>/dev/null || printf '\\n%%s\\n' %s >> \"$HOME/.zprofile\"; exec zsh -l",
+		quotedLine,
+		quotedLine,
+	)
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 type daemonAuditReporter struct {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -431,6 +431,59 @@ func TestAppInstallCommands(t *testing.T) {
 	})
 }
 
+func TestAppInstallCLIWarnsWhenCommandDirIsNotOnPath(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".local", "bin")
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", filepath.Join(t.TempDir(), "other-bin"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestApp(control.Manager{}, &stdout, &stderr)
+	app.InstallCLI = func(options install.CLIOptions) (install.CLIResult, error) {
+		return install.CLIResult{
+			LinkPath:   filepath.Join(binDir, "agent-secret"),
+			TargetPath: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		}, nil
+	}
+
+	code := app.Run(context.Background(), []string{"install-cli", "--bin-dir", binDir})
+	if code != 0 {
+		t.Fatalf("install-cli exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "is not on PATH") {
+		t.Fatalf("install-cli stdout = %q, want PATH warning", stdout.String())
+	}
+	wantOneLiner := "grep -qxF 'export PATH=\"$HOME/.local/bin:$PATH\"' \"$HOME/.zprofile\" 2>/dev/null || " +
+		"printf '\\n%s\\n' 'export PATH=\"$HOME/.local/bin:$PATH\"' >> \"$HOME/.zprofile\"; exec zsh -l"
+	if !strings.Contains(stdout.String(), wantOneLiner) {
+		t.Fatalf("install-cli stdout = %q, want zsh setup one-liner %q", stdout.String(), wantOneLiner)
+	}
+}
+
+func TestAppInstallCLISkipsPathWarningWhenCommandDirIsOnPath(t *testing.T) {
+	binDir := filepath.Join(t.TempDir(), "bin")
+	t.Setenv("PATH", strings.Join([]string{filepath.Join(t.TempDir(), "other-bin"), binDir}, string(os.PathListSeparator)))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestApp(control.Manager{}, &stdout, &stderr)
+	app.InstallCLI = func(options install.CLIOptions) (install.CLIResult, error) {
+		return install.CLIResult{
+			LinkPath:   filepath.Join(binDir, "agent-secret"),
+			TargetPath: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		}, nil
+	}
+
+	code := app.Run(context.Background(), []string{"install-cli", "--bin-dir", binDir})
+	if code != 0 {
+		t.Fatalf("install-cli exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stdout.String(), "is not on PATH") {
+		t.Fatalf("install-cli stdout = %q, did not expect PATH warning", stdout.String())
+	}
+}
+
 func TestAppSkipsDaemonManagerForNonDaemonCommands(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -800,6 +800,9 @@ The command creates:
 
   ~/.local/bin/agent-secret -> /Applications/Agent Secret.app/Contents/Resources/bin/agent-secret
 
+On a clean macOS shell, ~/.local/bin is usually not on PATH. If install-cli
+prints a PATH warning, paste the shown one-liner into Terminal.
+
 When run from a development or test build, it links to the executable that is
 currently running. If the command is already a symlink to that executable, it is
 left in place. Existing regular files and symlinks to different targets are not

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -160,6 +160,7 @@ PLIST
 #!/bin/sh
 case "$1" in
   install-cli)
+    printf 'bundled-agent-secret install-cli PATH=%s\n' "${PATH-}" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
     bin_dir=""
     while [ "$#" -gt 0 ]; do
       if [ "$1" = "--bin-dir" ]; then
@@ -471,6 +472,15 @@ test_untrusted_existing_cli_is_not_used_for_daemon_stop() {
   fi
 }
 
+test_install_cli_receives_original_path_before_sanitization() {
+  local name="install-cli-original-path"
+  local original_path="$tmp_dir/$name/bin:$tmp_dir/$name/bin-dir:$PATH"
+
+  run_installer "$name" PATH="$original_path"
+
+  assert_log_contains "$tmp_dir/$name/tools.log" "bundled-agent-secret install-cli PATH=$original_path"
+}
+
 test_identity_checks_run
 test_identity_failure_stops_install
 test_wrong_team_id_stops_install
@@ -484,5 +494,6 @@ test_destination_validation_rejects_bad_paths
 test_destination_validation_rejects_symlinked_parent_dirs
 test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts
 test_untrusted_existing_cli_is_not_used_for_daemon_stop
+test_install_cli_receives_original_path_before_sanitization
 
 echo "test-install: ok"


### PR DESCRIPTION
## Summary
- finish the setup app command-line tool install flow with a one-button result dialog
- warn when the command symlink directory is not on the caller PATH and show an idempotent zsh one-liner
- preserve the unattended installer sanitized tool PATH while passing the original PATH to install-cli for warning decisions
- add 0.0.2 release notes for this follow-up install UX release

## Validation
- mise run lint
- mise run build
- AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
- scripts/release/extract-release-notes.sh v0.0.2 /tmp/agent-secret-v0.0.2-notes.md
- npx markdownlint-cli CHANGELOG.md README.md docs/macos-distribution-plan.md