### PR TITLE
Let installer complete with diagnostic warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
+## [0.0.5] - 2026-05-04
+
+### Fixed
+
+- The unattended installer now completes even when post-install diagnostics
+  report that 1Password desktop integration is not configured yet.
+
 ## [0.0.4] - 2026-05-04
 
 ### Fixed

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -331,7 +331,9 @@ The root `install.sh` is the supported unattended installer. It:
 - Copy the app bundle.
 - Run the bundled CLI's `install-cli`.
 - Run the bundled CLI's `skill-install`.
-- Run `agent-secret doctor`.
+- Run `agent-secret doctor` and report diagnostics without failing the install
+  when optional local dependencies such as 1Password desktop integration are
+  not configured yet.
 
 It does not depend on Homebrew, 1Password CLI, or repo checkout state.
 

--- a/install.sh
+++ b/install.sh
@@ -439,4 +439,7 @@ echo "Installing Agent Secret skill"
 "$target_app/Contents/Resources/bin/agent-secret" skill-install --skills-dir "$skills_dir" --force
 
 echo "Running diagnostics"
-"$bin_dir/agent-secret" doctor
+if ! "$bin_dir/agent-secret" doctor; then
+  echo "agent-secret install: diagnostics reported issues; installation completed" >&2
+  echo "agent-secret install: rerun $bin_dir/agent-secret doctor after fixing local setup" >&2
+fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -164,7 +164,8 @@ case "$1" in
     cat >"$bin_dir/agent-secret" <<'BIN'
 #!/bin/sh
 if [ "${1:-}" = "doctor" ]; then
-  exit 0
+  printf 'installed-agent-secret doctor\n' >>"$AGENT_SECRET_INSTALL_TEST_LOG"
+  exit "${AGENT_SECRET_INSTALL_TEST_DOCTOR_STATUS:-0}"
 fi
 exit 0
 BIN
@@ -475,6 +476,17 @@ test_install_cli_receives_original_path_before_sanitization() {
   assert_log_contains "$tmp_dir/$name/tools.log" "bundled-agent-secret install-cli PATH=$original_path"
 }
 
+test_diagnostics_failure_does_not_fail_install() {
+  local name="doctor-warning"
+
+  run_installer "$name" AGENT_SECRET_INSTALL_TEST_DOCTOR_STATUS=9
+
+  assert_log_contains "$tmp_dir/$name/tools.log" "installed-agent-secret doctor"
+  if [ ! -d "$tmp_dir/$name/apps/Agent Secret.app" ]; then
+    fail "installer did not leave app installed after diagnostics failure"
+  fi
+}
+
 test_identity_checks_run
 test_installer_has_no_developer_tool_dependency
 test_identity_failure_stops_install
@@ -490,5 +502,6 @@ test_destination_validation_rejects_symlinked_parent_dirs
 test_dev_mode_unsigned_override_skips_identity_checks_for_local_artifacts
 test_untrusted_existing_cli_is_not_used_for_daemon_stop
 test_install_cli_receives_original_path_before_sanitization
+test_diagnostics_failure_does_not_fail_install
 
 echo "test-install: ok"


### PR DESCRIPTION
## Summary
- let install.sh complete when post-install doctor reports local setup issues such as missing 1Password desktop integration
- keep diagnostics visible and tell the user to rerun doctor after fixing setup
- add a regression that doctor failures do not undo or fail installation
- prepare v0.0.5 release notes

## Validation
- AGENT_SECRET_IN_MISE=1 scripts/test-install.sh
- mise run lint:shell
- mise exec -- npx --yes markdownlint-cli CHANGELOG.md docs/macos-distribution-plan.md
- scripts/release/extract-release-notes.sh v0.0.5 /tmp/agent-secret-v0.0.5-release-notes.md
- mise run lint