### PR TITLE
Bind 1Password account selection per request

### DIFF
--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -119,9 +119,10 @@ agent-secret exec --profile ansible --only CADDY_TOKEN,POSTGRES_PASSWORD -- \
 
 Account precedence is per-secret `account`, profile `account`, top-level
 `account`, CLI `--account`, `OP_ACCOUNT` / `AGENT_SECRET_1PASSWORD_ACCOUNT`,
-then the Agent Secret default. Prefer config accounts over shell environment
-when a project needs a specific 1Password account. Use `--account` for one-off
-wrappers or env-file migrations that should not require a project config yet.
+then a detected single signed-in 1Password CLI account, then the Agent Secret
+default. Prefer config accounts over shell environment when a project needs a
+specific 1Password account. Use `--account` for one-off wrappers or env-file
+migrations that should not require a project config yet.
 
 ## Env Files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
+## [0.0.6] - Pending
+
+### Fixed
+
+- Account selection is now bound into each `agent-secret exec` request, so
+  `--account`, project config changes, and account environment variables take
+  effect even when the per-user daemon is already running.
+- With no explicit account, `agent-secret` now detects the single signed-in
+  1Password CLI account before falling back to `my.1password.com`.
+- The unattended installer now runs post-install diagnostics with the caller's
+  original `PATH`, allowing diagnostics to see the same `op` command as the
+  user's shell.
+
 ## [0.0.5] - 2026-05-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ AGENT_SECRET_LIVE_REF="op://Test Vault/Test Item/token" \
 ```
 
 Set `OP_ACCOUNT` or `AGENT_SECRET_1PASSWORD_ACCOUNT` only when you want to
-force a specific 1Password account instead of `my.1password.com`. Project
-config accounts override those defaults for the secrets that declare them.
+force a specific 1Password account instead of the detected single signed-in
+1Password CLI account. Project config accounts override those defaults for the
+secrets that declare them.
 
 Release artifact verification is separate from pull request CI. For a local
 release-candidate check, run:
@@ -300,14 +301,15 @@ Override the install locations with `--bin-dir`, `--app-dir`,
 one-off flags, run `./scripts/dev-install.sh` directly. The dev installer
 replaces the app bundle and recreates the command and skill symlinks.
 
-By default, `agent-secret` uses the personal 1Password sign-in address
-`my.1password.com`. Set `OP_ACCOUNT` or `AGENT_SECRET_1PASSWORD_ACCOUNT` in the
-shell that will run `agent-secret exec` only when you want to force a specific
-account; the CLI binds that account into the approval request so already-running
-daemons resolve the same account the approver sees. Project config can also set
-`account` globally, per profile, or per secret, and those config values take
-precedence for the affected secret refs. On macOS, `agent-secret` starts the
-daemon through the nested `AgentSecretDaemon.app` inside `Agent Secret.app` so
+By default, `agent-secret` uses the single signed-in 1Password CLI account when
+it can detect one, then falls back to `my.1password.com`. Set `OP_ACCOUNT` or
+`AGENT_SECRET_1PASSWORD_ACCOUNT` in the shell that will run `agent-secret exec`
+only when you want to force a specific account; the CLI binds that account into
+the approval request so already-running daemons resolve the same account the
+approver sees. Project config can also set `account` globally, per profile, or
+per secret, and those config values take precedence for the affected secret
+refs. On macOS, `agent-secret` starts the daemon through the nested
+`AgentSecretDaemon.app` inside `Agent Secret.app` so
 1Password sees the SDK caller as Agent Secret instead of the terminal or agent
 desktop app that launched the CLI.
 
@@ -515,7 +517,8 @@ defined them unless the selected profile overrides that secret alias.
 
 `account` is optional. The precedence is per-secret `account`, then profile
 `account`, then top-level `account`, then CLI `--account`, then `OP_ACCOUNT` /
-`AGENT_SECRET_1PASSWORD_ACCOUNT`, then `my.1password.com`.
+`AGENT_SECRET_1PASSWORD_ACCOUNT`, then one detected signed-in 1Password CLI
+account, then `my.1password.com`.
 
 Run a profile with:
 

--- a/cmd/agent-secretd/main.go
+++ b/cmd/agent-secretd/main.go
@@ -53,7 +53,7 @@ func run() int {
 
 	broker, err := daemonbroker.New(daemonbroker.Options{
 		Approver: approver,
-		Resolver: opresolver.NewDesktopPool(config.accountName),
+		Resolver: opresolver.NewDesktopPool(),
 		Audit:    auditWriter,
 	})
 	if err != nil {
@@ -69,7 +69,7 @@ func run() int {
 		Broker:           broker,
 		Approvals:        approver,
 		ExecValidator:    peertrust.NewExecutableValidator(defaultClientPaths),
-		OnePasswordCheck: onePasswordDesktopIntegrationCheck(config.accountName),
+		OnePasswordCheck: onePasswordDesktopIntegrationCheck(),
 	})
 	if err != nil {
 		stderrf("agent-secretd: initialize server: %v\n", err)
@@ -82,8 +82,8 @@ func run() int {
 	return 0
 }
 
-func onePasswordDesktopIntegrationCheck(accountName string) func(context.Context) error {
-	return func(ctx context.Context) error {
+func onePasswordDesktopIntegrationCheck() func(context.Context, string) error {
+	return func(ctx context.Context, accountName string) error {
 		_, err := opresolver.NewDesktopResolver(ctx, opresolver.ClientOptions{
 			Account:            accountName,
 			IntegrationName:    "Agent Secret Doctor",
@@ -94,8 +94,7 @@ func onePasswordDesktopIntegrationCheck(accountName string) func(context.Context
 }
 
 type daemonConfig struct {
-	socketPath  string
-	accountName string
+	socketPath string
 }
 
 func parseDaemonConfig(args []string) (daemonConfig, error) {
@@ -108,12 +107,6 @@ func parseDaemonConfig(args []string) (daemonConfig, error) {
 	flags := flag.NewFlagSet("agent-secretd", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
 	flags.StringVar(&config.socketPath, "socket", socketPath, "daemon socket path")
-	flags.StringVar(
-		&config.accountName,
-		"account",
-		os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT"),
-		"1Password account sign-in address, name, or UUID; empty uses OP_ACCOUNT or my.1password.com",
-	)
 	if err := flags.Parse(args); err != nil {
 		return daemonConfig{}, err
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,7 +147,8 @@ Agent Secret chooses the account for each secret independently:
 3. Top-level `account`.
 4. CLI `--account`.
 5. `OP_ACCOUNT` or `AGENT_SECRET_1PASSWORD_ACCOUNT`.
-6. Built-in default `my.1password.com`.
+6. The single signed-in 1Password CLI account, when one can be detected.
+7. Built-in default `my.1password.com`.
 
 The account is part of the secret identity used for resolution, reusable
 approval matching, and in-memory caching. The same `op://` reference in two

--- a/docs/epic-2-spikes.md
+++ b/docs/epic-2-spikes.md
@@ -51,7 +51,8 @@ go test -tags integration ./...
 ```
 
 Set `OP_ACCOUNT` or `AGENT_SECRET_1PASSWORD_ACCOUNT` only when you want to force
-a specific 1Password account instead of `my.1password.com`.
+a specific 1Password account instead of the detected single signed-in
+1Password CLI account.
 
 The live test logs only value length and SHA-256 metadata. It does not print the
 secret value. On 2026-04-28, this passed against a test account after

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -761,10 +761,10 @@ Status: Complete
 - Added Swift socket client support for the approver app. Approval IPC now uses
   daemon socket messages instead of stdin/stdout, argv/env payloads, or temp
   files in the product path.
-- Wired `agent-secretd` to use the official 1Password SDK lazily after approval
-  with `my.1password.com` as the built-in default account, plus `OP_ACCOUNT`,
-  `AGENT_SECRET_1PASSWORD_ACCOUNT`, or `--account` as optional account
-  overrides, preserving approval-before-fetch ordering.
+- Wired `agent-secretd` to use the official 1Password SDK lazily after approval,
+  with explicit account overrides plus single-account 1Password CLI detection
+  before the `my.1password.com` fallback, preserving approval-before-fetch
+  ordering.
 - Added a redacted Swift approval view model showing reason, command, cwd,
   resolved binary, refs, time remaining, override warning, reusable-use limit,
   and memory-caching note without request IDs, nonces, or secret values.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -166,7 +166,7 @@ profiles:
 `account` is optional and may be set at the top level, profile level, or secret
 level. The precedence is per-secret `account`, then profile `account`, then
 top-level `account`, then `OP_ACCOUNT` / `AGENT_SECRET_1PASSWORD_ACCOUNT`, then
-`my.1password.com`.
+one detected signed-in 1Password CLI account, then `my.1password.com`.
 
 Profiles may include other profiles. Includes are resolved in order; later
 includes and the selected profile override earlier secrets with the same alias.

--- a/install.sh
+++ b/install.sh
@@ -439,7 +439,7 @@ echo "Installing Agent Secret skill"
 "$target_app/Contents/Resources/bin/agent-secret" skill-install --skills-dir "$skills_dir" --force
 
 echo "Running diagnostics"
-if ! "$bin_dir/agent-secret" doctor; then
+if ! PATH="$caller_path" "$bin_dir/agent-secret" doctor; then
   echo "agent-secret install: diagnostics reported issues; installation completed" >&2
   echo "agent-secret install: rerun $bin_dir/agent-secret doctor after fixing local setup" >&2
 fi

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/socket"
 	"github.com/kovyrin/agent-secret/internal/execwrap"
 	"github.com/kovyrin/agent-secret/internal/install"
+	"github.com/kovyrin/agent-secret/internal/opaccount"
 	"github.com/kovyrin/agent-secret/internal/randid"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
@@ -44,7 +45,7 @@ type daemonManager interface {
 	Status(ctx context.Context) (protocol.StatusPayload, error)
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
-	CheckOnePassword(ctx context.Context) error
+	CheckOnePassword(ctx context.Context, account string) error
 	SocketPath() string
 }
 
@@ -83,8 +84,8 @@ func (m daemonControlManager) Stop(ctx context.Context) error {
 	return m.manager.Stop(ctx)
 }
 
-func (m daemonControlManager) CheckOnePassword(ctx context.Context) error {
-	return m.manager.CheckOnePassword(ctx)
+func (m daemonControlManager) CheckOnePassword(ctx context.Context, account string) error {
+	return m.manager.CheckOnePassword(ctx, account)
 }
 
 func (m daemonControlManager) SocketPath() string {
@@ -326,7 +327,12 @@ func (a App) runDoctor(ctx context.Context) int {
 			a.stdoutln("native approver: ok")
 		}
 	}
-	if err := manager.CheckOnePassword(ctx); err != nil {
+	account := opaccount.SelectDesktopAccount(
+		os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT"),
+		os.Getenv("OP_ACCOUNT"),
+	)
+	a.stdoutf("1password account: %s\n", account)
+	if err := manager.CheckOnePassword(ctx, account); err != nil {
 		healthy = false
 		a.stdoutf("1password desktop integration: failed (%v)\n", err)
 	} else {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -43,6 +43,35 @@ func newTestAppWithDaemonManager(manager daemonManager, stdout io.Writer, stderr
 	return app
 }
 
+func runConfigProfileExec(
+	t *testing.T,
+	app App,
+	client *appFakeDaemonClient,
+	stdout *bytes.Buffer,
+	stderr *bytes.Buffer,
+) request.ExecRequest {
+	t.Helper()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := app.Run(context.Background(), []string{
+		"exec",
+		"--allow-mutable-executable",
+		"--",
+		os.Args[0], "-test.run=TestAppExecReReadsConfigAccountForRunningDaemon", "--", "child",
+	})
+	if code != 0 {
+		t.Fatalf("exec exit=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "env-ok" {
+		t.Fatalf("stdout = %q, want env-ok", stdout.String())
+	}
+	if len(client.requests) == 0 {
+		t.Fatal("fake daemon did not receive exec request")
+	}
+	return client.requests[len(client.requests)-1]
+}
+
 func TestAppExecRunsChildWithApprovedEnvAndPassthrough(t *testing.T) {
 	if os.Getenv("AGENT_SECRET_APP_EXEC_HELPER") == "1" {
 		runAppExecHelper()
@@ -127,6 +156,66 @@ func TestAppExecUsesManagerClientWithoutSocket(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "synthetic-secret-value") {
 		t.Fatalf("stderr leaked secret: %q", stderr.String())
+	}
+}
+
+func TestAppExecReReadsConfigAccountForRunningDaemon(t *testing.T) {
+	if os.Getenv("AGENT_SECRET_APP_EXEC_HELPER") == "1" {
+		runAppExecHelper()
+		return
+	}
+
+	root := t.TempDir()
+	t.Chdir(root)
+	writeExecutable(t, root, "unused-tool")
+	client := &appFakeDaemonClient{
+		execPayload: protocol.ExecResponsePayload{
+			Env:           map[string]string{"TOKEN": "synthetic-secret-value"},
+			SecretAliases: []string{"TOKEN"},
+		},
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(t.TempDir(), "d.sock"),
+		client:     client,
+		status:     protocol.StatusPayload{PID: 1234},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	t.Setenv("AGENT_SECRET_APP_EXEC_HELPER", "1")
+
+	writeProfileConfig(t, root, `
+version: 1
+default_profile: deploy
+profiles:
+  deploy:
+    account: First Account
+    reason: Run helper
+    secrets:
+      TOKEN: op://Example/Item/token
+`)
+	first := runConfigProfileExec(t, app, client, &stdout, &stderr)
+
+	writeProfileConfig(t, root, `
+version: 1
+default_profile: deploy
+profiles:
+  deploy:
+    account: Second Account
+    reason: Run helper
+    secrets:
+      TOKEN: op://Example/Item/token
+`)
+	second := runConfigProfileExec(t, app, client, &stdout, &stderr)
+
+	if first.Secrets[0].Account != "First Account" {
+		t.Fatalf("first request account = %q, want First Account", first.Secrets[0].Account)
+	}
+	if second.Secrets[0].Account != "Second Account" {
+		t.Fatalf("second request account = %q, want Second Account", second.Secrets[0].Account)
+	}
+	if manager.ensureCalls != 2 || manager.connectCalls != 2 {
+		t.Fatalf("manager calls: ensure=%d connect=%d, want 2 each", manager.ensureCalls, manager.connectCalls)
 	}
 }
 
@@ -243,6 +332,7 @@ func TestAppExecAllowsChildAfterDaemonStoppedStartedAudit(t *testing.T) {
 
 func TestAppDaemonStatusAndDoctor(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
 	client, cleanup := startAppTestServer(t, daemonbroker.Options{
 		Approver: &appApprover{decision: approval.Decision{Approved: true}},
 		Resolver: &appResolver{values: map[string]string{"op://Example/Item/token": "value"}},
@@ -307,11 +397,12 @@ func TestAppDaemonStatusReportsStoppedAfterRequestCancellation(t *testing.T) {
 
 func TestAppDoctorReportsFailureWithoutSecretValues(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
 	client, cleanup := startAppTestServer(t, daemonbroker.Options{
 		Approver: &appApprover{decision: approval.Decision{Approved: true}},
 		Resolver: &appResolver{values: map[string]string{"op://Example/Item/token": "synthetic-secret-value"}},
 		Audit:    &appAudit{},
-	}, func(context.Context) error {
+	}, func(context.Context, string) error {
 		return errors.New("desktop integration unavailable")
 	})
 	defer cleanup()
@@ -795,7 +886,7 @@ func (m *appFakeDaemonManager) Stop(context.Context) error {
 	return m.stopErr
 }
 
-func (m *appFakeDaemonManager) CheckOnePassword(context.Context) error {
+func (m *appFakeDaemonManager) CheckOnePassword(context.Context, string) error {
 	m.checkCalls++
 	return m.checkErr
 }
@@ -813,6 +904,7 @@ type appFakeDaemonClient struct {
 	closeErr           error
 
 	requestExecCalls   int
+	requests           []request.ExecRequest
 	closeCalls         int
 	startedPIDs        []int
 	completedExitCodes []int
@@ -826,9 +918,10 @@ func (c *appFakeDaemonClient) Close() error {
 func (c *appFakeDaemonClient) RequestExec(
 	_ context.Context,
 	_ protocol.Correlation,
-	_ request.ExecRequest,
+	req request.ExecRequest,
 ) (protocol.ExecResponsePayload, error) {
 	c.requestExecCalls++
+	c.requests = append(c.requests, req)
 	return c.execPayload, c.requestErr
 }
 
@@ -918,7 +1011,7 @@ func (appAllowPeer) Validate(_ *net.UnixConn) error {
 func startAppTestServer(
 	t *testing.T,
 	opts daemonbroker.Options,
-	onePasswordChecks ...func(context.Context) error,
+	onePasswordChecks ...func(context.Context, string) error,
 ) (appTestClient, func()) {
 	t.Helper()
 	dir, err := os.MkdirTemp("/tmp", "agent-secret-app-")
@@ -935,7 +1028,7 @@ func startAppTestServer(
 	if err != nil {
 		t.Fatalf("New returned error: %v", err)
 	}
-	onePasswordCheck := func(context.Context) error { return nil }
+	onePasswordCheck := func(context.Context, string) error { return nil }
 	if len(onePasswordChecks) > 0 {
 		onePasswordCheck = onePasswordChecks[0]
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -167,7 +167,7 @@ Safety rules:
   - Project configs can set account defaults at the file, profile, or secret level, and profiles may include other profiles.
   - --account sets a default 1Password account for CLI-provided refs when config does not already provide one.
   - ALIAS must look like an environment variable name, for example API_TOKEN.
-  - By default, the daemon uses the personal 1Password sign-in address my.1password.com. Set AGENT_SECRET_1PASSWORD_ACCOUNT only to override it.
+  - With no account override, agent-secret detects one signed-in 1Password CLI account before falling back to my.1password.com.
   - The wrapped command must appear after -- as argv. agent-secret does not parse shell strings.
   - Commands from current-user-writable files or directories are rejected unless --allow-mutable-executable is set.
   - exec has no --json mode and never prints secret values.
@@ -257,7 +257,8 @@ Project profiles:
 	  default_profile unless --profile is provided.
 	  CLI --reason and --ttl override profile defaults.
 	  Account precedence is per-secret account, profile account, top-level account,
-  --account, OP_ACCOUNT / AGENT_SECRET_1PASSWORD_ACCOUNT, then my.1password.com.
+  --account, OP_ACCOUNT / AGENT_SECRET_1PASSWORD_ACCOUNT, one detected signed-in
+  1Password CLI account, then my.1password.com.
   Included profiles are resolved in order. Later includes and the selected
   profile override earlier secrets with the same alias.
   1Password text file/document refs are resolved into the alias env value with
@@ -267,11 +268,12 @@ Project profiles:
 Environment:
 
   OP_ACCOUNT                      Optional 1Password account sign-in address, name, or UUID override.
-  AGENT_SECRET_1PASSWORD_ACCOUNT  Optional 1Password account sign-in address, name, or UUID override. Empty uses OP_ACCOUNT or my.1password.com.
+  AGENT_SECRET_1PASSWORD_ACCOUNT  Optional 1Password account sign-in address, name, or UUID override. Empty uses OP_ACCOUNT, then detection.
 
 Default account:
 
-  When no override is set, agent-secret asks 1Password Desktop for my.1password.com.
+  When no override is set, agent-secret uses the single signed-in 1Password CLI
+  account when one can be detected, then falls back to my.1password.com.
 
 Unsupported by design:
 
@@ -558,10 +560,7 @@ func execAccountFallback(cliAccount string) string {
 	if account := strings.TrimSpace(os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT")); account != "" {
 		return account
 	}
-	if account := strings.TrimSpace(os.Getenv("OP_ACCOUNT")); account != "" {
-		return account
-	}
-	return opaccount.DefaultDesktopAccount
+	return opaccount.SelectDesktopAccount("", os.Getenv("OP_ACCOUNT"))
 }
 
 func newOnlySet(aliases []string) map[string]struct{} {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -356,9 +356,21 @@ func TestParseExecAccountDefaultPrecedence(t *testing.T) {
 		name       string
 		opAccount  string
 		appAccount string
+		opScript   string
 		want       string
 	}{
 		{name: "built-in", want: opaccount.DefaultDesktopAccount},
+		{
+			name: "detected 1Password CLI account",
+			opScript: `
+if [ "$1" = "account" ] && [ "$2" = "list" ] && [ "$3" = "--format=json" ]; then
+  printf '%s\n' '[{"url":"my.1password.ca"}]'
+  exit 0
+fi
+exit 64
+`,
+			want: "my.1password.ca",
+		},
 		{name: "op account", opAccount: " Personal ", want: "Personal"},
 		{name: "app account", opAccount: " Personal ", appAccount: " Work ", want: "Work"},
 	}
@@ -370,6 +382,9 @@ func TestParseExecAccountDefaultPrecedence(t *testing.T) {
 				t.Fatalf("create bin dir: %v", err)
 			}
 			writeExecutable(t, binDir, "tool")
+			if tt.opScript != "" {
+				writeExecutableBody(t, binDir, "op", tt.opScript)
+			}
 			t.Chdir(root)
 			t.Setenv("PATH", binDir)
 			if tt.opAccount != "" {
@@ -933,8 +948,14 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 func writeExecutable(t *testing.T, dir string, name string) {
 	t.Helper()
 
+	writeExecutableBody(t, dir, name, "exit 0\n")
+}
+
+func writeExecutableBody(t *testing.T, dir string, name string, body string) {
+	t.Helper()
+
 	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: CLI parser tests need runnable fixture commands on PATH.
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil { //nolint:gosec // G306: CLI parser tests need runnable fixture commands on PATH.
 		t.Fatalf("write executable: %v", err)
 	}
 }

--- a/internal/daemon/control/client.go
+++ b/internal/daemon/control/client.go
@@ -113,8 +113,9 @@ func (c *Client) RequestStop(ctx context.Context) (protocol.StatusPayload, error
 	return payload, nil
 }
 
-func (c *Client) CheckOnePassword(ctx context.Context) error {
-	return roundTripAck(ctx, c, protocol.TypeOnePasswordStatus, protocol.Correlation{}, nil)
+func (c *Client) CheckOnePassword(ctx context.Context, account string) error {
+	payload := protocol.OnePasswordStatusPayload{Account: account}
+	return roundTripAck(ctx, c, protocol.TypeOnePasswordStatus, protocol.Correlation{}, payload)
 }
 
 func (c *Client) RequestExec(

--- a/internal/daemon/control/client_test.go
+++ b/internal/daemon/control/client_test.go
@@ -469,15 +469,19 @@ func TestClientCheckOnePasswordUsesDiagnosticsRequest(t *testing.T) {
 	})
 	defer cleanup()
 
-	if err := client.CheckOnePassword(context.Background()); err != nil {
+	if err := client.CheckOnePassword(context.Background(), "my.1password.ca"); err != nil {
 		t.Fatalf("CheckOnePassword returned error: %v", err)
 	}
 	env := receiveStalledRequest(t, requests)
 	if env.Type != protocol.TypeOnePasswordStatus {
 		t.Fatalf("request type = %s, want %s", env.Type, protocol.TypeOnePasswordStatus)
 	}
-	if len(env.Payload) != 0 {
-		t.Fatalf("onepassword status payload = %s, want empty", env.Payload)
+	payload, err := protocol.DecodeRequiredPayload[protocol.OnePasswordStatusPayload](env)
+	if err != nil {
+		t.Fatalf("decode onepassword status payload: %v", err)
+	}
+	if payload.Account != "my.1password.ca" {
+		t.Fatalf("onepassword status account = %q, want my.1password.ca", payload.Account)
 	}
 }
 

--- a/internal/daemon/control/manager.go
+++ b/internal/daemon/control/manager.go
@@ -144,13 +144,13 @@ func (m Manager) Stop(ctx context.Context) error {
 	return fmt.Errorf("%w: daemon still responds after stop", ErrDaemonStillRunning)
 }
 
-func (m Manager) CheckOnePassword(ctx context.Context) error {
+func (m Manager) CheckOnePassword(ctx context.Context, account string) error {
 	client, err := m.Connect(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = client.Close() }()
-	return client.CheckOnePassword(ctx)
+	return client.CheckOnePassword(ctx, account)
 }
 
 func (m Manager) Connect(ctx context.Context) (*Client, error) {

--- a/internal/daemon/control/manager_test.go
+++ b/internal/daemon/control/manager_test.go
@@ -227,7 +227,7 @@ func TestManagerControlMethodsReportMissingDaemon(t *testing.T) {
 	if _, err := manager.Status(context.Background()); !errors.Is(err, socket.ErrDaemonUnavailable) {
 		t.Fatalf("Status error = %v, want daemon unavailable", err)
 	}
-	if err := manager.CheckOnePassword(context.Background()); !errors.Is(err, socket.ErrDaemonUnavailable) {
+	if err := manager.CheckOnePassword(context.Background(), "my.1password.ca"); !errors.Is(err, socket.ErrDaemonUnavailable) {
 		t.Fatalf("CheckOnePassword error = %v, want daemon unavailable", err)
 	}
 	if err := manager.Stop(context.Background()); !errors.Is(err, socket.ErrDaemonUnavailable) {
@@ -486,47 +486,43 @@ func TestDaemonAppPathAndStartCommand(t *testing.T) {
 		t.Fatalf("mkdir daemon app: %v", err)
 	}
 	t.Setenv("AGENT_SECRET_DAEMON_APP_PATH", "/tmp/PoisonDaemon.app")
-	t.Setenv("OP_ACCOUNT", "DefaultFixture")
-	t.Setenv("AGENT_SECRET_1PASSWORD_ACCOUNT", "Fixture")
 	t.Setenv("AGENT_SECRET_APPROVER_PATH", "/tmp/PoisonApprover.app")
 
 	appPath, ok := daemonprocess.DefaultDaemonAppPath()
-	if runtime.GOOS == "darwin" {
-		if !ok || appPath != daemonAppPath {
-			t.Fatalf("default daemon app path = %q, %v", appPath, ok)
+	if runtime.GOOS != "darwin" {
+		if ok || appPath != "" {
+			t.Fatalf("non-darwin daemon app path = %q, %v", appPath, ok)
 		}
-		cmd := daemonprocess.StartCommand(context.Background(), appPath, []string{"--socket", "/tmp/d.sock"})
-		if cmd.Path != "/usr/bin/open" {
-			t.Fatalf("darwin app command path = %q, want /usr/bin/open", cmd.Path)
-		}
-		for _, want := range []string{
-			"-g",
-			"-n",
-			appPath,
-			"--env",
-			"OP_ACCOUNT=DefaultFixture",
-			"--env",
-			"AGENT_SECRET_1PASSWORD_ACCOUNT=Fixture",
-			"--args",
-			"--socket",
-			"/tmp/d.sock",
-		} {
-			if !slices.Contains(cmd.Args, want) {
-				t.Fatalf("darwin app command args %v missing %q", cmd.Args, want)
-			}
-		}
-		if slices.Contains(cmd.Args, "AGENT_SECRET_APPROVER_PATH=/tmp/PoisonApprover.app") {
-			t.Fatalf("darwin app command args forwarded poisoned approver path: %v", cmd.Args)
+		cmd := daemonprocess.StartCommand(context.Background(), "/tmp/agent-secretd", []string{"--socket", "/tmp/d.sock"})
+		if cmd.Path != "/tmp/agent-secretd" {
+			t.Fatalf("daemon command path = %q, want direct binary", cmd.Path)
 		}
 		return
 	}
-
-	if ok || appPath != "" {
-		t.Fatalf("non-darwin daemon app path = %q, %v", appPath, ok)
+	if !ok || appPath != daemonAppPath {
+		t.Fatalf("default daemon app path = %q, %v", appPath, ok)
 	}
-	cmd := daemonprocess.StartCommand(context.Background(), "/tmp/agent-secretd", []string{"--socket", "/tmp/d.sock"})
-	if cmd.Path != "/tmp/agent-secretd" {
-		t.Fatalf("daemon command path = %q, want direct binary", cmd.Path)
+	cmd := daemonprocess.StartCommand(context.Background(), appPath, []string{"--socket", "/tmp/d.sock"})
+	if cmd.Path != "/usr/bin/open" {
+		t.Fatalf("darwin app command path = %q, want /usr/bin/open", cmd.Path)
+	}
+	for _, want := range []string{
+		"-g",
+		"-n",
+		appPath,
+		"--args",
+		"--socket",
+		"/tmp/d.sock",
+	} {
+		if !slices.Contains(cmd.Args, want) {
+			t.Fatalf("darwin app command args %v missing %q", cmd.Args, want)
+		}
+	}
+	if slices.Contains(cmd.Args, "AGENT_SECRET_APPROVER_PATH=/tmp/PoisonApprover.app") {
+		t.Fatalf("darwin app command args forwarded poisoned approver path: %v", cmd.Args)
+	}
+	if slices.Contains(cmd.Args, "--env") {
+		t.Fatalf("darwin app command args forwarded environment: %v", cmd.Args)
 	}
 }
 

--- a/internal/daemon/process/process_unix.go
+++ b/internal/daemon/process/process_unix.go
@@ -20,9 +20,6 @@ func ConfigureDaemonProcess(cmd *exec.Cmd) {
 func StartCommand(ctx context.Context, path string, args []string) *exec.Cmd {
 	if runtime.GOOS == "darwin" && filepath.Ext(path) == ".app" {
 		openArgs := []string{"-g", "-n", path}
-		for _, env := range daemonAppEnvironment() {
-			openArgs = append(openArgs, "--env", env)
-		}
 		openArgs = append(openArgs, "--args")
 		openArgs = append(openArgs, args...)
 		//nolint:gosec // G204: open path is fixed; app path comes from control.NewManager defaults or explicit test Manager setup.
@@ -94,18 +91,4 @@ func daemonAppPathForExecutable(executable string) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-func daemonAppEnvironment() []string {
-	names := []string{
-		"OP_ACCOUNT",
-		"AGENT_SECRET_1PASSWORD_ACCOUNT",
-	}
-	env := make([]string, 0, len(names))
-	for _, name := range names {
-		if value, ok := os.LookupEnv(name); ok {
-			env = append(env, name+"="+value)
-		}
-	}
-	return env
 }

--- a/internal/daemon/process/process_unix_test.go
+++ b/internal/daemon/process/process_unix_test.go
@@ -42,8 +42,6 @@ func TestDaemonStartCommandUsesOpenForDarwinApp(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("darwin app launch is only used on macOS")
 	}
-	t.Setenv("OP_ACCOUNT", "DefaultFixture")
-	t.Setenv("AGENT_SECRET_1PASSWORD_ACCOUNT", "Fixture")
 
 	cmd := StartCommand(context.Background(), "/Applications/Agent Secret.app", []string{"--socket", "/tmp/d.sock"})
 	if cmd.Path != "/usr/bin/open" {
@@ -54,10 +52,6 @@ func TestDaemonStartCommandUsesOpenForDarwinApp(t *testing.T) {
 		"-g",
 		"-n",
 		"/Applications/Agent Secret.app",
-		"--env",
-		"OP_ACCOUNT=DefaultFixture",
-		"--env",
-		"AGENT_SECRET_1PASSWORD_ACCOUNT=Fixture",
 		"--args",
 		"--socket",
 		"/tmp/d.sock",
@@ -78,27 +72,6 @@ func TestDefaultDaemonPathReturnsDaemonCandidate(t *testing.T) {
 	case "agent-secretd", "AgentSecretDaemon.app":
 	default:
 		t.Fatalf("DefaultDaemonPath = %q, want daemon binary or app candidate", path)
-	}
-}
-
-func TestDaemonAppEnvironmentForwardsOnlyAccountSettings(t *testing.T) {
-	t.Setenv("OP_ACCOUNT", "DefaultFixture")
-	t.Setenv("AGENT_SECRET_1PASSWORD_ACCOUNT", "Fixture")
-	t.Setenv("AGENT_SECRET_APPROVER_PATH", "/tmp/PoisonApprover.app")
-
-	env := daemonAppEnvironment()
-	for _, want := range []string{
-		"OP_ACCOUNT=DefaultFixture",
-		"AGENT_SECRET_1PASSWORD_ACCOUNT=Fixture",
-	} {
-		if !slices.Contains(env, want) {
-			t.Fatalf("env = %q, want %q", env, want)
-		}
-	}
-	for _, entry := range env {
-		if entry == "AGENT_SECRET_APPROVER_PATH="+os.Getenv("AGENT_SECRET_APPROVER_PATH") {
-			t.Fatalf("env forwarded approver override: %q", env)
-		}
 	}
 }
 

--- a/internal/daemon/protocol/protocol.go
+++ b/internal/daemon/protocol/protocol.go
@@ -104,6 +104,10 @@ type StatusPayload struct {
 	PID int `json:"pid"`
 }
 
+type OnePasswordStatusPayload struct {
+	Account string `json:"account"`
+}
+
 func NewEnvelope(messageType MessageType, correlation Correlation, payload any) (Envelope, error) {
 	raw, err := marshalPayload(payload)
 	if err != nil {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/peertrust"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 	"github.com/kovyrin/agent-secret/internal/daemon/socket"
+	"github.com/kovyrin/agent-secret/internal/opresolver"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
@@ -48,7 +50,7 @@ type Server struct {
 	approvals               approval.ApprovalEndpoint
 	validator               PeerValidator
 	execValidator           peertrust.ExecValidator
-	onePasswordCheck        func(context.Context) error
+	onePasswordCheck        func(context.Context, string) error
 	maxFrameBytes           int64
 	readTimeout             time.Duration
 	now                     func() time.Time
@@ -64,7 +66,7 @@ type ServerOptions struct {
 	Approvals               approval.ApprovalEndpoint
 	Validator               PeerValidator
 	ExecValidator           peertrust.ExecValidator
-	OnePasswordCheck        func(context.Context) error
+	OnePasswordCheck        func(context.Context, string) error
 	MaxFrameBytes           int64
 	ReadTimeout             time.Duration
 	now                     func() time.Time
@@ -150,7 +152,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 	}
 	onePasswordCheck := opts.OnePasswordCheck
 	if onePasswordCheck == nil {
-		onePasswordCheck = func(context.Context) error { return ErrOnePasswordCheckUnavailable }
+		onePasswordCheck = func(context.Context, string) error { return ErrOnePasswordCheckUnavailable }
 	}
 	maxFrameBytes := opts.MaxFrameBytes
 	if maxFrameBytes <= 0 {
@@ -333,7 +335,16 @@ func (s *Server) handleStatusRequest(ctx context.Context, encoder *json.Encoder,
 		_ = writeOK(encoder, env.Correlation(), protocol.StatusPayload{PID: os.Getpid()})
 		return
 	}
-	if err := s.onePasswordCheck(ctx); err != nil {
+	payload, err := protocol.DecodeRequiredPayload[protocol.OnePasswordStatusPayload](env)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, err)
+		return
+	}
+	if strings.TrimSpace(payload.Account) == "" {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, opresolver.ErrAccountRequired)
+		return
+	}
+	if err := s.onePasswordCheck(ctx, payload.Account); err != nil {
 		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeResolveFailed, err)
 		return
 	}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -743,15 +743,20 @@ func TestServerOnePasswordStatusUsesInjectedCheck(t *testing.T) {
 	peer := peerInfoForTest(t, os.Getpid(), currentExecutable(t))
 	checkErr := errors.New("desktop integration unavailable")
 	checkCalls := 0
+	var checkedAccount string
 	server, err := NewServer(ServerOptions{
 		Broker: newTestBroker(t, daemonbroker.Options{
 			Approver: &mockApprover{decision: approval.Decision{Approved: true}},
 			Resolver: &mockResolver{values: map[string]string{"op://Example/Item/token": "value"}},
 			Audit:    &memoryAudit{},
 		}),
-		Validator:        staticPeerValidator{info: peer},
-		ExecValidator:    peertrust.NewExecutableValidator([]string{peer.ExecutablePath}),
-		OnePasswordCheck: func(context.Context) error { checkCalls++; return checkErr },
+		Validator:     staticPeerValidator{info: peer},
+		ExecValidator: peertrust.NewExecutableValidator([]string{peer.ExecutablePath}),
+		OnePasswordCheck: func(_ context.Context, account string) error {
+			checkCalls++
+			checkedAccount = account
+			return checkErr
+		},
 	})
 	if err != nil {
 		t.Fatalf("NewServer returned error: %v", err)
@@ -775,12 +780,15 @@ func TestServerOnePasswordStatusUsesInjectedCheck(t *testing.T) {
 
 	client := control.NewClient(clientConn)
 	defer func() { _ = client.Close() }()
-	err = client.CheckOnePassword(context.Background())
+	err = client.CheckOnePassword(context.Background(), "my.1password.ca")
 	if !control.IsProtocolError(err, protocol.ErrorCodeResolveFailed) {
 		t.Fatalf("CheckOnePassword error = %v, want resolve_failed", err)
 	}
 	if checkCalls != 1 {
 		t.Fatalf("one password check calls = %d, want 1", checkCalls)
+	}
+	if checkedAccount != "my.1password.ca" {
+		t.Fatalf("one password check account = %q, want my.1password.ca", checkedAccount)
 	}
 }
 

--- a/internal/opaccount/account.go
+++ b/internal/opaccount/account.go
@@ -1,8 +1,21 @@
 package opaccount
 
-import "strings"
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"time"
+)
 
 const DefaultDesktopAccount = "my.1password.com"
+
+type cliAccount struct {
+	URL         string `json:"url"`
+	Name        string `json:"name"`
+	Shorthand   string `json:"shorthand"`
+	AccountUUID string `json:"account_uuid"`
+}
 
 func SelectDesktopAccount(accountOverride string, opAccount string) string {
 	if account := strings.TrimSpace(accountOverride); account != "" {
@@ -11,5 +24,88 @@ func SelectDesktopAccount(accountOverride string, opAccount string) string {
 	if account := strings.TrimSpace(opAccount); account != "" {
 		return account
 	}
+	if account := detectSingleCLIAccount(); account != "" {
+		return account
+	}
 	return DefaultDesktopAccount
+}
+
+func detectSingleCLIAccount() string {
+	opPath, err := exec.LookPath("op")
+	if err != nil {
+		return ""
+	}
+	if account := detectSingleCLIAccountJSON(opPath); account != "" {
+		return account
+	}
+	return detectSingleCLIAccountTable(opPath)
+}
+
+func detectSingleCLIAccountJSON(opPath string) string {
+	output, err := runOPAccountList(opPath, "--format=json")
+	if err != nil {
+		return ""
+	}
+	var accounts []cliAccount
+	if err := json.Unmarshal(output, &accounts); err != nil {
+		return ""
+	}
+
+	return singleAccountName(accounts, func(account cliAccount) string {
+		for _, candidate := range []string{account.URL, account.Name, account.Shorthand, account.AccountUUID} {
+			if value := strings.TrimSpace(candidate); value != "" {
+				return value
+			}
+		}
+		return ""
+	})
+}
+
+func detectSingleCLIAccountTable(opPath string) string {
+	output, err := runOPAccountList(opPath)
+	if err != nil {
+		return ""
+	}
+
+	var accounts []string
+	for line := range strings.SplitSeq(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "URL ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		accounts = append(accounts, fields[0])
+	}
+	if len(accounts) != 1 {
+		return ""
+	}
+	return accounts[0]
+}
+
+func singleAccountName[T any](accounts []T, name func(T) string) string {
+	var selected string
+	count := 0
+	for _, account := range accounts {
+		candidate := strings.TrimSpace(name(account))
+		if candidate == "" {
+			continue
+		}
+		selected = candidate
+		count++
+	}
+	if count != 1 {
+		return ""
+	}
+	return selected
+}
+
+func runOPAccountList(opPath string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	commandArgs := append([]string{"account", "list"}, args...)
+	return exec.CommandContext(ctx, opPath, commandArgs...).Output() //nolint:gosec // G204: opPath is the user's 1Password CLI and this command reads only account metadata.
 }

--- a/internal/opaccount/account_test.go
+++ b/internal/opaccount/account_test.go
@@ -1,10 +1,12 @@
 package opaccount
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestSelectDesktopAccountPrecedence(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name            string
 		accountOverride string
@@ -30,12 +32,72 @@ func TestSelectDesktopAccountPrecedence(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			t.Setenv("PATH", t.TempDir())
 
 			got := SelectDesktopAccount(tt.accountOverride, tt.opAccount)
 			if got != tt.want {
 				t.Fatalf("account = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSelectDesktopAccountDetectsSingleJSONAccount(t *testing.T) {
+	writeFakeOP(t, `
+if [ "$1" = "account" ] && [ "$2" = "list" ] && [ "$3" = "--format=json" ]; then
+  printf '%s\n' '[{"url":"my.1password.ca","email":"testing-user1@example.test"}]'
+  exit 0
+fi
+exit 64
+`)
+
+	got := SelectDesktopAccount("", "")
+	if got != "my.1password.ca" {
+		t.Fatalf("account = %q, want detected account", got)
+	}
+}
+
+func TestSelectDesktopAccountDetectsSingleTableAccount(t *testing.T) {
+	writeFakeOP(t, `
+if [ "$1" = "account" ] && [ "$2" = "list" ] && [ "$3" = "--format=json" ]; then
+  exit 64
+fi
+if [ "$1" = "account" ] && [ "$2" = "list" ]; then
+  printf '%s\n' 'URL                EMAIL                             USER ID'
+  printf '%s\n' 'my.1password.ca    testing-user1@example.test       4POXGBG34RAQBMLPYCV42CSF4M'
+  exit 0
+fi
+exit 64
+`)
+
+	got := SelectDesktopAccount("", "")
+	if got != "my.1password.ca" {
+		t.Fatalf("account = %q, want detected account", got)
+	}
+}
+
+func TestSelectDesktopAccountFallsBackWhenCLIDetectionIsAmbiguous(t *testing.T) {
+	writeFakeOP(t, `
+if [ "$1" = "account" ] && [ "$2" = "list" ] && [ "$3" = "--format=json" ]; then
+  printf '%s\n' '[{"url":"my.1password.com"},{"url":"my.1password.ca"}]'
+  exit 0
+fi
+exit 64
+`)
+
+	got := SelectDesktopAccount("", "")
+	if got != DefaultDesktopAccount {
+		t.Fatalf("account = %q, want default account", got)
+	}
+}
+
+func writeFakeOP(t *testing.T, body string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	path := filepath.Join(binDir, "op")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil { //nolint:gosec // G306: account-selection tests need a runnable fake 1Password CLI.
+		t.Fatalf("write fake op: %v", err)
 	}
 }

--- a/internal/opresolver/pool.go
+++ b/internal/opresolver/pool.go
@@ -2,6 +2,7 @@ package opresolver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -10,10 +11,11 @@ import (
 
 const DefaultDesktopPoolInitTimeout = 30 * time.Second
 
+var ErrAccountRequired = errors.New("1Password account is required")
+
 type DesktopResolverFactory func(context.Context, ClientOptions) (*Resolver, error)
 
 type DesktopPoolOptions struct {
-	Account            string
 	IntegrationName    string
 	IntegrationVersion string
 	InitTimeout        time.Duration
@@ -22,7 +24,6 @@ type DesktopPoolOptions struct {
 
 type DesktopPool struct {
 	mu                 sync.Mutex
-	account            string
 	integrationName    string
 	integrationVersion string
 	initTimeout        time.Duration
@@ -42,8 +43,8 @@ type desktopPoolInit struct {
 	err      error
 }
 
-func NewDesktopPool(account string) *DesktopPool {
-	return NewDesktopPoolWithOptions(DesktopPoolOptions{Account: account})
+func NewDesktopPool() *DesktopPool {
+	return NewDesktopPoolWithOptions(DesktopPoolOptions{})
 }
 
 func NewDesktopPoolWithOptions(opts DesktopPoolOptions) *DesktopPool {
@@ -56,7 +57,6 @@ func NewDesktopPoolWithOptions(opts DesktopPoolOptions) *DesktopPool {
 		factory = NewDesktopResolver
 	}
 	return &DesktopPool{
-		account:            strings.TrimSpace(opts.Account),
 		integrationName:    strings.TrimSpace(opts.IntegrationName),
 		integrationVersion: strings.TrimSpace(opts.IntegrationVersion),
 		initTimeout:        initTimeout,
@@ -67,6 +67,10 @@ func NewDesktopPoolWithOptions(opts DesktopPoolOptions) *DesktopPool {
 }
 
 func (p *DesktopPool) Resolve(ctx context.Context, ref string, account string) (string, error) {
+	account = strings.TrimSpace(account)
+	if account == "" {
+		return "", ErrAccountRequired
+	}
 	resolver, err := p.client(ctx, account)
 	if err != nil {
 		return "", fmt.Errorf("create 1Password resolver: %w", err)
@@ -79,7 +83,10 @@ func (p *DesktopPool) Resolve(ctx context.Context, ref string, account string) (
 }
 
 func (p *DesktopPool) client(ctx context.Context, accountOverride string) (*Resolver, error) {
-	account := p.effectiveAccount(accountOverride)
+	account := strings.TrimSpace(accountOverride)
+	if account == "" {
+		return nil, ErrAccountRequired
+	}
 	resolver, init, owner := p.startClientInit(account)
 	if resolver != nil {
 		return resolver, nil
@@ -168,11 +175,4 @@ func waitForDesktopPoolInit(ctx context.Context, init *desktopPoolInit) (*Resolv
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
-}
-
-func (p *DesktopPool) effectiveAccount(accountOverride string) string {
-	if account := strings.TrimSpace(accountOverride); account != "" {
-		return account
-	}
-	return p.account
 }

--- a/internal/opresolver/pool_test.go
+++ b/internal/opresolver/pool_test.go
@@ -10,24 +10,13 @@ import (
 	"time"
 )
 
-func TestNewDesktopPoolUsesDesktopResolverWithoutAccountOverride(t *testing.T) {
+func TestDesktopPoolResolveRequiresRequestAccount(t *testing.T) {
 	t.Parallel()
 
-	pool := NewDesktopPool(" \t ")
-	if pool.account != "" {
-		t.Fatalf("account = %q, want resolver-level default account", pool.account)
-	}
-}
-
-func TestDesktopPoolEffectiveAccountUsesPerSecretOverride(t *testing.T) {
-	t.Parallel()
-
-	pool := NewDesktopPool("Fixture")
-	if account := pool.effectiveAccount(" Preview "); account != "Preview" {
-		t.Fatalf("account = %q, want Preview", account)
-	}
-	if account := pool.effectiveAccount(" \t "); account != "Fixture" {
-		t.Fatalf("account = %q, want Fixture", account)
+	pool := NewDesktopPool()
+	_, err := pool.Resolve(context.Background(), "op://Example Vault/Item/password", " \t ")
+	if !errors.Is(err, ErrAccountRequired) {
+		t.Fatalf("Resolve error = %v, want ErrAccountRequired", err)
 	}
 }
 
@@ -128,7 +117,6 @@ func TestDesktopPoolResolveReturnsSecretValue(t *testing.T) {
 	fake := &fakeSecretsAPI{value: "synthetic-secret-value"}
 	var gotOptions ClientOptions
 	pool := NewDesktopPoolWithOptions(DesktopPoolOptions{
-		Account:            "default-account",
 		IntegrationName:    "test integration",
 		IntegrationVersion: "test version",
 		Factory: func(_ context.Context, opts ClientOptions) (*Resolver, error) {

--- a/internal/opresolver/resolver_test.go
+++ b/internal/opresolver/resolver_test.go
@@ -179,6 +179,8 @@ func TestDesktopAccountUsesOPAccountEnvironment(t *testing.T) {
 }
 
 func TestDesktopAccountUsesSDKDefaultWhenUnset(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
 	account := opaccount.SelectDesktopAccount("", "")
 	if account != opaccount.DefaultDesktopAccount {
 		t.Fatalf("account = %q, want default account", account)

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -23,9 +23,10 @@ Environment:
   AGENT_SECRET_INSTALL_BIN_DIR  Default command symlink directory.
   AGENT_SECRET_INSTALL_APP_DIR  Default app install directory.
 
-By default agent-secret uses my.1password.com unless OP_ACCOUNT,
-AGENT_SECRET_1PASSWORD_ACCOUNT, --account, or project config chooses a
-different account.
+By default agent-secret uses the single signed-in 1Password CLI account when it
+can detect one, then falls back to my.1password.com. OP_ACCOUNT,
+AGENT_SECRET_1PASSWORD_ACCOUNT, --account, or project config can choose a
+specific account.
 USAGE
 }
 


### PR DESCRIPTION
## Summary

- bind the effective 1Password account into each exec request instead of daemon startup state
- auto-detect a single signed-in 1Password CLI account before falling back to my.1password.com
- make doctor diagnostics pass an explicit account and let the installer run doctor with the caller PATH

## Validation

- npx --yes markdownlint-cli CHANGELOG.md README.md docs/configuration.md docs/epic-2-spikes.md docs/implementation-plan.md docs/prd.md .agents/skills/agent-secret/SKILL.md
- mise run lint
- mise run build