### PR TITLE
Restart daemon after app upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ version numbers for public releases.
 
 - The daemon now retires when the installed daemon executable is replaced, and
   `agent-secret exec` retries once so the command uses the upgraded daemon.
+- The daemon now refreshes a cached 1Password desktop SDK client after a stale
+  client reports that no vault matched an otherwise valid approved ref.
 - The daemon now keeps the owning 1Password SDK client alive for cached desktop
   resolvers, preventing later `invalid client id` failures.
 - `agent-secret doctor` now reports and checks the 1Password account from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ version numbers for public releases.
 
 ### Fixed
 
+- The daemon now retires when the installed daemon executable is replaced, and
+  `agent-secret exec` retries once so the command uses the upgraded daemon.
 - The daemon now keeps the owning 1Password SDK client alive for cached desktop
   resolvers, preventing later `invalid client id` failures.
 - `agent-secret doctor` now reports and checks the 1Password account from the

--- a/cmd/agent-secretd/main.go
+++ b/cmd/agent-secretd/main.go
@@ -65,11 +65,17 @@ func run() int {
 		stderrf("agent-secretd: discover trusted clients: %v\n", err)
 		return 1
 	}
+	selfCheck, err := daemon.CurrentExecutableSelfCheck()
+	if err != nil {
+		stderrf("agent-secretd: initialize executable self-check: %v\n", err)
+		return 1
+	}
 	server, err := daemon.NewServer(daemon.ServerOptions{
 		Broker:           broker,
 		Approvals:        approver,
 		ExecValidator:    peertrust.NewExecutableValidator(defaultClientPaths),
 		OnePasswordCheck: onePasswordDesktopIntegrationCheck(),
+		SelfCheck:        selfCheck,
 	})
 	if err != nil {
 		stderrf("agent-secretd: initialize server: %v\n", err)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -181,13 +181,6 @@ func (a App) runExec(ctx context.Context, command Command) int {
 		a.stderrf("agent-secret: start daemon: %v\n", err)
 		return 1
 	}
-	client, err := manager.Connect(ctx)
-	if err != nil {
-		a.stderrf("agent-secret: connect daemon: %v\n", err)
-		return 1
-	}
-	defer func() { _ = client.Close() }()
-
 	requestID, err := a.randomID("req")
 	if err != nil {
 		a.stderrf("agent-secret: generate request id: %v\n", err)
@@ -199,11 +192,12 @@ func (a App) runExec(ctx context.Context, command Command) int {
 		return 1
 	}
 	correlation := protocol.Correlation{RequestID: requestID, Nonce: nonce}
-	payload, err := client.RequestExec(ctx, correlation, command.ExecRequest)
+	client, payload, err := a.requestExec(ctx, manager, correlation, command.ExecRequest)
 	if err != nil {
-		a.stderrf("agent-secret: request rejected: %v\n", err)
+		a.stderrf("agent-secret: %v\n", err)
 		return 1
 	}
+	defer func() { _ = client.Close() }()
 
 	interrupts := make(chan os.Signal, 2)
 	signal.Notify(interrupts, os.Interrupt, syscall.SIGTERM)
@@ -231,6 +225,41 @@ func (a App) runExec(ctx context.Context, command Command) int {
 		return 1
 	}
 	return result.ExitCode
+}
+
+func (a App) requestExec(
+	ctx context.Context,
+	manager daemonManager,
+	correlation protocol.Correlation,
+	req request.ExecRequest,
+) (daemonClient, protocol.ExecResponsePayload, error) {
+	client, err := manager.Connect(ctx)
+	if err != nil {
+		return nil, protocol.ExecResponsePayload{}, fmt.Errorf("connect daemon: %w", err)
+	}
+	payload, err := client.RequestExec(ctx, correlation, req)
+	if err == nil {
+		return client, payload, nil
+	}
+	if !control.IsProtocolError(err, protocol.ErrorCodeDaemonStopped) {
+		_ = client.Close()
+		return nil, protocol.ExecResponsePayload{}, fmt.Errorf("request rejected: %w", err)
+	}
+	_ = client.Close()
+
+	if err := manager.EnsureRunning(ctx); err != nil {
+		return nil, protocol.ExecResponsePayload{}, fmt.Errorf("start daemon after upgrade: %w", err)
+	}
+	client, err = manager.Connect(ctx)
+	if err != nil {
+		return nil, protocol.ExecResponsePayload{}, fmt.Errorf("connect daemon after upgrade: %w", err)
+	}
+	payload, err = client.RequestExec(ctx, correlation, req)
+	if err != nil {
+		_ = client.Close()
+		return nil, protocol.ExecResponsePayload{}, fmt.Errorf("request rejected: %w", err)
+	}
+	return client, payload, nil
 }
 
 func (a App) runDaemonStatus(ctx context.Context) int {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -156,6 +156,61 @@ func TestAppExecUsesManagerClientWithoutSocket(t *testing.T) {
 	}
 }
 
+func TestAppExecRetriesOnceWhenDaemonRetiresBeforeSpawn(t *testing.T) {
+	if os.Getenv("AGENT_SECRET_APP_EXEC_HELPER") == "1" {
+		runAppExecHelper()
+		return
+	}
+
+	retiredClient := &appFakeDaemonClient{
+		requestErr: &control.ProtocolError{Code: protocol.ErrorCodeDaemonStopped, Message: "daemon stopped"},
+	}
+	freshClient := &appFakeDaemonClient{
+		execPayload: protocol.ExecResponsePayload{
+			Env:           map[string]string{"TOKEN": "synthetic-secret-value"},
+			SecretAliases: []string{"TOKEN"},
+		},
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(t.TempDir(), "d.sock"),
+		clients:    []daemonClient{retiredClient, freshClient},
+		status:     protocol.StatusPayload{PID: 1234},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	t.Setenv("AGENT_SECRET_APP_EXEC_HELPER", "1")
+
+	code := app.Run(context.Background(), []string{
+		"exec",
+		"--reason", "Run helper",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--",
+		os.Args[0], "-test.run=TestAppExecRetriesOnceWhenDaemonRetiresBeforeSpawn", "--", "child",
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "env-ok" {
+		t.Fatalf("stdout = %q, want env-ok", stdout.String())
+	}
+	if manager.ensureCalls != 2 || manager.connectCalls != 2 {
+		t.Fatalf("manager calls: ensure=%d connect=%d, want 2 each", manager.ensureCalls, manager.connectCalls)
+	}
+	if retiredClient.requestExecCalls != 1 || retiredClient.closeCalls != 1 {
+		t.Fatalf("retired client calls: request=%d close=%d", retiredClient.requestExecCalls, retiredClient.closeCalls)
+	}
+	if freshClient.requestExecCalls != 1 || freshClient.closeCalls != 1 {
+		t.Fatalf("fresh client calls: request=%d close=%d", freshClient.requestExecCalls, freshClient.closeCalls)
+	}
+	if len(freshClient.startedPIDs) != 1 || len(freshClient.completedExitCodes) != 1 {
+		t.Fatalf("fresh client audit calls: started=%v completed=%v", freshClient.startedPIDs, freshClient.completedExitCodes)
+	}
+	if strings.Contains(stderr.String(), "request rejected") {
+		t.Fatalf("stderr reported pre-retry rejection: %q", stderr.String())
+	}
+}
+
 func TestAppExecReReadsConfigAccountForRunningDaemon(t *testing.T) {
 	if os.Getenv("AGENT_SECRET_APP_EXEC_HELPER") == "1" {
 		runAppExecHelper()
@@ -865,6 +920,7 @@ type appTestClient struct {
 type appFakeDaemonManager struct {
 	socketPath string
 	client     daemonClient
+	clients    []daemonClient
 	status     protocol.StatusPayload
 
 	ensureErr  error
@@ -893,6 +949,11 @@ func (m *appFakeDaemonManager) Connect(context.Context) (daemonClient, error) {
 	m.connectCalls++
 	if m.connectErr != nil {
 		return nil, m.connectErr
+	}
+	if len(m.clients) > 0 {
+		client := m.clients[0]
+		m.clients = m.clients[1:]
+		return client, nil
 	}
 	if m.client == nil {
 		return nil, errors.New("fake daemon client missing")

--- a/internal/daemon/broker/broker.go
+++ b/internal/daemon/broker/broker.go
@@ -115,6 +115,12 @@ func (b *Broker) Now() time.Time {
 	return b.now()
 }
 
+func (b *Broker) ActiveCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.active)
+}
+
 func (b *Broker) HandleExecDelivery(
 	ctx context.Context,
 	correlation protocol.Correlation,

--- a/internal/daemon/control/manager.go
+++ b/internal/daemon/control/manager.go
@@ -49,6 +49,10 @@ func NewManager(socketPath string) (Manager, error) {
 func (m Manager) EnsureRunning(ctx context.Context) error {
 	if err := m.statusBeforeStart(ctx); err == nil {
 		return nil
+	} else if isRetiringDaemon(err) {
+		if err := m.waitUntilUnavailable(ctx, 25*time.Millisecond); err != nil {
+			return err
+		}
 	} else if !errors.Is(err, socket.ErrDaemonUnavailable) {
 		return err
 	}
@@ -61,6 +65,10 @@ func (m Manager) EnsureRunning(ctx context.Context) error {
 func (m Manager) Start(ctx context.Context) error {
 	if err := m.statusBeforeStart(ctx); err == nil {
 		return nil
+	} else if isRetiringDaemon(err) {
+		if err := m.waitUntilUnavailable(ctx, 25*time.Millisecond); err != nil {
+			return err
+		}
 	} else if !errors.Is(err, socket.ErrDaemonUnavailable) {
 		return err
 	}
@@ -198,6 +206,40 @@ func (m Manager) waitUntilReady(ctx context.Context, interval time.Duration) err
 	}
 }
 
+func (m Manager) waitUntilUnavailable(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		interval = 25 * time.Millisecond
+	}
+	timeout := m.StartupTimeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		unavailable, err := m.statusUnavailable(waitCtx)
+		if err != nil {
+			return err
+		}
+		if unavailable {
+			return nil
+		}
+		select {
+		case <-waitCtx.Done():
+			ctxErr := waitCtx.Err()
+			if cause := context.Cause(waitCtx); cause != nil && !errors.Is(cause, ctxErr) {
+				ctxErr = errors.Join(ctxErr, cause)
+			}
+			return fmt.Errorf("%w: retiring daemon still responds: %w", ErrDaemonStillRunning, ctxErr)
+		case <-ticker.C:
+		}
+	}
+}
+
 func (m Manager) trustedDaemonPaths() ([]string, error) {
 	daemonPath := m.DaemonPath
 	if daemonPath == "" {
@@ -225,7 +267,14 @@ func (m Manager) statusUnavailable(ctx context.Context) (bool, error) {
 	if errors.Is(err, socket.ErrDaemonUnavailable) || errors.Is(err, io.EOF) {
 		return true, nil
 	}
+	if isRetiringDaemon(err) {
+		return false, nil
+	}
 	return false, err
+}
+
+func isRetiringDaemon(err error) bool {
+	return IsProtocolError(err, protocol.ErrorCodeDaemonStopped)
 }
 
 func (m Manager) daemonArgs() []string {

--- a/internal/daemon/control/manager_test.go
+++ b/internal/daemon/control/manager_test.go
@@ -251,6 +251,16 @@ func TestManagerWaitUntilReadyPreservesStartupDeadline(t *testing.T) {
 	}
 }
 
+func TestManagerWaitUntilUnavailableReturnsForMissingSocket(t *testing.T) {
+	t.Parallel()
+
+	manager := Manager{SocketPath: filepath.Join(t.TempDir(), "missing.sock")}
+
+	if err := manager.waitUntilUnavailable(context.Background(), 0); err != nil {
+		t.Fatalf("waitUntilUnavailable returned error: %v", err)
+	}
+}
+
 func TestManagerStartRequiresDaemonPathAfterSocketPreparation(t *testing.T) {
 	t.Parallel()
 
@@ -288,6 +298,25 @@ func TestManagerStatusUnavailableReturnsOtherStatusErrors(t *testing.T) {
 	}
 	if !errors.Is(err, peertrust.ErrUntrustedDaemon) {
 		t.Fatalf("statusUnavailable error = %v, want %v", err, peertrust.ErrUntrustedDaemon)
+	}
+}
+
+func TestManagerStatusUnavailableTreatsRetiringDaemonAsStillRunning(t *testing.T) {
+	t.Parallel()
+
+	path, stop := startFakeStatusErrorDaemon(t, protocol.ErrorCodeDaemonStopped)
+	defer stop()
+	manager := Manager{
+		SocketPath: path,
+		DaemonPath: os.Args[0],
+	}
+
+	unavailable, err := manager.statusUnavailable(context.Background())
+	if err != nil {
+		t.Fatalf("statusUnavailable returned error: %v", err)
+	}
+	if unavailable {
+		t.Fatal("statusUnavailable = true for retiring daemon, want false until socket disappears")
 	}
 }
 
@@ -552,6 +581,54 @@ func startFakeExecDaemon(t *testing.T) (string, func()) {
 		_ = listener.Close()
 		<-done
 		_ = os.RemoveAll(dir)
+	}
+}
+
+func startFakeStatusErrorDaemon(t *testing.T, code protocol.ErrorCode) (string, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "agent-secret-fake-status-daemon-")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	path := filepath.Join(dir, "d.sock")
+	listener, err := socket.ListenUnix(path)
+	unixsocket.SkipIfBindUnavailable(t, err)
+	if err != nil {
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		serveFakeStatusError(conn, code)
+	}()
+	return path, func() {
+		_ = listener.Close()
+		<-done
+		_ = os.RemoveAll(dir)
+	}
+}
+
+func serveFakeStatusError(conn *net.UnixConn, code protocol.ErrorCode) {
+	decoder := json.NewDecoder(conn)
+	encoder := json.NewEncoder(conn)
+	var env protocol.Envelope
+	if err := decoder.Decode(&env); err != nil {
+		return
+	}
+	resp, err := protocol.NewEnvelope(protocol.TypeError, env.Correlation(), protocol.ErrorPayload{
+		Code:    code,
+		Message: "daemon stopped",
+	})
+	if err != nil {
+		return
+	}
+	if err := encoder.Encode(resp); err != nil {
+		return
 	}
 }
 

--- a/internal/daemon/selfcheck.go
+++ b/internal/daemon/selfcheck.go
@@ -1,0 +1,39 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
+)
+
+var ErrExecutableChanged = errors.New("daemon executable changed on disk")
+
+func CurrentExecutableSelfCheck() (func() error, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve daemon executable: %w", err)
+	}
+	identity, err := fileidentity.Capture(path)
+	if err != nil {
+		return nil, fmt.Errorf("capture daemon executable identity: %w", err)
+	}
+	return NewExecutableSelfCheck(path, identity), nil
+}
+
+func NewExecutableSelfCheck(path string, expected fileidentity.Identity) func() error {
+	return func() error {
+		if expected.IsZero() {
+			return fmt.Errorf("%w: startup executable identity is missing", ErrExecutableChanged)
+		}
+		actual, err := fileidentity.Capture(path)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrExecutableChanged, err)
+		}
+		if actual != expected {
+			return fmt.Errorf("%w: executable %q no longer matches startup identity", ErrExecutableChanged, path)
+		}
+		return nil
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -51,12 +51,15 @@ type Server struct {
 	validator               PeerValidator
 	execValidator           peertrust.ExecValidator
 	onePasswordCheck        func(context.Context, string) error
+	selfCheck               func() error
 	maxFrameBytes           int64
 	readTimeout             time.Duration
 	now                     func() time.Time
 	beforeRead              func(time.Duration)
 	beforeExecResponseWrite func()
 	listenUnix              func(string) (unixListener, error)
+	retireMu                sync.Mutex
+	retireAfterActive       bool
 	stopOnce                sync.Once
 	stop                    chan struct{}
 }
@@ -67,6 +70,7 @@ type ServerOptions struct {
 	Validator               PeerValidator
 	ExecValidator           peertrust.ExecValidator
 	OnePasswordCheck        func(context.Context, string) error
+	SelfCheck               func() error
 	MaxFrameBytes           int64
 	ReadTimeout             time.Duration
 	now                     func() time.Time
@@ -172,6 +176,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		validator:               validator,
 		execValidator:           execValidator,
 		onePasswordCheck:        onePasswordCheck,
+		selfCheck:               opts.SelfCheck,
 		maxFrameBytes:           maxFrameBytes,
 		readTimeout:             readTimeout,
 		now:                     now,
@@ -236,6 +241,56 @@ func (s *Server) stopWithAudit(ctx context.Context, event audit.Event) {
 	s.stopOnce.Do(func() { close(s.stop) })
 }
 
+func (s *Server) retireIfExecutableChanged(ctx context.Context, encoder *json.Encoder, env protocol.Envelope) bool {
+	if s.selfCheck == nil || s.stopped() || !checksExecutableIdentity(env.Type) {
+		return false
+	}
+	if err := s.selfCheck(); err == nil {
+		return false
+	} else {
+		s.markRetireAfterActive()
+		if s.broker.ActiveCount() == 0 {
+			s.stopForExecutableChange(ctx)
+		}
+		stoppedErr := fmt.Errorf("%w: %w", daemonbroker.ErrDaemonStopped, err)
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeDaemonStopped, stoppedErr)
+		return true
+	}
+}
+
+func checksExecutableIdentity(messageType protocol.MessageType) bool {
+	//nolint:exhaustive // Only new foreground work should trigger daemon executable self-checks.
+	switch messageType {
+	case protocol.TypeDaemonStatus, protocol.TypeOnePasswordStatus, protocol.TypeRequestExec:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Server) markRetireAfterActive() {
+	s.retireMu.Lock()
+	defer s.retireMu.Unlock()
+	s.retireAfterActive = true
+}
+
+func (s *Server) stopIfRetiredAndIdle(ctx context.Context) {
+	s.retireMu.Lock()
+	retire := s.retireAfterActive
+	s.retireMu.Unlock()
+	if !retire || s.stopped() || s.broker.ActiveCount() != 0 {
+		return
+	}
+	s.stopForExecutableChange(ctx)
+}
+
+func (s *Server) stopForExecutableChange(ctx context.Context) {
+	s.stopWithAudit(ctx, audit.Event{
+		Type:      audit.EventDaemonStop,
+		ErrorCode: audit.ErrorCode(protocol.ErrorCodeDaemonStopped),
+	})
+}
+
 func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 	defer func() { _ = conn.Close() }()
 	if err := s.validator.Validate(conn); err != nil {
@@ -251,6 +306,7 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 		if err != nil {
 			if requestID := state.disconnectRequestID(); requestID != "" {
 				s.broker.ClientDisconnected(ctx, requestID)
+				s.stopIfRetiredAndIdle(ctx)
 			}
 			if errors.Is(err, protocol.ErrProtocolFrameSize) {
 				_ = writeErrorEncoder(encoder, protocol.Correlation{}, protocol.ErrorCodeFrameTooLarge, err)
@@ -262,6 +318,9 @@ func (s *Server) handleConn(ctx context.Context, conn *net.UnixConn) {
 		if err := protocol.ValidateEnvelope(env); err != nil {
 			_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadEnvelope, err)
 			continue
+		}
+		if s.retireIfExecutableChanged(ctx, encoder, env) {
+			return
 		}
 		if s.stopped() && env.Type != protocol.TypeDaemonStatus {
 			_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(daemonbroker.ErrDaemonStopped), daemonbroker.ErrDaemonStopped)
@@ -521,6 +580,7 @@ func (s *Server) handleCommandCompleted(
 		return false
 	}
 	_ = writeOK(encoder, env.Correlation(), nil)
+	s.stopIfRetiredAndIdle(ctx)
 	return true
 }
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -846,6 +846,44 @@ func TestServerRejectsExecOnExistingConnectionAfterStop(t *testing.T) {
 	}
 }
 
+func TestServerRetiresWhenExecutableSelfCheckFailsBeforeExec(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	resolver := &mockResolver{values: map[string]string{ref: "value"}}
+	aud := &memoryAudit{}
+	conn, stop := startRawServerConnWithOptions(t, ServerOptions{
+		Broker: newTestBroker(t, daemonbroker.Options{
+			Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+			Resolver: resolver,
+			Audit:    aud,
+		}),
+		Validator: staticPeerValidator{info: peerInfoForTest(t, os.Getpid(), currentExecutable(t))},
+		SelfCheck: func() error { return ErrExecutableChanged },
+	})
+	defer stop()
+
+	client := control.NewClient(conn)
+	defer func() { _ = client.Close() }()
+
+	_, err := client.RequestExec(context.Background(), testCorrelation("req_1", "nonce_1"), testExecRequest(t, []request.SecretSpec{
+		{Alias: "TOKEN", Ref: ref},
+	}))
+	if !control.IsProtocolError(err, protocol.ErrorCodeDaemonStopped) {
+		t.Fatalf("RequestExec error = %v, want daemon_stopped", err)
+	}
+	if calls := resolver.Calls(); len(calls) != 0 {
+		t.Fatalf("resolver called after executable self-check failure: %v", calls)
+	}
+	events := aud.Events()
+	if len(events) != 1 || events[0].Type != audit.EventDaemonStop {
+		t.Fatalf("audit events = %+v, want daemon_stop", events)
+	}
+	if events[0].ErrorCode != audit.ErrorCode(protocol.ErrorCodeDaemonStopped) {
+		t.Fatalf("daemon stop error code = %q, want daemon_stopped", events[0].ErrorCode)
+	}
+}
+
 func TestServerServeStopsWhenServerStops(t *testing.T) {
 	t.Parallel()
 

--- a/internal/opresolver/integration_test.go
+++ b/internal/opresolver/integration_test.go
@@ -38,6 +38,29 @@ func TestLiveDesktopResolveSecret(t *testing.T) {
 	t.Logf("resolved 1Password reference metadata: length=%d sha256=%s", metadata.Length, metadata.SHA256)
 }
 
+func TestLiveDesktopPoolResolveSecret(t *testing.T) {
+	ref := os.Getenv("AGENT_SECRET_LIVE_REF")
+	account := os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT")
+	if ref == "" {
+		t.Skip("set AGENT_SECRET_LIVE_REF to run live 1Password SDK pool test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	pool := NewDesktopPoolWithOptions(DesktopPoolOptions{
+		IntegrationName:    "Agent Secret Broker SDK Pool Spike",
+		IntegrationVersion: "dev",
+	})
+	value, err := pool.Resolve(ctx, ref, account)
+	if err != nil {
+		t.Fatalf("resolve live reference through pool: %v", err)
+	}
+
+	metadata := Secret{value: value}.Metadata()
+	t.Logf("resolved 1Password reference metadata through pool: length=%d sha256=%s", metadata.Length, metadata.SHA256)
+}
+
 func TestLiveDesktopResolveSecretTextFileReference(t *testing.T) {
 	ref := os.Getenv("AGENT_SECRET_LIVE_TEXT_FILE_REF")
 	account := os.Getenv("AGENT_SECRET_1PASSWORD_ACCOUNT")

--- a/internal/opresolver/pool.go
+++ b/internal/opresolver/pool.go
@@ -108,9 +108,12 @@ func (p *DesktopPool) resolveWithRefreshedClient(
 }
 
 func shouldRefreshDesktopClient(err error) bool {
-	return err != nil &&
-		!errors.Is(err, ErrInvalidReference) &&
-		strings.Contains(strings.ToLower(err.Error()), "invalid client id")
+	if err == nil || errors.Is(err, ErrInvalidReference) {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "invalid client id") ||
+		strings.Contains(message, "no vault matched the secret reference query")
 }
 
 func (p *DesktopPool) client(ctx context.Context, accountOverride string) (*Resolver, error) {

--- a/internal/opresolver/pool_test.go
+++ b/internal/opresolver/pool_test.go
@@ -180,6 +180,32 @@ func TestDesktopPoolRefreshesClientAfterInvalidClientID(t *testing.T) {
 	}
 }
 
+func TestDesktopPoolRefreshesClientAfterVaultNotFound(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	pool := testDesktopPoolWithFactory(func(_ context.Context, opts ClientOptions) (*Resolver, error) {
+		if opts.Account != "fixture.1password.com" {
+			return nil, fmt.Errorf("account = %q, want fixture.1password.com", opts.Account)
+		}
+		if calls.Add(1) == 1 {
+			return NewResolver(&fakeSecretsAPI{err: errors.New("no vault matched the secret reference query")})
+		}
+		return NewResolver(&fakeSecretsAPI{value: "fresh-secret-value"})
+	})
+
+	value, err := pool.Resolve(context.Background(), "op://Fixture Infra/PlanetScale/token", "fixture.1password.com")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if value != "fresh-secret-value" {
+		t.Fatalf("value = %q, want fresh-secret-value", value)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("factory calls = %d, want stale client plus refresh", got)
+	}
+}
+
 func TestDesktopPoolDoesNotRefreshClientForInvalidReference(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- capture the daemon executable identity at startup and retire the daemon when the installed binary changes
- treat `daemon_stopped` as a retirement signal in the control manager and wait for the socket to disappear before restart
- retry `agent-secret exec` once when the daemon retires before child spawn
- refresh a cached 1Password desktop SDK client once when it reports `no vault matched` for an approved ref

## Validation
- `npx --yes markdownlint-cli CHANGELOG.md`
- `mise exec -- go test ./internal/daemon ./internal/daemon/control ./internal/cli`
- `mise exec -- go test ./internal/opresolver`
- `AGENT_SECRET_1PASSWORD_ACCOUNT=fixture.1password.com AGENT_SECRET_LIVE_REF=... mise exec -- go test -tags=integration ./internal/opresolver -run TestLiveDesktopPoolResolveSecret -count=1 -v`
- `agent-secret exec --profile planetscale-query-report -- /usr/bin/true`
- `mise run planetscale:query-report -- --database control-plane --max-findings 3`
- `mise run test`
- `mise run lint`
- `mise run build`