### PR TITLE
Polish setup PATH command display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
+## [0.0.3] - Pending
+
+### Fixed
+
+- The setup app now renders the shell PATH command in a dark selectable
+  monospace block instead of plain alert text.
+
 ## [0.0.2] - 2026-05-04
 
 Follow-up macOS install UX release for clean-machine CLI setup.

--- a/approver/Sources/AgentSecretApproverApp/SetupDialog.swift
+++ b/approver/Sources/AgentSecretApproverApp/SetupDialog.swift
@@ -57,14 +57,104 @@ private func setupIntroText() -> String {
 }
 
 #if canImport(AppKit)
+    private let kSetupTerminalCommandWidth: CGFloat = 620
+    private let kSetupTerminalCommandPadding: CGFloat = 12
+    private let kSetupTerminalCommandFontSize: CGFloat = 12
+    private let kSetupTerminalBackgroundWhite: CGFloat = 0.07
+    private let kSetupTerminalBorderWhite: CGFloat = 0.22
+    private let kSetupTerminalBorderWidth: CGFloat = 1
+    private let kSetupTerminalCornerRadius: CGFloat = 8
+    private let kSetupTerminalTextWhite: CGFloat = 0.92
+    private let kSetupTerminalMinimumTextHeight: CGFloat = 42
+    private let kSetupTerminalMaximumTextHeight: CGFloat = 180
+    private let kSetupTerminalFrameOrigin: CGFloat = 0
+    private let kSetupTerminalOpaqueAlpha: CGFloat = 1
+    private let kSetupTerminalPaddingMultiplier: CGFloat = 2
+    private let kSetupTerminalUnlimitedLines = 0
+
     @MainActor
     private func showSetupResult(title: String, message: String, style: NSAlert.Style) {
+        let result = formattedSetupResult(message)
         let alert = NSAlert()
         alert.messageText = title
-        alert.informativeText = message
+        alert.informativeText = result.body
         alert.alertStyle = style
+        if let command = result.command {
+            alert.accessoryView = terminalCommandView(command)
+        }
         alert.addButton(withTitle: "Close")
         alert.runModal()
+    }
+
+    private func formattedSetupResult(_ message: String) -> (body: String, command: String?) {
+        let marker = "For zsh, run this one-liner:"
+        guard let markerRange = message.range(of: marker) else {
+            return (message, nil)
+        }
+
+        var body = String(message[..<markerRange.upperBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let command = message[markerRange.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
+        if body.hasPrefix("agent-secret command installed: ") {
+            body = replacingFirstLine(in: body, with: "agent-secret command installed.")
+        }
+        body = body.replacingOccurrences(of: "`agent-secret`", with: "agent-secret")
+        return (body, command.isEmpty ? nil : command)
+    }
+
+    @MainActor
+    private func terminalCommandView(_ command: String) -> NSView {
+        let width = kSetupTerminalCommandWidth
+        let padding = kSetupTerminalCommandPadding
+        let font = NSFont.monospacedSystemFont(ofSize: kSetupTerminalCommandFontSize, weight: .regular)
+        let textWidth = width - padding * kSetupTerminalPaddingMultiplier
+        let textHeight = terminalTextHeight(command, font: font, width: textWidth)
+        let height = textHeight + padding * kSetupTerminalPaddingMultiplier
+
+        let container = NSView(
+            frame: NSRect(
+                x: kSetupTerminalFrameOrigin,
+                y: kSetupTerminalFrameOrigin,
+                width: width,
+                height: height
+            )
+        )
+        container.wantsLayer = true
+        container.layer?.backgroundColor = terminalColor(kSetupTerminalBackgroundWhite).cgColor
+        container.layer?.borderColor = terminalColor(kSetupTerminalBorderWhite).cgColor
+        container.layer?.borderWidth = kSetupTerminalBorderWidth
+        container.layer?.cornerRadius = kSetupTerminalCornerRadius
+
+        let commandField = NSTextField(wrappingLabelWithString: command)
+        commandField.frame = NSRect(x: padding, y: padding, width: textWidth, height: textHeight)
+        commandField.autoresizingMask = [.width, .height]
+        commandField.font = font
+        commandField.isSelectable = true
+        commandField.lineBreakMode = .byCharWrapping
+        commandField.maximumNumberOfLines = kSetupTerminalUnlimitedLines
+        commandField.textColor = terminalColor(kSetupTerminalTextWhite)
+        container.addSubview(commandField)
+
+        return container
+    }
+
+    private func terminalTextHeight(_ text: String, font: NSFont, width: CGFloat) -> CGFloat {
+        let attributed = NSAttributedString(string: text, attributes: [.font: font])
+        let rect = attributed.boundingRect(
+            with: NSSize(width: width, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        )
+        return min(max(ceil(rect.height), kSetupTerminalMinimumTextHeight), kSetupTerminalMaximumTextHeight)
+    }
+
+    private func replacingFirstLine(in text: String, with replacement: String) -> String {
+        guard let newline = text.firstIndex(of: "\n") else {
+            return replacement
+        }
+        return replacement + text[newline...]
+    }
+
+    private func terminalColor(_ white: CGFloat) -> NSColor {
+        NSColor(calibratedWhite: white, alpha: kSetupTerminalOpaqueAlpha)
     }
 #endif
 


### PR DESCRIPTION
## Summary
- render the setup PATH one-liner in a dark selectable monospace block
- keep the setup success prose readable by pulling the command out of the plain alert text
- add pending 0.0.3 changelog note for the setup UI polish

## Validation
- mise run lint:swift
- mise run build
- npx markdownlint-cli CHANGELOG.md