### PR TITLE
Remove installer xcrun dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
+## [0.0.4] - 2026-05-04
+
+### Fixed
+
+- The unattended installer no longer requires Xcode or Command Line Tools for
+  `xcrun stapler validate`; release notarization remains verified by CI and
+  Gatekeeper.
+
 ## [0.0.3] - 2026-05-04
 
 ### Fixed

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -117,14 +117,18 @@ AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1 install.sh
 For local smoke tests, set `AGENT_SECRET_INSTALL_DEV_MODE=1` and point
 `AGENT_SECRET_DMG` plus `AGENT_SECRET_CHECKSUMS_FILE` at locally built
 artifacts. Unsigned local artifacts must also set
-`AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`; signed but unstapled local artifacts
-can set `AGENT_SECRET_REQUIRE_NOTARIZATION=0`. Production installs pin the
-GitHub host, repository, Team ID `B6L7QLWTZW`, and bundle identifiers
+`AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1`. Production installs pin the GitHub
+host, repository, Team ID `B6L7QLWTZW`, and bundle identifiers
 `com.kovyrin.agent-secret` and `com.kovyrin.agent-secret.daemon`; overriding
 those release trust roots requires development mode and local artifacts.
 Custom app, command, or skill destination roots require
 `AGENT_SECRET_ALLOW_CUSTOM_INSTALL_PATHS=1` and are rejected when empty,
 relative, broad, or symlinked.
+
+The unattended installer must not require Xcode or Command Line Tools. Release
+CI and maintainer verification use `stapler`, while customer installs rely on
+checksum, code signature, Team ID, bundle identifier, and Gatekeeper `spctl`
+assessment.
 
 ### Upgrade
 

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,6 @@ configure_tool_paths() {
   tool_ditto="/usr/bin/ditto"
   tool_codesign="/usr/bin/codesign"
   tool_spctl="/usr/sbin/spctl"
-  tool_xcrun="/usr/bin/xcrun"
   tool_plistbuddy="/usr/libexec/PlistBuddy"
 
   if [ -z "$install_tool_dir" ]; then
@@ -78,7 +77,6 @@ configure_tool_paths() {
   tool_ditto="$install_tool_dir/ditto"
   tool_codesign="$install_tool_dir/codesign"
   tool_spctl="$install_tool_dir/spctl"
-  tool_xcrun="$install_tool_dir/xcrun"
 }
 
 is_system_root_alias() {
@@ -180,7 +178,6 @@ repo="$production_repo"
 github_url="$production_github_url"
 github_api="$production_github_api"
 allow_unsigned_install=0
-require_notarization=1
 expected_team_id="$production_expected_team_id"
 expected_app_bundle_id="$production_expected_app_bundle_id"
 expected_daemon_bundle_id="$production_expected_daemon_bundle_id"
@@ -190,7 +187,6 @@ if [ "$install_dev_mode" != "1" ]; then
   require_dev_mode_for_env AGENT_SECRET_GITHUB_URL
   require_dev_mode_for_env AGENT_SECRET_GITHUB_API
   require_dev_mode_for_env AGENT_SECRET_ALLOW_UNSIGNED_INSTALL
-  require_dev_mode_for_env AGENT_SECRET_REQUIRE_NOTARIZATION
   require_dev_mode_for_env AGENT_SECRET_EXPECTED_TEAM_ID
   require_dev_mode_for_env AGENT_SECRET_EXPECTED_APP_BUNDLE_ID
   require_dev_mode_for_env AGENT_SECRET_EXPECTED_DAEMON_BUNDLE_ID
@@ -202,7 +198,6 @@ else
   github_url="${AGENT_SECRET_GITHUB_URL:-$production_github_url}"
   github_api="${AGENT_SECRET_GITHUB_API:-$production_github_api}"
   allow_unsigned_install="${AGENT_SECRET_ALLOW_UNSIGNED_INSTALL:-0}"
-  require_notarization="${AGENT_SECRET_REQUIRE_NOTARIZATION:-1}"
   expected_team_id="${AGENT_SECRET_EXPECTED_TEAM_ID:-$production_expected_team_id}"
   expected_app_bundle_id="${AGENT_SECRET_EXPECTED_APP_BUNDLE_ID:-$production_expected_app_bundle_id}"
   expected_daemon_bundle_id="${AGENT_SECRET_EXPECTED_DAEMON_BUNDLE_ID:-$production_expected_daemon_bundle_id}"
@@ -297,17 +292,12 @@ verify_dmg_identity() {
 
   require_tool codesign "$tool_codesign"
   require_tool spctl "$tool_spctl"
-  require_tool xcrun "$tool_xcrun"
 
   "$tool_codesign" --verify --strict --verbose=2 "$dmg" ||
     die "DMG code signature verification failed"
   verify_team_id "$dmg" "DMG"
   "$tool_spctl" --assess --type open --context context:primary-signature --verbose "$dmg" ||
     die "DMG Gatekeeper assessment failed"
-  if [ "$require_notarization" = "1" ]; then
-    "$tool_xcrun" stapler validate "$dmg" ||
-      die "DMG notarization ticket validation failed"
-  fi
 }
 
 codesign_team_id() {
@@ -370,10 +360,6 @@ verify_app_identity() {
   verify_team_id "$cli" "bundled agent-secret CLI"
   "$tool_spctl" --assess --type execute --verbose "$app" ||
     die "app Gatekeeper assessment failed"
-  if [ "$require_notarization" = "1" ]; then
-    "$tool_xcrun" stapler validate "$app" ||
-      die "app notarization ticket validation failed"
-  fi
 }
 
 stop_existing_daemon() {

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -69,16 +69,6 @@ printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
 exit "${AGENT_SECRET_INSTALL_TEST_SPCTL_STATUS:-0}"
 SCRIPT
 
-  cat >"$fake_bin/xcrun" <<'SCRIPT'
-#!/bin/sh
-printf 'xcrun' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
-for arg in "$@"; do
-  printf ' %s' "$arg" >>"$AGENT_SECRET_INSTALL_TEST_LOG"
-done
-printf '\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
-exit "${AGENT_SECRET_INSTALL_TEST_XCRUN_STATUS:-0}"
-SCRIPT
-
   cat >"$fake_bin/curl" <<'SCRIPT'
 #!/bin/sh
 printf 'curl' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
@@ -217,7 +207,7 @@ exit 44
 SCRIPT
   done
 
-  chmod 755 "$fake_bin/codesign" "$fake_bin/spctl" "$fake_bin/xcrun" \
+  chmod 755 "$fake_bin/codesign" "$fake_bin/spctl" \
     "$fake_bin/curl" "$fake_bin/shasum" \
     "$fake_bin/agent-secret" \
     "$fake_bin/ditto" "$fake_bin/hdiutil" \
@@ -309,10 +299,15 @@ test_identity_checks_run() {
   assert_log_contains "$log" "codesign --verify --strict --verbose=2"
   assert_log_contains "$log" "codesign -dv --verbose=4"
   assert_log_contains "$log" "spctl --assess --type open --context context:primary-signature --verbose"
-  assert_log_contains "$log" "xcrun stapler validate"
   assert_log_contains "$log" "codesign --verify --deep --strict --verbose=2"
   assert_log_contains "$log" "codesign -dv --verbose=4"
   assert_log_contains "$log" "spctl --assess --type execute --verbose"
+}
+
+test_installer_has_no_developer_tool_dependency() {
+  if grep -E 'xcrun|stapler|AGENT_SECRET_REQUIRE_NOTARIZATION' "$project_root/install.sh" >/dev/null; then
+    fail "installer must not require developer tools or stapler validation"
+  fi
 }
 
 test_identity_failure_stops_install() {
@@ -450,11 +445,10 @@ test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts() {
     AGENT_SECRET_INSTALL_DEV_MODE=1 \
     AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1 \
     AGENT_SECRET_INSTALL_TEST_CODESIGN_STATUS=23 \
-    AGENT_SECRET_INSTALL_TEST_SPCTL_STATUS=23 \
-    AGENT_SECRET_INSTALL_TEST_XCRUN_STATUS=23
+    AGENT_SECRET_INSTALL_TEST_SPCTL_STATUS=23
 
   log="$tmp_dir/unsigned-allowed/tools.log"
-  if grep -E '^(codesign|spctl|xcrun) ' "$log" >/dev/null; then
+  if grep -E '^(codesign|spctl) ' "$log" >/dev/null; then
     echo "---- tool log ----" >&2
     cat "$log" >&2
     fail "unsigned override should not call identity verification tools"
@@ -482,6 +476,7 @@ test_install_cli_receives_original_path_before_sanitization() {
 }
 
 test_identity_checks_run
+test_installer_has_no_developer_tool_dependency
 test_identity_failure_stops_install
 test_wrong_team_id_stops_install
 test_wrong_app_bundle_id_stops_install


### PR DESCRIPTION
## Summary
- remove installer-side xcrun/stapler validation so clean macOS machines do not need Xcode or Command Line Tools
- keep release notarization validation in CI/release verification and rely on Gatekeeper during install
- add an installer regression test that blocks xcrun/stapler references in install.sh
- prepare v0.0.4 release notes

## Validation
- AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
- mise run lint:shell
- mise exec -- npx --yes markdownlint-cli CHANGELOG.md docs/macos-distribution-plan.md
- scripts/release/test-release-docs.sh
- mise run lint