### PR TITLE
Prepare public release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,19 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
-## [0.0.7] - Pending
+## [0.0.7] - 2026-05-05
+
+### Added
+
+- Added public release security policy, contribution stance, and a dated
+  security-boundary review for the current macOS release candidate.
 
 ### Changed
 
 - `agent-secret exec` no longer rejects current-user-writable developer tools
   such as mise-installed commands before approval.
+- The README now states the current support boundaries and limitations for the
+  initial macOS Apple Silicon release.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+Agent Secret is not accepting broad external code contributions yet. The project
+is still pre-1.0 and the trusted surface is intentionally narrow while the local
+macOS release path settles.
+
+Useful contributions at this stage:
+
+- Bug reports with exact versions, commands, and non-secret logs.
+- Documentation corrections that do not expand the support promise.
+- Security reports through the private process in `SECURITY.md`.
+- Reproduction notes for clean macOS install, upgrade, uninstall, or 1Password
+  Desktop authorization behavior.
+
+Please do not send drive-by feature PRs, platform ports, new secret backends,
+session APIs, credential helpers, or installer integrations without prior
+discussion. Those areas can change the security model and release scope.
+
+## Development Setup
+
+Use `mise` as the project toolchain entrypoint:
+
+```bash
+mise run setup
+```
+
+Default checks:
+
+```bash
+mise run lint
+mise run build
+```
+
+Focused checks:
+
+```bash
+mise format
+mise run lint:go
+mise run lint:swift
+mise run lint:shell
+mise run lint:toml
+mise run lint:secrets
+mise run lint:vuln
+mise run test
+mise run test:race
+mise run test:coverage
+mise run test:smoke
+```
+
+Live 1Password integration tests are opt-in. Use test-only refs and never print
+resolved values.
+
+## Pull Request Expectations
+
+If a PR is discussed and accepted before implementation:
+
+- Keep the change focused.
+- Update `CHANGELOG.md` for user-facing behavior, release-process changes, and
+  security-relevant fixes.
+- Update docs when support boundaries, commands, install behavior, or threat
+  model assumptions change.
+- Add fast unit tests before implementation when behavior changes.
+- Do not commit raw secret values, real credential fixtures, private 1Password
+  item metadata, or local signing material.
+
+For Markdown changes, run:
+
+```bash
+npx --yes markdownlint-cli <path>
+```

--- a/README.md
+++ b/README.md
@@ -11,17 +11,37 @@ This repository is designed as a standalone open-source project.
 
 ## Status
 
-Planning scaffold, research spikes, Epic 3 core Go packages, the Epic 4
-CLI/daemon/exec path, and the Epic 5 native approver socket integration are in
-place. The macOS app bundle, development installer, local DMG builder,
-unattended install/uninstall scripts, and optional release signing hooks are in
-place on the distribution PR.
+Agent Secret is in a macOS Apple Silicon release-candidate stage. The shipped
+surface is the local app bundle, `agent-secret exec`, the per-user daemon,
+native approval UI, project profiles, env-file migration path, install and
+uninstall scripts, bundled coding-agent skill, and signed/notarized GitHub
+Release artifacts.
+
+The current public release target is intentionally narrow. Agent Secret is not
+yet a cross-platform secret manager, background updater, session-handle service,
+or general credential-helper framework.
+
+## Current Support Boundaries
+
+- macOS only.
+- Apple Silicon release artifacts only.
+- 1Password is the only secret backend.
+- The only shipped secret delivery mode is CLI-supervised `agent-secret exec`
+  with environment injection.
+- Session handles, `with-session`, credential helpers, file-descriptor delivery,
+  and socket value reads are not shipped.
+- Linux and Windows are not supported.
+- There is no automatic updater. Upgrade by installing a newer release over the
+  existing app.
 
 ## Current Documents
 
 - [Changelog](CHANGELOG.md)
+- [Security Policy](SECURITY.md)
+- [Contributing](CONTRIBUTING.md)
 - [Product Requirements](docs/prd.md)
 - [Threat Model](docs/threat-model.md)
+- [Public Release Security Boundary Review](docs/security-boundary-review-2026-05-05.md)
 - [Implementation Plan](docs/implementation-plan.md)
 - [Configuration Reference](docs/configuration.md)
 - [macOS Distribution Plan](docs/macos-distribution-plan.md)
@@ -208,7 +228,7 @@ Unattended install and upgrade use the same script. Pin the bootstrap script to
 the same immutable release tag as `AGENT_SECRET_VERSION`:
 
 ```bash
-version="v0.3.1"
+version="v0.0.7"
 base_url="https://raw.githubusercontent.com/kovyrin/agent-secret"
 curl -fsSL "$base_url/${version}/install.sh" |
   AGENT_SECRET_VERSION="$version" sh
@@ -231,7 +251,7 @@ curl -fsSL "$base_url/${version}/install.sh" |
 Useful installer environment variables:
 
 ```bash
-AGENT_SECRET_VERSION=v0.3.1
+AGENT_SECRET_VERSION=v0.0.7
 AGENT_SECRET_APP_DIR="$HOME/Applications"
 AGENT_SECRET_BIN_DIR="$HOME/.local/bin"
 AGENT_SECRET_SKILLS_DIR="$HOME/.agents/skills"
@@ -250,7 +270,7 @@ development mode with local files:
 
 ```bash
 AGENT_SECRET_INSTALL_DEV_MODE=1 \
-AGENT_SECRET_DMG=./dist/Agent-Secret-v0.3.1-macos-arm64.dmg \
+AGENT_SECRET_DMG=./dist/Agent-Secret-v0.0.7-macos-arm64.dmg \
 AGENT_SECRET_CHECKSUMS_FILE=./dist/checksums.txt \
 AGENT_SECRET_ALLOW_UNSIGNED_INSTALL=1 \
 ./install.sh
@@ -347,7 +367,7 @@ AGENT_SECRET_NOTARY_KEY="$(cat AuthKey_KEYID.p8)"
 AGENT_SECRET_NOTARY_KEY_ID=KEYID
 AGENT_SECRET_NOTARY_ISSUER_ID=ISSUER_UUID
 scripts/release/check-release-signing-env.sh
-AGENT_SECRET_IN_MISE=1 scripts/release/build-release.sh v0.3.1 --require-production-signing
+AGENT_SECRET_IN_MISE=1 scripts/release/build-release.sh v0.0.7 --require-production-signing
 ```
 
 `AGENT_SECRET_NOTARY_KEY` may also point at a local `.p8` file. Notarization is
@@ -553,6 +573,20 @@ Agent Secret is designed to keep raw secret values away from coding agents while
 still letting a human approve narrowly scoped commands. It is a local broker, not
 a sandbox. The approved child process receives the secret and can use, print, or
 forward it like any other process environment value.
+
+### Limitations
+
+- Agent Secret does not protect against root, the kernel, a compromised
+  1Password app, or a fully compromised macOS user session.
+- Same-UID local processes are in scope for specific trust-boundary checks, but
+  Agent Secret is not a sandbox for all activity by the logged-in user.
+- Approved child processes receive raw secrets by design through their
+  environment and can leak them after launch.
+- Audit logs contain metadata such as command argv, cwd, reason, aliases,
+  `op://` refs, accounts, timing, decisions, and child status. They do not
+  contain raw secret values.
+- Live 1Password integration tests are opt-in and must use test-only refs. They
+  may trigger 1Password Desktop authorization prompts.
 
 ### Trusted Components
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# Security Policy
+
+## Supported Versions
+
+Agent Secret is pre-1.0 software. Until the first stable release, security fixes
+target the latest published release and current `main`.
+
+The supported runtime scope is narrow:
+
+- macOS on Apple Silicon.
+- 1Password Desktop integration through the official 1Password SDK.
+- CLI-supervised `agent-secret exec` with environment injection.
+
+Linux, Windows, session handles, credential helpers, automatic updates, and
+alternative secret backends are not supported security surfaces yet.
+
+## Reporting A Vulnerability
+
+Use GitHub private vulnerability reporting:
+
+<https://github.com/kovyrin/agent-secret/security/advisories/new>
+
+Do not open a public issue with exploit details, raw secret values, private
+vault names, real `op://` refs, credentials, crash dumps that may contain
+environment variables, or screenshots that reveal sensitive metadata.
+
+If private vulnerability reporting is unavailable, open a minimal public issue
+that says you have a security report and need a private contact path. Include no
+technical details beyond the affected component.
+
+## What To Include
+
+Useful reports include:
+
+- Affected version, commit, or release tag.
+- macOS version and hardware architecture.
+- Whether the build was a signed release, local dev build, or custom artifact.
+- The trust boundary involved, using `docs/threat-model.md` when possible.
+- Reproduction steps using synthetic refs or test-only 1Password items.
+- Expected impact, especially whether raw secret values can be fetched,
+  delivered, logged, persisted, or sent to the wrong process.
+
+## Response Expectations
+
+There is no guaranteed SLA before 1.0. The expected maintainer flow is:
+
+1. Acknowledge the report after it is seen.
+2. Triage whether it is inside the supported threat model.
+3. Prepare a fix, mitigation, or documentation correction.
+4. Release and document the fix when the issue affects a published release.
+
+Reports outside the current scope may still be useful, but they may be treated
+as hardening or roadmap work instead of release-blocking vulnerabilities.
+
+## Security Scope
+
+Agent Secret is a local approval and execution broker. It is not a sandbox.
+
+In scope:
+
+- Same-UID processes crossing a documented socket, executable identity, install,
+  release artifact, audit, approval, or secret-delivery boundary.
+- Fetching a secret before local approval.
+- Delivering a secret outside the displayed command, cwd, account, or ref scope.
+- Logging, printing, or persisting raw secret values.
+- Accepting release artifacts from the wrong signer, bundle ID, or notarization
+  state.
+
+Out of scope:
+
+- Root, kernel, hypervisor, physical-access, or fully compromised user-session
+  attackers.
+- A malicious approved child process after the operator intentionally delivered
+  secrets to it.
+- 1Password Desktop or the official 1Password SDK returning the wrong value.
+- Downstream tools leaking secrets after receiving approved environment
+  variables.
+
+See `docs/threat-model.md` for the review contract used by this repository.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -29,15 +29,16 @@ Source: [Product Requirements](prd.md)
 - Session mode and credential helpers come after the `exec` path is proven.
 - Live 1Password tests require explicit opt-in configuration and must not print
   values.
-- V1 is private dogfood first, with standalone structure and docs.
-- The first real dogfood workflows are Terraform and Ansible commands that need
+- V1 is a narrow macOS Apple Silicon release, with standalone structure and
+  public-facing docs.
+- The first real validation workflows are Terraform and Ansible commands that need
   scoped credentials.
 - A generic `op-secrets.yml`-style config-driven secret sync flow is a candidate
-  follow-on dogfood workflow.
+  follow-on validation workflow.
 - V1 `exec` accepts explicit `--secret ALIAS=op://...` mappings,
   project-local `agent-secret.yml` / `.agent-secret.yml` profiles including
   `default_profile`, and `--env-file` inputs. A broader `--secret-config` or
-  config-driven sync workflow remains a follow-on dogfood candidate.
+  config-driven sync workflow remains a follow-on validation candidate.
 - Delivery is env-only `agent-secret exec`; session-handle delivery remains a
   future Epic 6 concern for tools or wrappers that cannot consume env vars
   cleanly.
@@ -180,8 +181,8 @@ Source: [Product Requirements](prd.md)
   project-local `--profile` support covers named ref bundles.
 - No reusable approval management commands in v1 beyond `agent-secret daemon
   stop`.
-- No public-release polish such as notarized installers, contribution process,
-  or broad support docs until the private dogfood loop works.
+- No broad platform support, long-term support promise, or contribution process
+  beyond the explicit pre-1.0 stance until the macOS release path is stable.
 
 ## Epic 1: Standalone Project Scaffold
 
@@ -981,22 +982,23 @@ Status: Not started
 - Failure modes fail closed with clear messages.
 - LaunchAgent and helper startup are documented or implemented.
 - Audit logs are inspectable directly as JSONL files without a CLI viewer.
-- Local run/install notes exist as convenience docs only, with no v1 trust-path
-  policy.
+- Local run/install notes distinguish development builds from signed public
+  release artifacts.
 
 ### Epic 7 Definition Of Done
 
 - `doctor` tests cover healthy and unhealthy local configurations.
 - A daily-use smoke checklist exists.
-- Codesigning and notarization are explicitly not required for private dogfood
-  and are documented as pre-public-distribution work.
+- Local development builds may be ad-hoc signed, while public release artifacts
+  require Developer ID signing, notarization, stapling, and verification.
 
 ### Epic 7 Risks And Mitigations
 
-- Risk: public distribution needs stronger binary identity than private dogfood.
-- Mitigation: defer signing/notarization and installation-integrity guidance to
-  the release path; `exec` rejects current-user-writable executable paths unless
-  the caller explicitly opts into mutable local executable launch.
+- Risk: public distribution needs stronger binary identity than local
+  development builds.
+- Mitigation: keep signing, notarization, Team ID, bundle ID, and installation
+  integrity checks in the release path; make approval display the resolved
+  command identity before any secret access.
 
 ### Epic 7 Tasks
 
@@ -1031,8 +1033,8 @@ Status: Not started
   examples use project-local paths.
 - Implementation:
   - document that v1 does not enforce or warn on binary install paths
-  - document that private dogfood does not require codesigning or notarization
-  - document codesigning/notarization expectations before wider distribution
+  - document that local development builds may be ad-hoc signed
+  - document codesigning/notarization expectations for public release artifacts
   - document standalone repository release checklist
 - Verification:
   - `npx --yes markdownlint-cli '**/*.md'`
@@ -1044,11 +1046,11 @@ Status: Not started
 - Epic 3 can start after the request fields from Epic 2 are confirmed.
 - Epic 4 depends on Epic 3 and can use fake approver and fake SDK interfaces.
 - Epic 5 can run in parallel with Epic 4 once approval fixtures are defined.
-- The first dogfood target is Epic 4 plus Epic 5: env-only `exec`, hidden daemon
+- The first validation target is Epic 4 plus Epic 5: env-only `exec`, hidden daemon
   startup, and reusable same-command approvals.
 - Epic 6 depends on the completed `exec`, daemon socket, native approval, and
   reusable approval paths. It should not block initial Terraform/Ansible
-  dogfood.
+  validation.
 - Epic 7 should follow the first working `exec` path, then broaden after session
   handles land.
 
@@ -1097,7 +1099,7 @@ Status: Not started
 
 The first three smokes should prove approval, fetch, env delivery, audit, and
 cleanup without intentional infrastructure mutation. Credential sync is a later
-dogfood step because it may write to a project-managed encrypted or managed
+validation step because it may write to a project-managed encrypted or managed
 secret store.
 
 ## Fixtures

--- a/docs/macos-distribution-plan.md
+++ b/docs/macos-distribution-plan.md
@@ -85,7 +85,7 @@ Agents and setup scripts pin the bootstrap script to the same immutable release
 tag as `AGENT_SECRET_VERSION`:
 
 ```bash
-version="v0.3.1"
+version="v0.0.7"
 base_url="https://raw.githubusercontent.com/kovyrin/agent-secret"
 curl -fsSL "$base_url/${version}/install.sh" |
   AGENT_SECRET_VERSION="$version" sh
@@ -107,7 +107,7 @@ The installer should:
 Useful installer options:
 
 ```bash
-AGENT_SECRET_VERSION=v0.3.1 install.sh
+AGENT_SECRET_VERSION=v0.0.7 install.sh
 AGENT_SECRET_APP_DIR="$HOME/Applications" install.sh
 AGENT_SECRET_BIN_DIR="$HOME/.local/bin" install.sh
 AGENT_SECRET_SKILLS_DIR="$HOME/.agents/skills" install.sh

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,6 +1,6 @@
 # Product Requirements: Agent Secret Broker
 
-Status: draft.
+Status: implementation-backed release-candidate contract.
 
 ## Summary
 
@@ -8,24 +8,25 @@ Agent Secret Broker is a local, macOS-first system for letting coding agents use
 1Password-backed secrets without making the agent a trusted secret holder. The
 agent requests exact secret references with a reason and a bounded policy. A
 local broker presents a native approval prompt, fetches approved secrets through
-the official 1Password SDK, and delivers them through constrained execution or
-short-lived capabilities.
+the official 1Password SDK, and delivers them through CLI-supervised execution.
+Short-lived capability modes remain future work.
 
 The first user is a local developer running coding agents such as Codex, Claude
 Code, Cursor agent, or similar tools. The first practical workflow is running
 local infrastructure commands, such as Terraform, that need credentials from
 1Password.
 
-## V1 Product Stance
+## Initial Product Stance
 
-V1 is a private dogfood tool first and a standalone project second. Success
-means the tool is safe and useful for real local agent workflows before it is
-polished for public distribution.
+The initial public release is a narrow macOS Apple Silicon tool for real local
+agent workflows. Success means the shipped `agent-secret exec` path is useful,
+auditable, and honest about its limits before the project expands into more
+platforms, secret backends, or delivery modes.
 
-Open-source readiness is a design constraint, not a release gate. The project
-should keep clean boundaries, avoid external runtime dependencies, and maintain
-honest docs, but it can defer public-package polish such as notarized installers,
-contributor docs, broad platform support, and long-term support promises.
+Open-source readiness is a release constraint. The project keeps clean
+boundaries, avoids external runtime dependencies, maintains honest docs, and
+ships signed/notarized release artifacts without promising broad platform
+support or long-term support before 1.0.
 
 When Go code is added, the module path should be
 `github.com/kovyrin/agent-secret`. That keeps imports, examples, and docs
@@ -56,8 +57,8 @@ policy and reuse keys but not shown in the approval prompt.
 - Never print secret values to the console or return them to the agent.
 - Support command execution through `agent-secret exec` as the default delivery
   mode.
-- Support short-lived sessions, opaque per-secret handles, and credential-helper
-  integrations after the `exec` path is proven.
+- Leave room for future short-lived sessions, opaque per-secret handles, and
+  credential-helper integrations without shipping them in the initial release.
 - Keep secret values in memory only by default.
 - Enforce TTL, requested refs, command, cwd, UID, strict macOS peer/process
   checks for session/socket reads, and max reads only for session/socket reads.
@@ -108,11 +109,11 @@ one-shot in-memory copies. If the user approved same-command reuse, the daemon
 keeps those values in memory only until the approval TTL or use limit is
 exhausted.
 
-The same v1 path should support Ansible commands that need environment-provided
+The same initial path should support Ansible commands that need environment-provided
 credentials, inventory access tokens, SSH-related variables, or cloud provider
-credentials. Terraform and Ansible are the first real dogfood workflows.
+credentials. Terraform and Ansible are representative validation workflows.
 
-### Use Case 2: Multi-Step Deployment Session
+### Future Use Case: Multi-Step Deployment Session
 
 An agent requests a short session for a bounded workflow such as:
 
@@ -126,6 +127,8 @@ The user approves once for a TTL. The broker returns a session ID or opaque
 handles, and subsequent commands must run through broker wrappers such as
 `agent-secret with-session`.
 
+This is not shipped in the initial public release.
+
 ### Use Case 3: Config-Driven Secret Sync
 
 Some local projects keep a checked-in mapping from logical credential keys to
@@ -133,7 +136,7 @@ Some local projects keep a checked-in mapping from logical credential keys to
 values into the project's own encrypted or managed secret store. The broker
 feature should stay generic and should not depend on any one consumer project.
 
-The first dogfood-ready config workflow is project-local profiles. A checked-in
+The first release-ready config workflow is project-local profiles. A checked-in
 `agent-secret.yml` file names reusable secret bundles while still storing only
 `op://` refs and metadata. If `default_profile` is set, the caller can omit
 `--profile` when no explicit `--secret` flags are provided:
@@ -560,9 +563,9 @@ Audit logs must never include:
 - 1Password item field values
 - child stdout or stderr
 
-For v1 private dogfood, audit logs store full `op://` refs so local debugging is
-straightforward. This records vault, item, and field names as metadata, but never
-secret values. Logs must be current-user-only by default.
+For the initial release, audit logs store full `op://` refs so local debugging
+is straightforward. This records vault, item, and field names as metadata, but
+never secret values. Logs must be current-user-only by default.
 V1 uses a fixed per-user macOS audit log at
 `~/Library/Logs/agent-secret/audit.jsonl` and does not accept a CLI audit-path
 override. The daemon owns audit path selection, creates directories/files with
@@ -606,7 +609,7 @@ process-supervision role.
 
 ### Delivery Sequence
 
-The dogfood sequence is:
+The validation sequence is:
 
 1. env-only `agent-secret exec`;
 2. ephemeral Unix socket reads for tools or wrappers that cannot consume
@@ -964,9 +967,9 @@ CLI path this tool is meant to replace.
 - Use public macOS APIs only.
 - Avoid private APIs and Accessibility-permission hacks.
 - Prefer a per-user LaunchAgent after the on-demand v1 works.
-- Private dogfood does not require codesigning or notarization. Build and run
-  locally first; signed binaries, notarization, and a hardened Swift app are
-  pre-public-distribution work.
+- Local development builds may be ad-hoc signed. Public release artifacts must
+  be Developer ID signed, notarized, stapled, and verified by the release
+  process.
 - Consider mutual identity checks between daemon and approver where practical.
 
 ## MVP Scope
@@ -1007,7 +1010,7 @@ MVP can defer:
 - AWS `credential_process`
 - SSH-agent-like mode
 - file descriptor mode
-- codesigning and notarization automation
+- broader release-channel automation beyond signed/notarized GitHub Releases
 - policy file system
 - team sharing
 - Linux support
@@ -1088,7 +1091,7 @@ Deliverables:
 
 Exit criteria:
 
-- The tool is safe enough for daily local use by one developer on macOS.
+- The tool is safe enough for daily local use on supported macOS systems.
 - Common failure modes fail closed with clear messages.
 
 ### Milestone 4: Credential Helpers
@@ -1158,7 +1161,7 @@ Exit criteria:
   denial, approval, and error events without secret values or environment
   payloads.
 
-### Session Mode Criteria
+### Future Session Mode Criteria
 
 - Session create returns handles only.
 - Handles cannot be resolved after TTL.
@@ -1209,12 +1212,13 @@ Exit criteria:
 - Default workflows never require console secret output.
 - Broker-generated logs contain zero secret values.
 - Approval appears before the 1Password prompt in normal flows.
-- Terraform and Ansible dogfood workflows work end to end through `exec`.
+- Terraform and Ansible-style validation workflows work end to end through
+  `exec`.
 - A config-driven secret sync workflow is either supported or explicitly
-  designed as the next dogfood target.
+  designed as a future target.
 - Session expiration and max-read tests pass reliably.
 
-Initial dogfood smokes should run in this order:
+Initial validation smokes should run in this order:
 
 1. `terraform plan`
 2. `ansible-playbook site.yml --check`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -134,6 +134,26 @@ lives in `AGENT_SECRET_IN_MISE=1 scripts/release/test-release-notes.sh`.
 
 12. Confirm the published release page shows the expected notes and assets.
 
+## Clean-Machine Release Candidate Drill
+
+Before public announcement, test the latest release candidate on a clean macOS
+user account or VM:
+
+1. Install through the human DMG flow by dragging `Agent Secret.app` into
+   `/Applications`.
+2. Open the app, install command-line tools, and run `agent-secret doctor`.
+3. Approve 1Password Desktop SDK authorization and run one test-only
+   `agent-secret exec` flow that does not print secret values.
+4. Install or upgrade through the pinned `install.sh` flow for the same tag.
+5. Confirm `agent-secret doctor`, `agent-secret skill-install`, and the bundled
+   skill symlink work after upgrade.
+6. Run the pinned `uninstall.sh` flow and confirm it removes the app, command
+   symlink, skill symlink, and support state while preserving audit logs by
+   default.
+
+Record evidence in the public release prep issue before treating the candidate
+as public-announcement ready.
+
 ## Signing Preconditions
 
 The tag-triggered release job needs these repository secrets configured:

--- a/docs/security-boundary-review-2026-05-05.md
+++ b/docs/security-boundary-review-2026-05-05.md
@@ -1,0 +1,171 @@
+# Public Release Security Boundary Review
+
+Review date: 2026-05-05.
+
+Review target: public-release preparation after `v0.0.7` release-candidate
+changes on `main`.
+
+Review contract: `docs/threat-model.md`.
+
+Conclusion: no unresolved release-blocking findings were identified in this
+review. The remaining public-release blocker is clean-machine install, upgrade,
+and uninstall evidence for the `v0.0.7` candidate.
+
+## Scope
+
+This review covered the shipped macOS Apple Silicon surface:
+
+- `agent-secret exec` with environment injection.
+- Per-user daemon socket.
+- Native macOS approval app.
+- 1Password Desktop SDK resolution after approval.
+- Reusable same-command approvals.
+- Metadata-only audit log.
+- Release DMG, install, and uninstall trust checks.
+
+This review did not cover unshipped session handles, `with-session`, credential
+helpers, Linux, Windows, automatic updates, or alternative secret backends.
+
+## Boundary Walk
+
+### CLI To Daemon Socket
+
+Status: pass.
+
+Evidence reviewed:
+
+- `internal/daemon/socket` enforces private socket directory expectations.
+- `internal/daemon/peertrust` and `internal/daemon/control` authenticate daemon
+  and CLI peers before secret-bearing responses or control operations.
+- Protocol envelopes carry version, request ID, nonce, and typed payloads.
+- Server tests cover peer validation, daemon retirement, disconnect behavior,
+  and malformed protocol paths.
+
+Residual risk:
+
+- A fully compromised user session remains out of scope. Same-UID processes are
+  handled only at the documented socket and executable identity boundaries.
+
+### Daemon To Native Approver
+
+Status: pass.
+
+Evidence reviewed:
+
+- The daemon launches the bundled app path and validates approver executable
+  identity.
+- The approver validates the daemon peer before rendering approval metadata.
+- Approval decisions include request ID and nonce.
+- Approval expiration is enforced by controller and daemon behavior, not only by
+  SwiftUI button state.
+- Daemon-supplied error text is sanitized before display.
+
+Residual risk:
+
+- The approval window uses public macOS foregrounding APIs. It is not a true
+  system-modal prompt, which is documented as out of scope.
+
+### Trusted Executable Identity
+
+Status: pass.
+
+Evidence reviewed:
+
+- Production wiring constructs explicit peer validators in `cmd/agent-secretd`.
+- File identity and signature checks live in focused trust packages with unit
+  tests.
+- The CLI verifies approved executable identity immediately before child spawn.
+- The daemon records its executable identity at startup and retires after the
+  installed daemon executable is replaced; `agent-secret exec` retries once when
+  retirement happens before child spawn.
+
+Residual risk:
+
+- The first upgrade from a pre-auto-retire daemon still needs one manual daemon
+  stop or process exit because old code cannot self-retire. Future upgrades use
+  the new daemon self-check path.
+
+### Symlink And Path Handling
+
+Status: pass.
+
+Evidence reviewed:
+
+- Request validation uses strict path resolution on trust paths.
+- Install and uninstall scripts refuse broad, relative, and symlinked custom
+  roots unless explicit custom-path opt-in is provided.
+- Uninstall verifies expected bundle identifiers and Developer ID Team ID before
+  removing app bundles unless explicit force flags are set.
+- Audit paths require private directories and regular files.
+
+Residual risk:
+
+- Local development mode intentionally allows unsigned local artifacts behind
+  explicit development flags. That path is not a production install promise.
+
+### Release Artifact Verification
+
+Status: pass.
+
+Evidence reviewed:
+
+- Tag-triggered releases require production signing and notarization inputs.
+- The installer verifies checksum, DMG signature, expected Team ID, Gatekeeper
+  assessment, notarization ticket, mounted app bundle ID, daemon bundle ID, and
+  bundled CLI signature before copying.
+- Release docs require local verification of DMG signature, Team ID, stapling,
+  Gatekeeper, `hdiutil verify`, mounted app identity, and draft release notes.
+- Production release trust roots are pinned to the expected repository, Team ID,
+  bundle IDs, notarization mode, and GitHub release host.
+
+Residual risk:
+
+- Public release readiness still needs one clean-machine human DMG and uninstall
+  drill for the exact `v0.0.7` candidate.
+
+### Audit Redaction And Fail-Closed Delivery
+
+Status: pass.
+
+Evidence reviewed:
+
+- Audit event types carry refs, aliases, accounts, commands, decisions, timing,
+  and child status, not raw secret values.
+- Audit tests reject accidental value-bearing fields.
+- Broker paths write required audit metadata before payload delivery; audit
+  failure before payload delivery blocks child execution.
+- Live verification prints only non-secret metadata such as length and hash.
+
+Residual risk:
+
+- `op://` refs, aliases, and account names are metadata but can still be
+  sensitive. This is documented in the threat model and README limitations.
+
+### Approval Expiry, Cancellation, Timeout, And Disconnect
+
+Status: pass.
+
+Evidence reviewed:
+
+- Approval expiration is enforced before display and at decision handling.
+- Pending approvals can time out without 1Password access.
+- Denial and timeout prevent secret fetch.
+- CLI disconnect before payload delivery fails closed.
+- Disconnect after child spawn is audited as best effort while the child exit
+  behavior remains under CLI supervision.
+- Reusable approval use accounting consumes a use only after payload delivery.
+
+Residual risk:
+
+- `exec` TTL bounds approval and spawn, not already-running child lifetime.
+  That is documented product behavior.
+
+## Release Readiness Notes
+
+Before public announcement:
+
+1. Cut and publish the `v0.0.7` candidate from current `main`.
+2. Run clean-machine human DMG install, unattended install/upgrade, and uninstall
+   checks against `v0.0.7`.
+3. Keep the `SECURITY.md`, `CONTRIBUTING.md`, README support boundaries, and
+   limitations aligned with the shipped surface.

--- a/scripts/checks/test-public-docs.sh
+++ b/scripts/checks/test-public-docs.sh
@@ -33,6 +33,18 @@ for term in "${private_terms[@]}"; do
   fi
 done
 
+stale_public_terms=(
+  "distribution PR"
+  "private dogfood"
+)
+
+for term in "${stale_public_terms[@]}"; do
+  matches="$(grep -n -F -- "$term" "${scan_files[@]}" || true)"
+  if [ -n "$matches" ]; then
+    fail "public docs contain stale release-readiness wording '$term': $matches"
+  fi
+done
+
 secret_print_examples=(
   "-- env"
   "-- printenv"


### PR DESCRIPTION
## Summary
- add `SECURITY.md` and a pre-1.0 contribution stance
- document the public release security-boundary review
- clarify README support boundaries, limitations, and shipped-vs-future product surface
- scrub stale dogfood/distribution wording and add the clean-machine RC drill
- date the `0.0.7` changelog section for release

## Validation
- `npx --yes markdownlint-cli README.md SECURITY.md CONTRIBUTING.md CHANGELOG.md docs/prd.md docs/implementation-plan.md docs/release-process.md docs/macos-distribution-plan.md docs/security-boundary-review-2026-05-05.md`
- `AGENT_SECRET_IN_MISE=1 scripts/checks/test-public-docs.sh`
- `AGENT_SECRET_IN_MISE=1 scripts/release/test-release-docs.sh && AGENT_SECRET_IN_MISE=1 scripts/release/test-release-notes.sh`
- `git diff --check`
- `mise run lint`
- `mise run build`
- `mise run test:smoke`
