### PR TITLE
Prepare v0.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
-## [0.0.6] - Pending
+## [0.0.6] - 2026-05-04
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

- mark the v0.0.6 changelog section as released for today's tag

## Validation

- npx --yes markdownlint-cli CHANGELOG.md