### PR TITLE
Add agent-friendly CLI surfaces

### DIFF
--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -42,6 +42,7 @@ Confirm the tool is available:
 
 ```bash
 agent-secret --help
+agent-secret agent-context --json
 agent-secret doctor
 ```
 
@@ -66,6 +67,25 @@ If the project has `default_profile`, the profile can be implicit:
 agent-secret exec -- terraform plan
 ```
 
+Inspect project profiles without resolving values:
+
+```bash
+agent-secret profile list --json
+agent-secret profile show --json terraform-cloudflare
+```
+
+Validate a request without prompting, resolving values, or spawning the child:
+
+```bash
+agent-secret exec --dry-run --json --profile terraform-cloudflare -- terraform plan
+```
+
+Use an existing reusable approval without opening a new prompt:
+
+```bash
+agent-secret exec --reuse-only --profile terraform-cloudflare -- terraform plan
+```
+
 Use a shell only when the shell is the command you actually want approved:
 
 ```bash
@@ -76,7 +96,9 @@ agent-secret exec \
 ```
 
 The wrapped command must appear after `--` as argv. Agent Secret does not parse
-shell strings and does not have an `exec --json` mode.
+shell strings. Normal `exec` does not have JSON output because child
+stdin/stdout/stderr pass through unchanged; only `exec --dry-run --json`
+returns JSON.
 
 ## Project Profiles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,30 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
+## [0.0.12] - Pending
+
+### Added
+
+- Added `agent-secret agent-context --json` for coding agents that need a
+  machine-readable summary of commands, flags, output formats, config
+  discovery, and available project profiles.
+- Added JSON output for `doctor`, `daemon status|start|stop`, `version`,
+  `install-cli`, and `skill-install`.
+- Added `agent-secret profile list|show` to inspect resolved project profiles
+  without resolving or printing secret values.
+- Added `agent-secret exec --dry-run --json` to validate an exec request
+  without starting the daemon, prompting for approval, resolving values, or
+  spawning the child command.
+- Added `agent-secret exec --reuse-only` for no-prompt execution that uses an
+  existing matching reusable approval or fails without opening a new approval
+  prompt.
+
+### Changed
+
+- CLI validation errors now include valid choices or examples for unknown
+  commands, unknown subcommands, invalid item metadata formats, invalid aliases,
+  and malformed `--secret` mappings.
+
 ## [0.0.11] - 2026-05-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,12 +55,33 @@ Use a project profile:
 agent-secret exec --profile terraform-cloudflare -- terraform plan
 ```
 
+Validate what an agent is about to request without prompting or running the
+child:
+
+```bash
+agent-secret exec --dry-run --json --profile terraform-cloudflare -- terraform plan
+```
+
+Use an existing reusable approval without opening a new prompt:
+
+```bash
+agent-secret exec --reuse-only --profile terraform-cloudflare -- terraform plan
+```
+
 Inspect item metadata without revealing values:
 
 ```bash
 agent-secret item describe "op://Example Infra/Database Credentials"
 agent-secret item describe --format env-refs --prefix DATABASE \
   "op://Example Infra/Database Credentials"
+```
+
+Inspect the agent-facing CLI surface or project profiles:
+
+```bash
+agent-secret agent-context --json
+agent-secret profile list --json
+agent-secret profile show --json terraform-cloudflare
 ```
 
 ## What You Approve
@@ -106,6 +127,10 @@ precedence, env-file migration, and the full schema.
 
 - `agent-secret exec -- COMMAND [ARG...]`: run a command with approved secrets.
 - `agent-secret item describe REF`: inspect 1Password item fields without
+  values.
+- `agent-secret agent-context --json`: print a machine-readable command and
+  config discovery schema for coding agents.
+- `agent-secret profile list|show`: inspect project profiles without resolving
   values.
 - `agent-secret doctor`: print non-secret setup diagnostics.
 - `agent-secret daemon status|start|stop`: inspect or control the per-user

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,11 +189,16 @@ Current flags:
   environment variables in the child process.
 - `--force-refresh`: when a reusable approval matches, refetch approved refs
   before delivering them to the child.
+- `--dry-run`: validate the request and print preflight output without starting
+  the daemon, prompting for approval, resolving values, or spawning the child.
+- `--reuse-only`: use an existing matching reusable approval or fail without
+  opening a new approval prompt.
+- `--json`: print machine-readable preflight output. Only valid with
+  `--dry-run`.
 - `-h`, `--help`: print detailed `exec` help.
 
 Unsupported by design:
 
-- `--json`: `exec` passes stdin, stdout, and stderr through unchanged.
 - `--reuse`: reusable approvals are chosen in the approval UI.
 
 Explicit `--secret` flags may be combined with `--profile` for one-off
@@ -226,6 +231,47 @@ The resolved file contents are injected into the alias environment variable
 with multiline text preserved. Agent Secret does not create a temp file for the
 value and env-var delivery does not support binary attachments with NUL bytes.
 
+## Agent-Friendly Introspection
+
+Agents can ask Agent Secret for a machine-readable summary of the current CLI
+surface:
+
+```bash
+agent-secret agent-context --json
+```
+
+The output includes command names, flags, output formats, safety conventions,
+config discovery filenames, and any profiles found in the current project. It
+does not resolve 1Password references or print secret values.
+
+Use `--config PATH` when the config is not discoverable from the current
+directory:
+
+```bash
+agent-secret agent-context --config ./agent-secret.yml --json
+```
+
+## Profile Inspection
+
+Use `profile list` and `profile show` when an agent needs to discover available
+project profiles without parsing YAML itself:
+
+```bash
+agent-secret profile list --json
+agent-secret profile show --json terraform-cloudflare
+```
+
+If `profile show` is called without a profile name, it shows the config's
+`default_profile`. Output contains resolved aliases, refs, account metadata,
+reason, TTL, and includes. It never fetches or prints secret values.
+
+Text output is available for humans:
+
+```bash
+agent-secret profile list
+agent-secret profile show terraform-cloudflare
+```
+
 ## Item Metadata Inspection
 
 Use `agent-secret item describe` when an agent has an item-level ref but does
@@ -257,15 +303,15 @@ environment account overrides, then default desktop account detection.
 Daemon management:
 
 ```bash
-agent-secret daemon status
-agent-secret daemon start
-agent-secret daemon stop
+agent-secret daemon status [--json]
+agent-secret daemon start [--json]
+agent-secret daemon stop [--json]
 ```
 
 Diagnostics:
 
 ```bash
-agent-secret doctor
+agent-secret doctor [--json]
 ```
 
 `doctor` prints non-secret setup diagnostics. It should not require or resolve
@@ -274,7 +320,8 @@ real secret values.
 CLI installation:
 
 ```bash
-agent-secret install-cli
+agent-secret version [--json]
+agent-secret install-cli [--json]
 agent-secret install-cli --bin-dir "$HOME/.local/bin"
 agent-secret install-cli --force
 ```
@@ -286,7 +333,7 @@ an existing regular file or different symlink only when `--force` is passed.
 Skill installation:
 
 ```bash
-agent-secret skill-install
+agent-secret skill-install [--json]
 agent-secret skill-install --skills-dir "$HOME/.agents/skills"
 agent-secret skill-install --force
 ```

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -31,6 +31,7 @@ const (
 	EventApprovalDenied                     EventType = "approval_denied"
 	EventApprovalTimedOut                   EventType = "approval_timed_out"
 	EventApprovalReused                     EventType = "approval_reused"
+	EventApprovalReuseMissed                EventType = "approval_reuse_missed"
 	EventApprovalRefreshed                  EventType = "approval_refreshed"
 	EventSecretFetchStarted                 EventType = "secret_fetch_started"
 	EventSecretFetchFailed                  EventType = "secret_fetch_failed"
@@ -75,6 +76,7 @@ type Event struct {
 	RemainingTTLMillis *int64      `json:"remaining_ttl_ms,omitempty"`
 	RemainingUses      *int        `json:"remaining_uses,omitempty"`
 	ForceRefresh       bool        `json:"force_refresh,omitempty"`
+	ReuseOnly          bool        `json:"reuse_only,omitempty"`
 	OverrideEnv        bool        `json:"override_env,omitempty"`
 	OverriddenAliases  []string    `json:"overridden_aliases,omitempty"`
 }
@@ -111,6 +113,7 @@ func FromExecRequest(eventType EventType, requestID string, req request.ExecRequ
 		CWD:                req.CWD,
 		SecretRefs:         secretRefs(req.Secrets),
 		ForceRefresh:       req.ForceRefresh,
+		ReuseOnly:          req.ReuseOnly,
 		OverrideEnv:        req.OverrideEnv,
 		OverriddenAliases:  slices.Clone(req.OverriddenAliases),
 	}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -122,20 +122,25 @@ func (a App) Run(ctx context.Context, args []string) int {
 		a.stdoutln(command.HelpText)
 		return 0
 	case KindVersion:
-		a.stdoutln(command.VersionText)
-		return 0
+		return a.runVersion(command)
+	case KindAgentContext:
+		return a.runAgentContext(command)
 	case KindExec:
 		return a.runExec(ctx, command)
 	case KindItemDescribe:
 		return a.runItemDescribe(ctx, command)
+	case KindProfileList:
+		return a.runProfileList(command)
+	case KindProfileShow:
+		return a.runProfileShow(command)
 	case KindDaemonStatus:
-		return a.runDaemonStatus(ctx)
+		return a.runDaemonStatusWithOutput(ctx, command.OutputJSON)
 	case KindDaemonStart:
-		return a.runDaemonStart(ctx)
+		return a.runDaemonStart(ctx, command)
 	case KindDaemonStop:
-		return a.runDaemonStop(ctx)
+		return a.runDaemonStop(ctx, command)
 	case KindDoctor:
-		return a.runDoctor(ctx)
+		return a.runDoctor(ctx, command)
 	case KindInstallCLI:
 		return a.runInstallCLI(command)
 	case KindSkillInstall:

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -1,0 +1,249 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/kovyrin/agent-secret/internal/buildinfo"
+	"github.com/kovyrin/agent-secret/internal/profileconfig"
+	"github.com/kovyrin/agent-secret/internal/request"
+)
+
+type versionOutput struct {
+	SchemaVersion string `json:"schema_version"`
+	CLI           string `json:"cli"`
+	Version       string `json:"version"`
+	Revision      string `json:"revision,omitempty"`
+	Display       string `json:"display"`
+}
+
+type agentContextOutput struct {
+	SchemaVersion string                    `json:"schema_version"`
+	CLI           string                    `json:"cli"`
+	Version       string                    `json:"version"`
+	Commands      map[string]commandContext `json:"commands"`
+	Config        configContext             `json:"config"`
+	Available     availableContext          `json:"available"`
+	Conventions   conventionsContext        `json:"conventions"`
+}
+
+type commandContext struct {
+	Summary     string                    `json:"summary"`
+	Subcommands map[string]commandContext `json:"subcommands,omitempty"`
+	Flags       []flagContext             `json:"flags,omitempty"`
+	Outputs     []string                  `json:"outputs,omitempty"`
+	Notes       []string                  `json:"notes,omitempty"`
+}
+
+type flagContext struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Repeatable  bool     `json:"repeatable,omitempty"`
+	Default     string   `json:"default,omitempty"`
+	Values      []string `json:"values,omitempty"`
+	Description string   `json:"description"`
+}
+
+type configContext struct {
+	Discovery      []string `json:"discovery"`
+	InspectCommand string   `json:"inspect_command"`
+}
+
+type availableContext struct {
+	ProfileConfig *profileConfigContext `json:"profile_config,omitempty"`
+}
+
+type profileConfigContext struct {
+	SourcePath     string   `json:"source_path"`
+	DefaultProfile string   `json:"default_profile,omitempty"`
+	Profiles       []string `json:"profiles"`
+	Error          string   `json:"error,omitempty"`
+}
+
+type conventionsContext struct {
+	JSONFlag         string   `json:"json_flag"`
+	NoPromptFlag     string   `json:"no_prompt_flag"`
+	DryRunFlag       string   `json:"dry_run_flag"`
+	SecretSafety     []string `json:"secret_safety"`
+	MutationBoundary []string `json:"mutation_boundary"`
+}
+
+func (a App) runVersion(command Command) int {
+	if !command.OutputJSON {
+		a.stdoutln(command.VersionText)
+		return 0
+	}
+	if err := a.writeJSON(versionOutput{
+		SchemaVersion: "1",
+		CLI:           "agent-secret",
+		Version:       buildinfo.Version,
+		Revision:      buildinfo.Revision,
+		Display:       buildinfo.DisplayVersion(),
+	}); err != nil {
+		a.stderrf("agent-secret: write version json: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func (a App) runAgentContext(command Command) int {
+	output := agentContextOutput{
+		SchemaVersion: "1",
+		CLI:           "agent-secret",
+		Version:       buildinfo.DisplayVersion(),
+		Commands:      agentContextCommands(),
+		Config: configContext{
+			Discovery:      []string{"agent-secret.yml", ".agent-secret.yml"},
+			InspectCommand: "agent-secret profile list --json",
+		},
+		Available: availableContext{
+			ProfileConfig: profileConfigContextFor(command.AgentContextOptions.ConfigPath),
+		},
+		Conventions: conventionsContext{
+			JSONFlag:     "--json",
+			NoPromptFlag: "--reuse-only",
+			DryRunFlag:   "--dry-run",
+			SecretSafety: []string{
+				"secret values are never printed by agent-secret",
+				"exec passes child stdin/stdout/stderr through unchanged",
+				"item describe returns metadata only",
+			},
+			MutationBoundary: []string{
+				"exec --dry-run validates without prompting or spawning",
+				"exec --reuse-only fails instead of opening a new approval prompt",
+				"daemon stop clears daemon-owned reusable approvals and cached values",
+			},
+		},
+	}
+	if err := a.writeJSON(output); err != nil {
+		a.stderrf("agent-secret: write agent-context json: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func profileConfigContextFor(configPath string) *profileConfigContext {
+	info, err := profileconfig.Inspect(profileconfig.LoadOptions{ConfigPath: configPath})
+	if err != nil {
+		if errors.Is(err, profileconfig.ErrConfigNotFound) {
+			return nil
+		}
+		return &profileConfigContext{Error: err.Error()}
+	}
+	profiles := make([]string, 0, len(info.Profiles))
+	for _, profile := range info.Profiles {
+		profiles = append(profiles, profile.Name)
+	}
+	return &profileConfigContext{
+		SourcePath:     info.SourcePath,
+		DefaultProfile: info.DefaultProfile,
+		Profiles:       profiles,
+	}
+}
+
+func agentContextCommands() map[string]commandContext {
+	return map[string]commandContext{
+		"agent-context": {
+			Summary: "Print a versioned machine-readable description of the CLI surface.",
+			Flags: []flagContext{
+				{Name: "--config", Type: "path", Description: "Profile config path for available profile discovery."},
+				{Name: "--json", Type: "bool", Default: "true", Description: "Accepted for consistency; output is always JSON."},
+			},
+			Outputs: []string{"json"},
+		},
+		"daemon": {
+			Summary: "Troubleshoot the hidden per-user daemon.",
+			Subcommands: map[string]commandContext{
+				"status": {Summary: "Report whether the daemon is running.", Flags: jsonFlag(), Outputs: []string{"text", "json"}},
+				"start":  {Summary: "Start the daemon and report its status.", Flags: jsonFlag(), Outputs: []string{"text", "json"}},
+				"stop":   {Summary: "Stop the daemon and clear daemon-owned reusable approvals.", Flags: jsonFlag(), Outputs: []string{"text", "json"}},
+			},
+		},
+		"doctor": {
+			Summary: "Print non-secret local setup diagnostics.",
+			Flags:   jsonFlag(),
+			Outputs: []string{"text", "json"},
+		},
+		"exec": {
+			Summary: "Run a command with approved secrets injected as environment variables.",
+			Flags: []flagContext{
+				{Name: "--reason", Type: "string", Description: "Human-readable reason shown to the approver."},
+				{Name: "--secret", Type: "mapping", Repeatable: true, Description: "Secret alias mapping: ALIAS=op://vault/item/field."},
+				{Name: "--profile", Type: "string", Description: "Load a named project profile."},
+				{Name: "--only", Type: "string", Repeatable: true, Description: "Filter profile/env-file aliases; comma-separated values are accepted."},
+				{Name: "--env-file", Type: "path", Repeatable: true, Description: "Load dotenv entries; op:// values become approved refs."},
+				{Name: "--account", Type: "string", Description: "Default 1Password account for refs without a config account."},
+				{Name: "--config", Type: "path", Description: "Profile config path."},
+				{Name: "--cwd", Type: "path", Description: "Child working directory."},
+				{Name: "--ttl", Type: "duration", Default: request.DefaultExecTTL.String(), Description: "Approval TTL.", Values: []string{request.MinRequestTTL.String() + ".." + request.MaxRequestTTL.String()}},
+				{Name: "--override-env", Type: "bool", Description: "Allow approved aliases to replace existing child env vars."},
+				{Name: "--force-refresh", Type: "bool", Description: "Refetch values for a matching reusable approval before delivery."},
+				{Name: "--dry-run", Type: "bool", Description: "Validate request and print preflight output without prompting or spawning."},
+				{Name: "--reuse-only", Type: "bool", Description: "Use an existing reusable approval or fail without prompting."},
+				{Name: "--json", Type: "bool", Description: "Only valid with --dry-run."},
+			},
+			Outputs: []string{"child passthrough", "dry-run text", "dry-run json"},
+			Notes:   []string{"the wrapped command must appear after -- as argv", "normal exec has no JSON mode because child output is passed through unchanged"},
+		},
+		"install-cli": {
+			Summary: "Install or repair the command symlink for this user.",
+			Flags: append([]flagContext{
+				{Name: "--bin-dir", Type: "path", Default: "~/.local/bin", Description: "Directory that should contain the agent-secret command."},
+				{Name: "--force", Type: "bool", Description: "Replace an existing regular file or different symlink."},
+			}, jsonFlag()...),
+			Outputs: []string{"text", "json"},
+		},
+		"item": {
+			Summary: "Inspect 1Password item metadata without revealing secret values.",
+			Subcommands: map[string]commandContext{
+				"describe": {
+					Summary: "Show approved item metadata.",
+					Flags: []flagContext{
+						{Name: "--account", Type: "string", Description: "1Password account override."},
+						{Name: "--config", Type: "path", Description: "Profile config path."},
+						{Name: "--format", Type: "enum", Default: "text", Values: []string{"text", "json", "env-refs"}, Description: "Output format."},
+						{Name: "--prefix", Type: "string", Description: "Prefix generated aliases in env-refs output."},
+						{Name: "--reason", Type: "string", Default: "Inspect 1Password item metadata", Description: "Human-readable reason shown to the approver."},
+						{Name: "--ttl", Type: "duration", Default: request.DefaultItemDescribeTTL.String(), Values: []string{request.MinRequestTTL.String() + ".." + request.MaxRequestTTL.String()}, Description: "Approval TTL."},
+					},
+					Outputs: []string{"text", "json", "env-refs"},
+				},
+			},
+		},
+		"profile": {
+			Summary: "Inspect project profile configuration without resolving secret values.",
+			Subcommands: map[string]commandContext{
+				"list": {
+					Summary: "List profile names from the discovered config.",
+					Flags: append([]flagContext{
+						{Name: "--config", Type: "path", Description: "Profile config path."},
+					}, jsonFlag()...),
+					Outputs: []string{"text", "json"},
+				},
+				"show": {
+					Summary: "Show one resolved profile, defaulting to default_profile.",
+					Flags: append([]flagContext{
+						{Name: "--config", Type: "path", Description: "Profile config path."},
+					}, jsonFlag()...),
+					Outputs: []string{"text", "json"},
+				},
+			},
+		},
+		"skill-install": {
+			Summary: "Install or repair the bundled Agent Secret coding-agent skill.",
+			Flags: append([]flagContext{
+				{Name: "--skills-dir", Type: "path", Default: "~/.agents/skills", Description: "Directory that should contain the agent-secret skill."},
+				{Name: "--force", Type: "bool", Description: "Replace an existing regular file or different symlink."},
+			}, jsonFlag()...),
+			Outputs: []string{"text", "json"},
+		},
+		"version": {
+			Summary: "Print the installed agent-secret version.",
+			Flags:   jsonFlag(),
+			Outputs: []string{"text", "json"},
+		},
+	}
+}
+
+func jsonFlag() []flagContext {
+	return []flagContext{{Name: "--json", Type: "bool", Description: "Print JSON output."}}
+}

--- a/internal/cli/app_daemon.go
+++ b/internal/cli/app_daemon.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -13,119 +14,306 @@ import (
 	"github.com/kovyrin/agent-secret/internal/profileconfig"
 )
 
-func (a App) runDaemonStatus(ctx context.Context) int {
+type daemonStatusOutput struct {
+	SchemaVersion string `json:"schema_version"`
+	Running       bool   `json:"running"`
+	PID           int    `json:"pid,omitempty"`
+	Error         string `json:"error,omitempty"`
+}
+
+type daemonStopOutput struct {
+	SchemaVersion string `json:"schema_version"`
+	Stopped       bool   `json:"stopped"`
+	Error         string `json:"error,omitempty"`
+}
+
+type doctorOutput struct {
+	SchemaVersion string        `json:"schema_version"`
+	OK            bool          `json:"ok"`
+	Platform      string        `json:"platform"`
+	DaemonSocket  string        `json:"daemon_socket"`
+	Checks        []doctorCheck `json:"checks"`
+}
+
+type doctorCheck struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Path    string `json:"path,omitempty"`
+	PID     int    `json:"pid,omitempty"`
+	Account string `json:"account,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+func (a App) runDaemonStatusWithOutput(ctx context.Context, jsonOutput bool) int {
 	manager, err := a.daemonManager()
 	if err != nil {
+		if jsonOutput {
+			return a.writeDaemonStatusJSON(daemonStatusOutput{SchemaVersion: "1", Running: false, Error: err.Error()}, 1)
+		}
 		a.stdoutf("agent-secretd: stopped (%v)\n", err)
 		return 1
 	}
 	status, err := manager.Status(ctx)
 	if err != nil {
+		if jsonOutput {
+			return a.writeDaemonStatusJSON(daemonStatusOutput{SchemaVersion: "1", Running: false, Error: err.Error()}, 1)
+		}
 		a.stdoutf("agent-secretd: stopped (%v)\n", err)
 		return 1
+	}
+	if jsonOutput {
+		return a.writeDaemonStatusJSON(daemonStatusOutput{SchemaVersion: "1", Running: true, PID: status.PID}, 0)
 	}
 	a.stdoutf("agent-secretd: running pid=%d\n", status.PID)
 	return 0
 }
 
-func (a App) runDaemonStart(ctx context.Context) int {
+func (a App) runDaemonStart(ctx context.Context, command Command) int {
 	manager, err := a.daemonManager()
 	if err != nil {
+		if command.OutputJSON {
+			return a.writeDaemonStatusJSON(daemonStatusOutput{SchemaVersion: "1", Running: false, Error: err.Error()}, 1)
+		}
 		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
 		return 1
 	}
 	if err := manager.Start(ctx); err != nil {
+		if command.OutputJSON {
+			return a.writeDaemonStatusJSON(daemonStatusOutput{SchemaVersion: "1", Running: false, Error: err.Error()}, 1)
+		}
 		a.stderrf("agent-secret: start daemon: %v\n", err)
 		return 1
 	}
 	status, err := manager.Status(ctx)
 	if err != nil {
+		if command.OutputJSON {
+			return a.writeDaemonStatusJSON(daemonStatusOutput{SchemaVersion: "1", Running: false, Error: err.Error()}, 1)
+		}
 		a.stderrf("agent-secret: daemon started but status failed: %v\n", err)
 		return 1
+	}
+	if command.OutputJSON {
+		return a.writeDaemonStatusJSON(daemonStatusOutput{SchemaVersion: "1", Running: true, PID: status.PID}, 0)
 	}
 	a.stdoutf("agent-secretd: running pid=%d\n", status.PID)
 	return 0
 }
 
-func (a App) runDaemonStop(ctx context.Context) int {
+func (a App) runDaemonStop(ctx context.Context, command Command) int {
 	manager, err := a.daemonManager()
 	if err != nil {
+		if command.OutputJSON {
+			return a.writeDaemonStopJSON(daemonStopOutput{SchemaVersion: "1", Stopped: false, Error: err.Error()}, 1)
+		}
 		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
 		return 1
 	}
 	if err := manager.Stop(ctx); err != nil {
+		if command.OutputJSON {
+			return a.writeDaemonStopJSON(daemonStopOutput{SchemaVersion: "1", Stopped: false, Error: err.Error()}, 1)
+		}
 		a.stderrf("agent-secret: stop daemon: %v\n", err)
 		return 1
+	}
+	if command.OutputJSON {
+		return a.writeDaemonStopJSON(daemonStopOutput{SchemaVersion: "1", Stopped: true}, 0)
 	}
 	a.stdoutln("agent-secretd: stopped")
 	return 0
 }
 
-func (a App) runDoctor(ctx context.Context) int {
+func (a App) runDoctor(ctx context.Context, command Command) int {
 	manager, err := a.daemonManager()
 	if err != nil {
+		if command.OutputJSON {
+			return a.writeJSONError("initialize daemon manager", err)
+		}
 		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
 		return 1
 	}
 	healthy := true
-	a.stdoutln("agent-secret doctor")
-	a.stdoutf("platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-	a.stdoutf("daemon socket: %s\n", manager.SocketPath())
-	if auditPath, err := checkAuditLogWritable(ctx); err != nil {
-		healthy = false
-		if auditPath == "" {
-			a.stdoutf("audit log: failed (%v)\n", err)
-		} else {
-			a.stdoutf("audit log: failed %s (%v)\n", auditPath, err)
-		}
-	} else {
-		a.stdoutf("audit log: writable %s\n", auditPath)
+	checks := make([]doctorCheck, 0, 8)
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	jsonOutput := command.OutputJSON
+	if !jsonOutput {
+		a.stdoutln("agent-secret doctor")
+		a.stdoutf("platform: %s\n", platform)
+		a.stdoutf("daemon socket: %s\n", manager.SocketPath())
 	}
-	if err := manager.EnsureRunning(ctx); err != nil {
-		healthy = false
-		a.stdoutf("daemon startup: failed (%v)\n", err)
-	} else {
-		a.stdoutln("daemon startup: ok")
-	}
-	if status, err := manager.Status(ctx); err == nil {
-		a.stdoutf("daemon: running pid=%d\n", status.PID)
-	} else {
-		healthy = false
-		a.stdoutf("daemon: failed (%v)\n", err)
-	}
-	if err := socket.ValidateSocketDirectoryForPath(manager.SocketPath()); err != nil {
-		healthy = false
-		a.stdoutf("socket directory: failed (%v)\n", err)
-	} else {
-		a.stdoutln("socket directory: private")
-	}
+
+	var check doctorCheck
+	var checkOK bool
+	check, checkOK = a.auditLogDoctorCheck(ctx, jsonOutput)
+	checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
+	check, checkOK = a.daemonStartupDoctorCheck(ctx, manager, jsonOutput)
+	checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
+	check, checkOK = a.daemonStatusDoctorCheck(ctx, manager, jsonOutput)
+	checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
+	check, checkOK = a.socketDirectoryDoctorCheck(manager, jsonOutput)
+	checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
 	if check := a.DoctorApproverCheck; check != nil {
-		if err := check(ctx); err != nil {
-			healthy = false
-			a.stdoutf("native approver: failed (%v)\n", err)
-		} else {
-			a.stdoutln("native approver: ok")
-		}
+		check, checkOK := a.nativeApproverDoctorCheck(ctx, check, jsonOutput)
+		checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
 	}
+
 	account, configSource, err := doctorOnePasswordAccount()
 	if err != nil {
 		healthy = false
-		a.stdoutf("project config: failed (%v)\n", err)
+		checks = append(checks, doctorCheck{Name: "project_config", Status: "failed", Error: err.Error()})
+		if !jsonOutput {
+			a.stdoutf("project config: failed (%v)\n", err)
+		}
 	}
 	if configSource != "" {
-		a.stdoutf("project config: %s\n", configSource)
+		checks = append(checks, doctorCheck{Name: "project_config", Status: "ok", Path: configSource})
+		if !jsonOutput {
+			a.stdoutf("project config: %s\n", configSource)
+		}
 	}
-	a.stdoutf("1password account: %s\n", displayOnePasswordAccount(account))
-	if err := manager.CheckOnePassword(ctx, account); err != nil {
-		healthy = false
-		a.stdoutf("1password desktop integration: failed (%v)\n", err)
-	} else {
-		a.stdoutln("1password desktop integration: ok")
+	displayAccount := displayOnePasswordAccount(account)
+	if !jsonOutput {
+		a.stdoutf("1password account: %s\n", displayAccount)
+	}
+	check, checkOK = a.onePasswordDoctorCheck(ctx, manager, account, displayAccount, jsonOutput)
+	checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
+	if jsonOutput {
+		if err := a.writeJSON(doctorOutput{
+			SchemaVersion: "1",
+			OK:            healthy,
+			Platform:      platform,
+			DaemonSocket:  manager.SocketPath(),
+			Checks:        checks,
+		}); err != nil {
+			a.stderrf("agent-secret: write doctor json: %v\n", err)
+			return 1
+		}
 	}
 	if !healthy {
 		return 1
 	}
 	return 0
+}
+
+func appendDoctorCheck(checks []doctorCheck, healthy bool, check doctorCheck, checkOK bool) ([]doctorCheck, bool) {
+	if !checkOK {
+		healthy = false
+	}
+	return append(checks, check), healthy
+}
+
+func (a App) auditLogDoctorCheck(ctx context.Context, jsonOutput bool) (doctorCheck, bool) {
+	auditPath, err := checkAuditLogWritable(ctx)
+	if err != nil {
+		status := fmt.Sprintf("failed (%v)", err)
+		if auditPath != "" {
+			status = fmt.Sprintf("failed %s (%v)", auditPath, err)
+		}
+		if !jsonOutput {
+			a.stdoutf("audit log: %s\n", status)
+		}
+		return doctorCheck{Name: "audit_log", Status: "failed", Path: auditPath, Error: err.Error()}, false
+	}
+	if !jsonOutput {
+		a.stdoutf("audit log: writable %s\n", auditPath)
+	}
+	return doctorCheck{Name: "audit_log", Status: "ok", Path: auditPath}, true
+}
+
+func (a App) daemonStartupDoctorCheck(ctx context.Context, manager daemonManager, jsonOutput bool) (doctorCheck, bool) {
+	if err := manager.EnsureRunning(ctx); err != nil {
+		if !jsonOutput {
+			a.stdoutf("daemon startup: failed (%v)\n", err)
+		}
+		return doctorCheck{Name: "daemon_startup", Status: "failed", Error: err.Error()}, false
+	}
+	if !jsonOutput {
+		a.stdoutln("daemon startup: ok")
+	}
+	return doctorCheck{Name: "daemon_startup", Status: "ok"}, true
+}
+
+func (a App) daemonStatusDoctorCheck(ctx context.Context, manager daemonManager, jsonOutput bool) (doctorCheck, bool) {
+	status, err := manager.Status(ctx)
+	if err != nil {
+		if !jsonOutput {
+			a.stdoutf("daemon: failed (%v)\n", err)
+		}
+		return doctorCheck{Name: "daemon_status", Status: "failed", Error: err.Error()}, false
+	}
+	if !jsonOutput {
+		a.stdoutf("daemon: running pid=%d\n", status.PID)
+	}
+	return doctorCheck{Name: "daemon_status", Status: "ok", PID: status.PID}, true
+}
+
+func (a App) socketDirectoryDoctorCheck(manager daemonManager, jsonOutput bool) (doctorCheck, bool) {
+	if err := socket.ValidateSocketDirectoryForPath(manager.SocketPath()); err != nil {
+		if !jsonOutput {
+			a.stdoutf("socket directory: failed (%v)\n", err)
+		}
+		return doctorCheck{Name: "socket_directory", Status: "failed", Error: err.Error()}, false
+	}
+	if !jsonOutput {
+		a.stdoutln("socket directory: private")
+	}
+	return doctorCheck{Name: "socket_directory", Status: "ok"}, true
+}
+
+func (a App) nativeApproverDoctorCheck(
+	ctx context.Context,
+	check func(context.Context) error,
+	jsonOutput bool,
+) (doctorCheck, bool) {
+	if err := check(ctx); err != nil {
+		if !jsonOutput {
+			a.stdoutf("native approver: failed (%v)\n", err)
+		}
+		return doctorCheck{Name: "native_approver", Status: "failed", Error: err.Error()}, false
+	}
+	if !jsonOutput {
+		a.stdoutln("native approver: ok")
+	}
+	return doctorCheck{Name: "native_approver", Status: "ok"}, true
+}
+
+func (a App) onePasswordDoctorCheck(
+	ctx context.Context,
+	manager daemonManager,
+	account string,
+	displayAccount string,
+	jsonOutput bool,
+) (doctorCheck, bool) {
+	if err := manager.CheckOnePassword(ctx, account); err != nil {
+		if !jsonOutput {
+			a.stdoutf("1password desktop integration: failed (%v)\n", err)
+		}
+		return doctorCheck{
+			Name:    "1password_desktop_integration",
+			Status:  "failed",
+			Account: displayAccount,
+			Error:   err.Error(),
+		}, false
+	}
+	if !jsonOutput {
+		a.stdoutln("1password desktop integration: ok")
+	}
+	return doctorCheck{Name: "1password_desktop_integration", Status: "ok", Account: displayAccount}, true
+}
+
+func (a App) writeDaemonStatusJSON(output daemonStatusOutput, code int) int {
+	if err := a.writeJSON(output); err != nil {
+		a.stderrf("agent-secret: write daemon status json: %v\n", err)
+		return 1
+	}
+	return code
+}
+
+func (a App) writeDaemonStopJSON(output daemonStopOutput, code int) int {
+	if err := a.writeJSON(output); err != nil {
+		a.stderrf("agent-secret: write daemon stop json: %v\n", err)
+		return 1
+	}
+	return code
 }
 
 func doctorOnePasswordAccount() (string, string, error) {

--- a/internal/cli/app_exec.go
+++ b/internal/cli/app_exec.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/kovyrin/agent-secret/internal/daemon/control"
@@ -15,7 +16,33 @@ import (
 	"github.com/kovyrin/agent-secret/internal/request"
 )
 
+type execDryRunOutput struct {
+	SchemaVersion string            `json:"schema_version"`
+	OK            bool              `json:"ok"`
+	WouldPrompt   bool              `json:"would_prompt"`
+	WouldSpawn    bool              `json:"would_spawn"`
+	Request       execDryRunRequest `json:"request"`
+	Notes         []string          `json:"notes"`
+}
+
+type execDryRunRequest struct {
+	Reason                 string               `json:"reason"`
+	Command                []string             `json:"command"`
+	ResolvedExecutable     string               `json:"resolved_executable"`
+	CWD                    string               `json:"cwd"`
+	TTL                    string               `json:"ttl"`
+	EnvironmentFingerprint string               `json:"environment_fingerprint"`
+	Secrets                []request.SecretSpec `json:"secrets"`
+	OverrideEnv            bool                 `json:"override_env"`
+	OverriddenAliases      []string             `json:"overridden_aliases,omitempty"`
+	ForceRefresh           bool                 `json:"force_refresh"`
+	ReuseOnly              bool                 `json:"reuse_only"`
+}
+
 func (a App) runExec(ctx context.Context, command Command) int {
+	if command.ExecDryRun {
+		return a.runExecDryRun(command)
+	}
 	manager, err := a.daemonManager()
 	if err != nil {
 		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
@@ -69,6 +96,71 @@ func (a App) runExec(ctx context.Context, command Command) int {
 		return 1
 	}
 	return result.ExitCode
+}
+
+func (a App) runExecDryRun(command Command) int {
+	req := command.ExecRequest
+	output := execDryRunOutput{
+		SchemaVersion: "1",
+		OK:            true,
+		WouldPrompt:   !req.ReuseOnly,
+		WouldSpawn:    false,
+		Request: execDryRunRequest{
+			Reason:                 req.Reason,
+			Command:                req.Command,
+			ResolvedExecutable:     req.ResolvedExecutable,
+			CWD:                    req.CWD,
+			TTL:                    req.TTL.String(),
+			EnvironmentFingerprint: req.EnvironmentFingerprint,
+			Secrets:                dryRunSecrets(req.Secrets),
+			OverrideEnv:            req.OverrideEnv,
+			OverriddenAliases:      req.OverriddenAliases,
+			ForceRefresh:           req.ForceRefresh,
+			ReuseOnly:              req.ReuseOnly,
+		},
+		Notes: []string{
+			"validated request locally",
+			"did not start the daemon",
+			"did not prompt for approval",
+			"did not resolve or print secret values",
+			"did not spawn the child command",
+		},
+	}
+	if command.OutputJSON {
+		if err := a.writeJSON(output); err != nil {
+			a.stderrf("agent-secret: write exec dry-run json: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	a.stdoutln("agent-secret exec dry run: ok")
+	a.stdoutf("would prompt: %t\n", output.WouldPrompt)
+	a.stdoutf("would spawn: %t\n", output.WouldSpawn)
+	a.stdoutf("reason: %s\n", req.Reason)
+	a.stdoutf("cwd: %s\n", req.CWD)
+	a.stdoutf("command: %s\n", shellQuoteArgs(req.Command))
+	a.stdoutf("ttl: %s\n", req.TTL)
+	a.stdoutln("secrets:")
+	for _, secret := range req.Secrets {
+		account := secret.Account
+		if account == "" {
+			account = "(default desktop account)"
+		}
+		a.stdoutf("  %s=%s account=%s\n", secret.Alias, secret.Ref.Raw, account)
+	}
+	return 0
+}
+
+func dryRunSecrets(secrets []request.Secret) []request.SecretSpec {
+	out := make([]request.SecretSpec, 0, len(secrets))
+	for _, secret := range secrets {
+		out = append(out, request.SecretSpec{
+			Alias:   secret.Alias,
+			Ref:     secret.Ref.Raw,
+			Account: secret.Account,
+		})
+	}
+	return out
 }
 
 func (a App) requestExec(
@@ -132,4 +224,15 @@ func isFatalCommandStartedAuditFailure(err error) bool {
 		protocolErr.Code == protocol.ErrorCodeRequestExpired ||
 		protocolErr.Code == protocol.ErrorCodeStaleApproval ||
 		protocolErr.Code == protocol.ErrorCodeUntrustedClient
+}
+
+func shellQuoteArgs(args []string) string {
+	var out strings.Builder
+	for index, arg := range args {
+		if index > 0 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(shellSingleQuote(arg))
+	}
+	return out.String()
 }

--- a/internal/cli/app_install.go
+++ b/internal/cli/app_install.go
@@ -9,6 +9,19 @@ import (
 	"github.com/kovyrin/agent-secret/internal/install"
 )
 
+type installOutput struct {
+	SchemaVersion string       `json:"schema_version"`
+	Installed     bool         `json:"installed"`
+	LinkPath      string       `json:"link_path"`
+	TargetPath    string       `json:"target_path"`
+	PathWarning   *pathWarning `json:"path_warning,omitempty"`
+}
+
+type pathWarning struct {
+	Directory string `json:"directory"`
+	Command   string `json:"command"`
+}
+
 func (a App) runInstallCLI(command Command) int {
 	installCLI := a.InstallCLI
 	if installCLI == nil {
@@ -16,8 +29,28 @@ func (a App) runInstallCLI(command Command) int {
 	}
 	result, err := installCLI(command.InstallCLIOptions)
 	if err != nil {
+		if command.OutputJSON {
+			return a.writeJSONError("install-cli", err)
+		}
 		a.stderrf("agent-secret: install-cli: %v\n", err)
 		return 1
+	}
+	if command.OutputJSON {
+		output := installOutput{
+			SchemaVersion: "1",
+			Installed:     true,
+			LinkPath:      result.LinkPath,
+			TargetPath:    result.TargetPath,
+		}
+		binDir := filepath.Dir(result.LinkPath)
+		if !pathContainsDir(os.Getenv("PATH"), binDir) {
+			output.PathWarning = &pathWarning{Directory: displayHomePath(binDir), Command: zshPathSetupCommand(binDir)}
+		}
+		if err := a.writeJSON(output); err != nil {
+			a.stderrf("agent-secret: write install-cli json: %v\n", err)
+			return 1
+		}
+		return 0
 	}
 	a.stdoutf("agent-secret command installed: %s -> %s\n", result.LinkPath, result.TargetPath)
 	a.warnIfCommandDirMissingFromPath(filepath.Dir(result.LinkPath))
@@ -31,8 +64,23 @@ func (a App) runSkillInstall(command Command) int {
 	}
 	result, err := installSkill(command.InstallSkillOptions)
 	if err != nil {
+		if command.OutputJSON {
+			return a.writeJSONError("skill-install", err)
+		}
 		a.stderrf("agent-secret: skill-install: %v\n", err)
 		return 1
+	}
+	if command.OutputJSON {
+		if err := a.writeJSON(installOutput{
+			SchemaVersion: "1",
+			Installed:     true,
+			LinkPath:      result.LinkPath,
+			TargetPath:    result.TargetPath,
+		}); err != nil {
+			a.stderrf("agent-secret: write skill-install json: %v\n", err)
+			return 1
+		}
+		return 0
 	}
 	a.stdoutf("agent-secret skill installed: %s -> %s\n", result.LinkPath, result.TargetPath)
 	return 0

--- a/internal/cli/app_output.go
+++ b/internal/cli/app_output.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (a App) writeJSON(value any) error {
+	encoder := json.NewEncoder(a.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func (a App) writeJSONError(context string, err error) int {
+	if writeErr := a.writeJSON(map[string]any{
+		"schema_version": "1",
+		"ok":             false,
+		"context":        context,
+		"error":          fmt.Sprintf("%s: %v", context, err),
+	}); writeErr != nil {
+		a.stderrf("agent-secret: write json: %v\n", writeErr)
+	}
+	return 1
+}

--- a/internal/cli/app_profile.go
+++ b/internal/cli/app_profile.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/kovyrin/agent-secret/internal/profileconfig"
+)
+
+type profileListOutput struct {
+	SchemaVersion  string                     `json:"schema_version"`
+	SourcePath     string                     `json:"source_path"`
+	DefaultProfile string                     `json:"default_profile,omitempty"`
+	Profiles       []profileListProfileOutput `json:"profiles"`
+}
+
+type profileListProfileOutput struct {
+	Name    string `json:"name"`
+	Default bool   `json:"default"`
+}
+
+type profileShowOutput struct {
+	SchemaVersion string                    `json:"schema_version"`
+	SourcePath    string                    `json:"source_path"`
+	Profile       profileconfig.ProfileInfo `json:"profile"`
+}
+
+func (a App) runProfileList(command Command) int {
+	info, err := profileconfig.Inspect(profileconfig.LoadOptions{ConfigPath: command.ProfileOptions.ConfigPath})
+	if err != nil {
+		return a.profileError(command.OutputJSON, "load profile config", err)
+	}
+	if command.OutputJSON {
+		profiles := make([]profileListProfileOutput, 0, len(info.Profiles))
+		for _, profile := range info.Profiles {
+			profiles = append(profiles, profileListProfileOutput{Name: profile.Name, Default: profile.Default})
+		}
+		if err := a.writeJSON(profileListOutput{
+			SchemaVersion:  "1",
+			SourcePath:     info.SourcePath,
+			DefaultProfile: info.DefaultProfile,
+			Profiles:       profiles,
+		}); err != nil {
+			a.stderrf("agent-secret: write profile list json: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writer := tabwriter.NewWriter(a.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintf(writer, "config:\t%s\n", info.SourcePath); err != nil {
+		return a.profileWriteError(err)
+	}
+	if info.DefaultProfile != "" {
+		if _, err := fmt.Fprintf(writer, "default_profile:\t%s\n", info.DefaultProfile); err != nil {
+			return a.profileWriteError(err)
+		}
+	}
+	if _, err := fmt.Fprintln(writer, "profiles:"); err != nil {
+		return a.profileWriteError(err)
+	}
+	if len(info.Profiles) == 0 {
+		if _, err := fmt.Fprintln(writer, "  (none)"); err != nil {
+			return a.profileWriteError(err)
+		}
+		return a.profileWriteError(writer.Flush())
+	}
+	for _, profile := range info.Profiles {
+		marker := ""
+		if profile.Default {
+			marker = " (default)"
+		}
+		if _, err := fmt.Fprintf(writer, "  %s%s\n", profile.Name, marker); err != nil {
+			return a.profileWriteError(err)
+		}
+	}
+	return a.profileWriteError(writer.Flush())
+}
+
+func (a App) runProfileShow(command Command) int {
+	info, err := profileconfig.Inspect(profileconfig.LoadOptions{ConfigPath: command.ProfileOptions.ConfigPath})
+	if err != nil {
+		return a.profileError(command.OutputJSON, "load profile config", err)
+	}
+	profile, err := selectProfile(info, command.ProfileOptions.Name)
+	if err != nil {
+		return a.profileError(command.OutputJSON, "select profile", err)
+	}
+	if command.OutputJSON {
+		if err := a.writeJSON(profileShowOutput{
+			SchemaVersion: "1",
+			SourcePath:    info.SourcePath,
+			Profile:       profile,
+		}); err != nil {
+			a.stderrf("agent-secret: write profile show json: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writer := tabwriter.NewWriter(a.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintf(writer, "config:\t%s\n", info.SourcePath); err != nil {
+		return a.profileWriteError(err)
+	}
+	if _, err := fmt.Fprintf(writer, "profile:\t%s\n", profile.Name); err != nil {
+		return a.profileWriteError(err)
+	}
+	if profile.Default {
+		if _, err := fmt.Fprintln(writer, "default:\ttrue"); err != nil {
+			return a.profileWriteError(err)
+		}
+	}
+	if profile.Account != "" {
+		if _, err := fmt.Fprintf(writer, "account:\t%s\n", profile.Account); err != nil {
+			return a.profileWriteError(err)
+		}
+	}
+	if profile.Reason != "" {
+		if _, err := fmt.Fprintf(writer, "reason:\t%s\n", profile.Reason); err != nil {
+			return a.profileWriteError(err)
+		}
+	}
+	if profile.TTL != "" {
+		if _, err := fmt.Fprintf(writer, "ttl:\t%s\n", profile.TTL); err != nil {
+			return a.profileWriteError(err)
+		}
+	}
+	if len(profile.Include) > 0 {
+		if _, err := fmt.Fprintf(writer, "include:\t%s\n", joinComma(profile.Include)); err != nil {
+			return a.profileWriteError(err)
+		}
+	}
+	if _, err := fmt.Fprintln(writer, "secrets:"); err != nil {
+		return a.profileWriteError(err)
+	}
+	for _, secret := range profile.Secrets {
+		account := secret.Account
+		if account == "" {
+			account = "(default desktop account)"
+		}
+		if _, err := fmt.Fprintf(writer, "  %s\t%s\t%s\n", secret.Alias, secret.Ref, account); err != nil {
+			return a.profileWriteError(err)
+		}
+	}
+	return a.profileWriteError(writer.Flush())
+}
+
+func selectProfile(info profileconfig.ConfigInfo, name string) (profileconfig.ProfileInfo, error) {
+	if name == "" {
+		name = info.DefaultProfile
+	}
+	if name == "" {
+		return profileconfig.ProfileInfo{}, fmt.Errorf("%w: default_profile is required when no profile name is provided", profileconfig.ErrProfileNotFound)
+	}
+	for _, profile := range info.Profiles {
+		if profile.Name == name {
+			return profile, nil
+		}
+	}
+	return profileconfig.ProfileInfo{}, fmt.Errorf("%w: %q; valid profiles: %s", profileconfig.ErrProfileNotFound, name, validProfileNames(info))
+}
+
+func validProfileNames(info profileconfig.ConfigInfo) string {
+	names := make([]string, 0, len(info.Profiles))
+	for _, profile := range info.Profiles {
+		names = append(names, profile.Name)
+	}
+	return joinComma(names)
+}
+
+func joinComma(values []string) string {
+	var out strings.Builder
+	for index, value := range values {
+		if index > 0 {
+			out.WriteString(", ")
+		}
+		out.WriteString(value)
+	}
+	return out.String()
+}
+
+func (a App) profileError(jsonOutput bool, context string, err error) int {
+	if jsonOutput {
+		return a.writeJSONError(context, err)
+	}
+	if errors.Is(err, profileconfig.ErrConfigNotFound) {
+		a.stderrf("agent-secret: %s: %v\n", context, err)
+		return 2
+	}
+	a.stderrf("agent-secret: %s: %v\n", context, err)
+	return 1
+}
+
+func (a App) profileWriteError(err error) int {
+	if err != nil {
+		a.stderrf("agent-secret: write profile output: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -586,6 +586,146 @@ func TestAppDaemonStatusAndDoctor(t *testing.T) {
 		!strings.Contains(stdout.String(), "1password desktop integration: ok") {
 		t.Fatalf("doctor output missing diagnostics: %q", stdout.String())
 	}
+	stdout.Reset()
+	if code := app.Run(context.Background(), []string{"daemon", "status", "--json"}); code != 0 {
+		t.Fatalf("daemon status json exit=%d stderr=%q", code, stderr.String())
+	}
+	var status daemonStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("daemon status json did not decode: %v\n%s", err, stdout.String())
+	}
+	if !status.Running || status.PID == 0 {
+		t.Fatalf("daemon status json = %+v", status)
+	}
+	stdout.Reset()
+	if code := app.Run(context.Background(), []string{"doctor", "--json"}); code != 0 {
+		t.Fatalf("doctor json exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var doctor doctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &doctor); err != nil {
+		t.Fatalf("doctor json did not decode: %v\n%s", err, stdout.String())
+	}
+	if !doctor.OK || doctor.Platform == "" || len(doctor.Checks) == 0 {
+		t.Fatalf("doctor json = %+v", doctor)
+	}
+}
+
+func TestAppDaemonJSONStartStopAndFailures(t *testing.T) {
+	socketDir := t.TempDir()
+	//nolint:gosec // G302: daemon socket directories must be private but executable by their owner.
+	if err := os.Chmod(socketDir, 0o700); err != nil {
+		t.Fatalf("chmod socket dir: %v", err)
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(socketDir, "d.sock"),
+		status:     protocol.StatusPayload{PID: 4321},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	if code := app.Run(context.Background(), []string{"daemon", "start", "--json"}); code != 0 {
+		t.Fatalf("daemon start json exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var status daemonStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("daemon start json did not decode: %v\n%s", err, stdout.String())
+	}
+	if !status.Running || status.PID != 4321 || manager.startCalls != 1 || manager.statusCalls != 1 {
+		t.Fatalf("daemon start json = %+v manager=%+v", status, manager)
+	}
+
+	stdout.Reset()
+	if code := app.Run(context.Background(), []string{"daemon", "stop", "--json"}); code != 0 {
+		t.Fatalf("daemon stop json exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var stop daemonStopOutput
+	if err := json.Unmarshal(stdout.Bytes(), &stop); err != nil {
+		t.Fatalf("daemon stop json did not decode: %v\n%s", err, stdout.String())
+	}
+	if !stop.Stopped || manager.stopCalls != 1 {
+		t.Fatalf("daemon stop json = %+v manager=%+v", stop, manager)
+	}
+
+	stdout.Reset()
+	manager.statusErr = errors.New("status unavailable")
+	if code := app.Run(context.Background(), []string{"daemon", "status", "--json"}); code != 1 {
+		t.Fatalf("daemon status failure exit=%d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("daemon status failure json did not decode: %v\n%s", err, stdout.String())
+	}
+	if status.Running || !strings.Contains(status.Error, "status unavailable") {
+		t.Fatalf("daemon status failure json = %+v", status)
+	}
+
+	stdout.Reset()
+	manager.startErr = errors.New("start unavailable")
+	if code := app.Run(context.Background(), []string{"daemon", "start", "--json"}); code != 1 {
+		t.Fatalf("daemon start failure exit=%d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("daemon start failure json did not decode: %v\n%s", err, stdout.String())
+	}
+	if status.Running || !strings.Contains(status.Error, "start unavailable") {
+		t.Fatalf("daemon start failure json = %+v", status)
+	}
+
+	stdout.Reset()
+	manager.stopErr = errors.New("stop unavailable")
+	if code := app.Run(context.Background(), []string{"daemon", "stop", "--json"}); code != 1 {
+		t.Fatalf("daemon stop failure exit=%d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &stop); err != nil {
+		t.Fatalf("daemon stop failure json did not decode: %v\n%s", err, stdout.String())
+	}
+	if stop.Stopped || !strings.Contains(stop.Error, "stop unavailable") {
+		t.Fatalf("daemon stop failure json = %+v", stop)
+	}
+}
+
+func TestAppDoctorReportsJSONDependencyFailures(t *testing.T) {
+	homeFile := filepath.Join(t.TempDir(), "home")
+	if err := os.WriteFile(homeFile, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write home file: %v", err)
+	}
+	t.Setenv("HOME", homeFile)
+	socketDir := filepath.Join(t.TempDir(), "insecure-socket-dir")
+	//nolint:gosec // G301: intentionally creates an insecure socket dir for doctor failure coverage.
+	if err := os.Mkdir(socketDir, 0o755); err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(socketDir, "d.sock"),
+		ensureErr:  errors.New("startup unavailable"),
+		statusErr:  errors.New("status unavailable"),
+		checkErr:   errors.New("desktop unavailable"),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	app.DoctorApproverCheck = func(context.Context) error { return errors.New("approver unavailable") }
+
+	if code := app.Run(context.Background(), []string{"doctor", "--json"}); code != 1 {
+		t.Fatalf("doctor json failure exit=%d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	var output doctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor json failure did not decode: %v\n%s", err, stdout.String())
+	}
+	for _, name := range []string{
+		"audit_log",
+		"daemon_startup",
+		"daemon_status",
+		"socket_directory",
+		"native_approver",
+		"1password_desktop_integration",
+	} {
+		check, found := findDoctorCheck(output.Checks, name)
+		if !found || check.Status != "failed" || check.Error == "" {
+			t.Fatalf("doctor check %s = %+v found=%t output=%+v", name, check, found, output)
+		}
+	}
 }
 
 func TestAppVersionDoesNotStartDaemon(t *testing.T) {
@@ -607,6 +747,253 @@ func TestAppVersionDoesNotStartDaemon(t *testing.T) {
 			manager.connectCalls,
 			manager.statusCalls,
 		)
+	}
+
+	stdout.Reset()
+	if code := app.Run(context.Background(), []string{"version", "--json"}); code != 0 {
+		t.Fatalf("version json exit=%d stderr=%q", code, stderr.String())
+	}
+	var output versionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("version json did not decode: %v\n%s", err, stdout.String())
+	}
+	if output.SchemaVersion != "1" || output.CLI != "agent-secret" || output.Display != "agent-secret dev" {
+		t.Fatalf("version json output = %+v", output)
+	}
+	if manager.ensureCalls != 0 || manager.connectCalls != 0 || manager.statusCalls != 0 {
+		t.Fatalf("version json touched daemon manager")
+	}
+}
+
+func TestAppExecDryRunJSONDoesNotStartDaemonPromptOrSpawn(t *testing.T) {
+	root := t.TempDir()
+	writeExecutable(t, root, "tool")
+	t.Chdir(root)
+	t.Setenv("PATH", root)
+	manager := &appFakeDaemonManager{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	code := app.Run(context.Background(), []string{
+		"exec",
+		"--dry-run",
+		"--json",
+		"--reuse-only",
+		"--reason", "Preflight deploy",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--",
+		"tool",
+	})
+	if code != 0 {
+		t.Fatalf("dry-run exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var output execDryRunOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("dry-run json did not decode: %v\n%s", err, stdout.String())
+	}
+	if !output.OK || output.WouldPrompt || output.WouldSpawn {
+		t.Fatalf("unexpected dry-run booleans: %+v", output)
+	}
+	if output.Request.Reason != "Preflight deploy" ||
+		output.Request.Secrets[0].Ref != "op://Example/Item/token" ||
+		!output.Request.ReuseOnly {
+		t.Fatalf("unexpected dry-run request: %+v", output.Request)
+	}
+	if strings.Contains(stdout.String()+stderr.String(), "synthetic-secret-value") {
+		t.Fatalf("dry-run leaked secret-looking canary")
+	}
+	if manager.ensureCalls != 0 || manager.connectCalls != 0 || manager.statusCalls != 0 {
+		t.Fatalf("dry-run touched daemon manager: %+v", manager)
+	}
+}
+
+func TestAppExecDryRunTextDescribesPromptAndCommand(t *testing.T) {
+	root := t.TempDir()
+	writeExecutable(t, root, "tool")
+	t.Chdir(root)
+	t.Setenv("PATH", root)
+	manager := &appFakeDaemonManager{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	code := app.Run(context.Background(), []string{
+		"exec",
+		"--dry-run",
+		"--reason", "Preflight deploy",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--",
+		"tool", "arg with space", "plain",
+	})
+	if code != 0 {
+		t.Fatalf("dry-run exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{
+		"agent-secret exec dry run: ok",
+		"would prompt: true",
+		"would spawn: false",
+		"command: '",
+		"'arg with space'",
+		"TOKEN=op://Example/Item/token account=(default desktop account)",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("dry-run stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if manager.ensureCalls != 0 || manager.connectCalls != 0 || manager.statusCalls != 0 {
+		t.Fatalf("dry-run touched daemon manager: %+v", manager)
+	}
+}
+
+func TestAppAgentContextAndProfilesJSON(t *testing.T) {
+	root := t.TempDir()
+	writeProfileConfig(t, root, `
+version: 1
+default_profile: deploy
+profiles:
+  base:
+    reason: Base
+    secrets:
+      BASE_TOKEN: op://Example/Base/token
+  deploy:
+    include:
+      - base
+    reason: Deploy
+    secrets:
+      DEPLOY_TOKEN: op://Example/Deploy/token
+`)
+	t.Chdir(root)
+	manager := &appFakeDaemonManager{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	if code := app.Run(context.Background(), []string{"agent-context", "--json"}); code != 0 {
+		t.Fatalf("agent-context exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var contextOutput agentContextOutput
+	if err := json.Unmarshal(stdout.Bytes(), &contextOutput); err != nil {
+		t.Fatalf("agent-context json did not decode: %v\n%s", err, stdout.String())
+	}
+	if contextOutput.SchemaVersion != "1" ||
+		contextOutput.Available.ProfileConfig == nil ||
+		contextOutput.Available.ProfileConfig.DefaultProfile != "deploy" ||
+		contextOutput.Commands["exec"].Summary == "" {
+		t.Fatalf("unexpected agent-context output: %+v", contextOutput)
+	}
+
+	stdout.Reset()
+	if code := app.Run(context.Background(), []string{"profile", "list", "--json"}); code != 0 {
+		t.Fatalf("profile list exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var listOutput profileListOutput
+	if err := json.Unmarshal(stdout.Bytes(), &listOutput); err != nil {
+		t.Fatalf("profile list json did not decode: %v\n%s", err, stdout.String())
+	}
+	if listOutput.DefaultProfile != "deploy" || len(listOutput.Profiles) != 2 || !listOutput.Profiles[1].Default {
+		t.Fatalf("unexpected profile list output: %+v", listOutput)
+	}
+
+	stdout.Reset()
+	if code := app.Run(context.Background(), []string{"profile", "show", "--json"}); code != 0 {
+		t.Fatalf("profile show exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var showOutput profileShowOutput
+	if err := json.Unmarshal(stdout.Bytes(), &showOutput); err != nil {
+		t.Fatalf("profile show json did not decode: %v\n%s", err, stdout.String())
+	}
+	if showOutput.Profile.Name != "deploy" || len(showOutput.Profile.Secrets) != 2 {
+		t.Fatalf("unexpected profile show output: %+v", showOutput)
+	}
+	if strings.Contains(stdout.String()+stderr.String(), "synthetic-secret-value") {
+		t.Fatalf("profile output leaked secret-looking canary")
+	}
+	if manager.ensureCalls != 0 || manager.connectCalls != 0 || manager.statusCalls != 0 {
+		t.Fatalf("agent metadata commands touched daemon manager: %+v", manager)
+	}
+}
+
+func TestAppProfilesTextAndErrors(t *testing.T) {
+	root := t.TempDir()
+	writeProfileConfig(t, root, `
+version: 1
+default_profile: deploy
+profiles:
+  base:
+    reason: Base
+    secrets:
+      BASE_TOKEN:
+        ref: op://Example/Base/token
+        account: base.1password.com
+  deploy:
+    include:
+      - base
+    account: deploy.1password.com
+    reason: Deploy
+    ttl: 30m
+    secrets:
+      DEPLOY_TOKEN: op://Example/Deploy/token
+`)
+	t.Chdir(root)
+	manager := &appFakeDaemonManager{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	if code := app.Run(context.Background(), []string{"profile", "list"}); code != 0 {
+		t.Fatalf("profile list exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"default_profile:", "deploy", "base", "deploy (default)"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("profile list stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+
+	stdout.Reset()
+	if code := app.Run(context.Background(), []string{"profile", "show", "deploy"}); code != 0 {
+		t.Fatalf("profile show exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{
+		"profile:", "deploy",
+		"account:", "deploy.1password.com",
+		"reason:", "Deploy",
+		"ttl:", "30m",
+		"include:", "base",
+		"DEPLOY_TOKEN",
+		"BASE_TOKEN",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("profile show stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := app.Run(context.Background(), []string{"profile", "show", "missing"}); code != 1 {
+		t.Fatalf("profile show missing exit=%d, want 1; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "valid profiles: base, deploy") {
+		t.Fatalf("profile show missing stderr = %q", stderr.String())
+	}
+
+	stderr.Reset()
+	if code := app.Run(context.Background(), []string{"profile", "show", "--json", "missing"}); code != 1 {
+		t.Fatalf("profile show missing json exit=%d, want 1; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var errOutput struct {
+		SchemaVersion string `json:"schema_version"`
+		OK            bool   `json:"ok"`
+		Context       string `json:"context"`
+		Error         string `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &errOutput); err != nil {
+		t.Fatalf("profile error json did not decode: %v\n%s", err, stdout.String())
+	}
+	if errOutput.SchemaVersion != "1" || errOutput.OK || errOutput.Context != "select profile" ||
+		!strings.Contains(errOutput.Error, "select profile") ||
+		!strings.Contains(errOutput.Error, "valid profiles") {
+		t.Fatalf("profile error json = %+v", errOutput)
 	}
 }
 
@@ -667,6 +1054,15 @@ func TestAppDoctorReportsFailureWithoutSecretValues(t *testing.T) {
 	if strings.Contains(stdout.String(), "synthetic-secret-value") || strings.Contains(stderr.String(), "synthetic-secret-value") {
 		t.Fatalf("doctor leaked secret: stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
+}
+
+func findDoctorCheck(checks []doctorCheck, name string) (doctorCheck, bool) {
+	for _, check := range checks {
+		if check.Name == name {
+			return check, true
+		}
+	}
+	return doctorCheck{}, false
 }
 
 func TestAppDaemonStartAndStopCommands(t *testing.T) {
@@ -765,6 +1161,30 @@ func TestAppInstallCommands(t *testing.T) {
 		if gotOptions.SkillsDir != "/tmp/skills" || !gotOptions.Force {
 			t.Fatalf("skill-install options = %+v", gotOptions)
 		}
+	})
+}
+
+func TestAppInstallCommandsJSON(t *testing.T) {
+	t.Run("cli", func(t *testing.T) {
+		runInstallCommandJSONTest(t, []string{"install-cli", "--bin-dir", "/tmp/bin", "--json"}, func(app *App) {
+			app.InstallCLI = func(options install.CLIOptions) (install.CLIResult, error) {
+				return install.CLIResult{
+					LinkPath:   filepath.Join(options.BinDir, "agent-secret"),
+					TargetPath: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+				}, nil
+			}
+		}, "/tmp/bin/agent-secret")
+	})
+
+	t.Run("skill", func(t *testing.T) {
+		runInstallCommandJSONTest(t, []string{"skill-install", "--skills-dir", "/tmp/skills", "--json"}, func(app *App) {
+			app.InstallSkill = func(options install.SkillOptions) (install.SkillResult, error) {
+				return install.SkillResult{
+					LinkPath:   filepath.Join(options.SkillsDir, "agent-secret"),
+					TargetPath: "/Applications/Agent Secret.app/Contents/Resources/skills/agent-secret",
+				}, nil
+			}
+		}, "/tmp/skills/agent-secret")
 	})
 }
 
@@ -872,6 +1292,26 @@ func runInstallCommandTest(t *testing.T, args []string, configure func(*App), st
 	}
 	if !strings.Contains(stdout.String(), stdoutWant) {
 		t.Fatalf("%v stdout = %q, want %q", args, stdout.String(), stdoutWant)
+	}
+}
+
+func runInstallCommandJSONTest(t *testing.T, args []string, configure func(*App), linkPath string) {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestApp(control.Manager{}, &stdout, &stderr)
+	configure(&app)
+
+	if code := app.Run(context.Background(), args); code != 0 {
+		t.Fatalf("%v exit=%d stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+	}
+	var output installOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("%v json did not decode: %v\n%s", args, err, stdout.String())
+	}
+	if !output.Installed || output.LinkPath != linkPath {
+		t.Fatalf("%v json = %+v", args, output)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kovyrin/agent-secret/internal/buildinfo"
 	"github.com/kovyrin/agent-secret/internal/install"
 	"github.com/kovyrin/agent-secret/internal/itemmetadata"
 	"github.com/kovyrin/agent-secret/internal/request"
@@ -13,7 +12,7 @@ import (
 var (
 	ErrHelpRequested       = errors.New("help requested")
 	ErrInvalidArguments    = errors.New("invalid arguments")
-	ErrUnsupportedExecJSON = errors.New("exec does not support json output")
+	ErrUnsupportedExecJSON = errors.New("exec supports --json only with --dry-run")
 	ErrUnsupportedReuse    = errors.New("reusable approvals are chosen in the approver")
 	ErrShellStringCommand  = errors.New("command must be argv after --")
 )
@@ -23,8 +22,11 @@ type Kind string
 const (
 	KindHelp         Kind = "help"
 	KindVersion      Kind = "version"
+	KindAgentContext Kind = "agent_context"
 	KindExec         Kind = "exec"
 	KindItemDescribe Kind = "item_describe"
+	KindProfileList  Kind = "profile_list"
+	KindProfileShow  Kind = "profile_show"
 	KindDoctor       Kind = "doctor"
 	KindInstallCLI   Kind = "install_cli"
 	KindSkillInstall Kind = "skill_install"
@@ -35,11 +37,15 @@ const (
 
 type Command struct {
 	Kind                Kind
+	OutputJSON          bool
 	ExecRequest         request.ExecRequest
 	ExecEnv             []string
+	ExecDryRun          bool
 	ItemDescribeRequest request.ItemDescribeRequest
 	ItemDescribeFormat  itemmetadata.Format
 	ItemDescribePrefix  string
+	AgentContextOptions ConfigCommandOptions
+	ProfileOptions      ProfileCommandOptions
 	InstallCLIOptions   install.CLIOptions
 	InstallSkillOptions install.SkillOptions
 	HelpText            string
@@ -61,11 +67,15 @@ func (p Parser) Parse(args []string) (Command, error) {
 	case "-h", "--help", "help":
 		return Command{Kind: KindHelp, HelpText: TopHelp()}, ErrHelpRequested
 	case "-v", "--version", "version":
-		return Command{Kind: KindVersion, VersionText: buildinfo.DisplayVersion()}, nil
+		return parseVersion(args[1:])
+	case "agent-context":
+		return parseAgentContext(args[1:])
 	case "exec":
 		return p.parseExec(args[1:])
 	case "item":
 		return p.parseItem(args[1:], args)
+	case "profile":
+		return parseProfile(args[1:])
 	case "daemon":
 		return parseDaemon(args[1:])
 	case "doctor":
@@ -75,6 +85,10 @@ func (p Parser) Parse(args []string) (Command, error) {
 	case "skill-install":
 		return parseSkillInstall(args[1:])
 	default:
-		return Command{}, fmt.Errorf("%w: unknown command %q", ErrInvalidArguments, args[0])
+		return Command{}, fmt.Errorf(
+			"%w: unknown command %q; expected one of: agent-context, daemon, doctor, exec, help, install-cli, item, profile, skill-install, version",
+			ErrInvalidArguments,
+			args[0],
+		)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -837,6 +837,9 @@ func TestParseDaemonAndDoctorCommands(t *testing.T) {
 		{args: []string{"daemon", "start"}, want: KindDaemonStart},
 		{args: []string{"daemon", "stop"}, want: KindDaemonStop},
 		{args: []string{"doctor"}, want: KindDoctor},
+		{args: []string{"agent-context", "--json"}, want: KindAgentContext},
+		{args: []string{"profile", "list", "--json"}, want: KindProfileList},
+		{args: []string{"profile", "show", "--json"}, want: KindProfileShow},
 		{args: []string{"install-cli"}, want: KindInstallCLI},
 		{args: []string{"skill-install"}, want: KindSkillInstall},
 		{args: []string{"--version"}, want: KindVersion},
@@ -849,6 +852,46 @@ func TestParseDaemonAndDoctorCommands(t *testing.T) {
 		if command.Kind != tt.want {
 			t.Fatalf("Parse(%v) kind = %s, want %s", tt.args, command.Kind, tt.want)
 		}
+	}
+}
+
+func TestParseMachineReadableFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, dir, "tool")
+	parser := NewParser()
+
+	command, err := parser.Parse([]string{
+		"exec",
+		"--dry-run",
+		"--json",
+		"--reuse-only",
+		"--reason", "Preflight",
+		"--cwd", dir,
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--",
+		"./tool",
+	})
+	if err != nil {
+		t.Fatalf("Parse exec dry-run returned error: %v", err)
+	}
+	if command.Kind != KindExec || !command.ExecDryRun || !command.OutputJSON || !command.ExecRequest.ReuseOnly {
+		t.Fatalf("unexpected dry-run command: %+v", command)
+	}
+
+	command, err = parser.Parse([]string{"daemon", "status", "--json"})
+	if err != nil {
+		t.Fatalf("Parse daemon status json returned error: %v", err)
+	}
+	if command.Kind != KindDaemonStatus || !command.OutputJSON {
+		t.Fatalf("daemon status json command = %+v", command)
+	}
+
+	command, err = parser.Parse([]string{"version", "--json"})
+	if err != nil {
+		t.Fatalf("Parse version json returned error: %v", err)
+	}
+	if command.Kind != KindVersion || !command.OutputJSON {
+		t.Fatalf("version json command = %+v", command)
 	}
 }
 
@@ -963,7 +1006,12 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 		{
 			name:  "top",
 			args:  []string{"--help"},
-			wants: []string{"agent-secret controls", "exec", "item", "install-cli", "skill-install", "daemon", "doctor", "version", "desktop account"},
+			wants: []string{"agent-secret controls", "agent-context", "exec", "item", "profile", "install-cli", "skill-install", "daemon", "doctor", "version", "desktop account"},
+		},
+		{
+			name:  "agent-context",
+			args:  []string{"agent-context", "--help"},
+			wants: []string{"agent-context", "--config", "--json", "never resolves"},
 		},
 		{
 			name:  "item",
@@ -978,7 +1026,22 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 		{
 			name:  "exec",
 			args:  []string{"exec", "--help"},
-			wants: []string{"--reason", "--secret", "--profile", "--only", "--env-file", "--account", "include:", "account:", "default_profile", "agent-secret.yml", "--force-refresh", "Default account", "audit.jsonl", "stdin", "stdout", "stderr"},
+			wants: []string{"--reason", "--secret", "--profile", "--only", "--env-file", "--account", "include:", "account:", "default_profile", "agent-secret.yml", "--force-refresh", "--dry-run", "--reuse-only", "Default account", "audit.jsonl", "stdin", "stdout", "stderr"},
+		},
+		{
+			name:  "profile",
+			args:  []string{"profile", "--help"},
+			wants: []string{"profile", "list", "show", "without resolving secret values"},
+		},
+		{
+			name:  "profile list",
+			args:  []string{"profile", "list", "--help"},
+			wants: []string{"profile list", "--config", "--json"},
+		},
+		{
+			name:  "profile show",
+			args:  []string{"profile", "show", "--help"},
+			wants: []string{"profile show", "default_profile", "--config", "--json"},
 		},
 		{
 			name:  "daemon",
@@ -988,7 +1051,12 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 		{
 			name:  "doctor",
 			args:  []string{"doctor", "--help"},
-			wants: []string{"non-secret local diagnostics", "1Password"},
+			wants: []string{"non-secret local diagnostics", "1Password", "--json"},
+		},
+		{
+			name:  "version",
+			args:  []string{"version", "--help"},
+			wants: []string{"version", "--json"},
 		},
 		{
 			name:  "install-cli",

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -25,6 +25,8 @@ type execFlags struct {
 	account      string
 	overrideEnv  bool
 	forceRefresh bool
+	dryRun       bool
+	reuseOnly    bool
 	secrets      secretFlags
 	only         onlyFlags
 	envFiles     envFileFlags
@@ -80,6 +82,8 @@ func (p Parser) parseExec(args []string) (Command, error) {
 	fs.StringVar(&execOpts.account, "account", "", "1Password account")
 	fs.BoolVar(&execOpts.overrideEnv, "override-env", false, "override existing env aliases")
 	fs.BoolVar(&execOpts.forceRefresh, "force-refresh", false, "refresh reusable approval values")
+	fs.BoolVar(&execOpts.dryRun, "dry-run", false, "validate request and print preflight output without prompting or spawning")
+	fs.BoolVar(&execOpts.reuseOnly, "reuse-only", false, "use an existing reusable approval or fail without prompting")
 	jsonOutput := fs.Bool("json", false, "unsupported")
 	reuse := fs.Bool("reuse", false, "unsupported")
 	fs.Var(&execOpts.secrets, "secret", "secret mapping")
@@ -88,7 +92,7 @@ func (p Parser) parseExec(args []string) (Command, error) {
 	if err := fs.Parse(args[:boundary]); err != nil {
 		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
 	}
-	if *jsonOutput {
+	if *jsonOutput && !execOpts.dryRun {
 		return Command{}, ErrUnsupportedExecJSON
 	}
 	if *reuse {
@@ -112,12 +116,13 @@ func (p Parser) parseExec(args []string) (Command, error) {
 		ttl:          inputs.ttl,
 		overrideEnv:  execOpts.overrideEnv,
 		forceRefresh: execOpts.forceRefresh,
+		reuseOnly:    execOpts.reuseOnly,
 	})
 	if err != nil {
 		return Command{}, fmt.Errorf("build exec request: %w", err)
 	}
 
-	return Command{Kind: KindExec, ExecRequest: req, ExecEnv: inputs.env}, nil
+	return Command{Kind: KindExec, OutputJSON: *jsonOutput, ExecRequest: req, ExecEnv: inputs.env, ExecDryRun: execOpts.dryRun}, nil
 }
 
 func resolveExecInputs(flags execFlags) (execInputs, error) {

--- a/internal/cli/flag_values.go
+++ b/internal/cli/flag_values.go
@@ -18,7 +18,7 @@ func (s *secretFlags) String() string {
 func (s *secretFlags) Set(value string) error {
 	alias, ref, ok := strings.Cut(value, "=")
 	if !ok || alias == "" || ref == "" {
-		return fmt.Errorf("%w: --secret must be ALIAS=op://example", ErrInvalidArguments)
+		return fmt.Errorf("%w: --secret must be ALIAS=op://vault/item/field, for example API_TOKEN=op://Example/Item/token", ErrInvalidArguments)
 	}
 	s.specs = append(s.specs, request.SecretSpec{Alias: alias, Ref: ref})
 	return nil

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -16,8 +16,10 @@ Secrets are never printed by agent-secret and are never written to disk. The nor
 
 Commands:
 
+  agent-context Print a machine-readable command and config discovery schema.
   exec       Run a command with approved secrets injected as environment variables.
   item       Inspect 1Password item metadata without revealing secret values.
+  profile    Inspect project profiles without resolving secret values.
   install-cli Install or repair the agent-secret command symlink for this user.
   skill-install Install or repair the Agent Secret agent skill for this user.
   daemon    Troubleshoot the hidden per-user daemon: status, start, stop.
@@ -50,6 +52,8 @@ Common examples:
 
   agent-secret item describe "op://Example/Cloudflare Token"
   agent-secret item describe --format env-refs --prefix CLOUDFLARE "op://Example/Cloudflare Token"
+  agent-secret profile list --json
+  agent-secret exec --dry-run --json --profile terraform-cloudflare -- terraform plan
 
 Safety rules:
 
@@ -64,7 +68,9 @@ Safety rules:
   - ALIAS must look like an environment variable name, for example API_TOKEN.
   - With no account override, agent-secret auto-selects the local personal 1Password desktop account.
   - The wrapped command must appear after -- as argv. agent-secret does not parse shell strings.
-  - exec has no --json mode and never prints secret values.
+  - normal exec has no --json mode and never prints secret values.
+  - exec --dry-run --json validates locally without starting the daemon, prompting, resolving values, or spawning the child.
+  - exec --reuse-only uses a matching reusable approval or fails without opening a new approval prompt.
   - Text file/document refs such as op://Example/GitHub App/key.pem are injected as env values; binary attachments are not supported.
   - item describe requires approval and prints item metadata only: field labels, types, concealment flags, and refs.
   - agent-secret skill-install links the bundled Agent Secret skill into ~/.agents/skills/agent-secret.
@@ -72,7 +78,21 @@ Safety rules:
   - Audit metadata is written to ~/Library/Logs/agent-secret/audit.jsonl.
   - Non-zero child exits are returned as child exits, not as broker failures.
 
-Run agent-secret exec --help for flags and more examples.
+	Run agent-secret exec --help for flags and more examples.
+`)
+}
+
+func AgentContextHelp() string {
+	return strings.TrimSpace(`
+agent-secret agent-context prints a versioned JSON schema for agent introspection.
+
+Usage:
+
+  agent-secret agent-context [--config PATH] [--json]
+
+The output describes commands, flags, supported output formats, config discovery,
+and any profiles available from the discovered project config. It never resolves
+1Password refs or prints secret values.
 `)
 }
 
@@ -117,6 +137,53 @@ Examples:
 `)
 }
 
+func ProfileHelp() string {
+	return strings.TrimSpace(`
+agent-secret profile inspects project profile configuration without resolving secret values.
+
+Commands:
+
+  list  List profile names from agent-secret.yml or .agent-secret.yml.
+  show  Show one resolved profile, defaulting to default_profile.
+
+Run agent-secret profile list --help or agent-secret profile show --help for flags.
+`)
+}
+
+func ProfileListHelp() string {
+	return strings.TrimSpace(`
+agent-secret profile list lists profile names from the discovered project config.
+
+Usage:
+
+  agent-secret profile list [--config PATH] [--json]
+
+Flags:
+
+  --config PATH  Profile config path. Defaults to upward discovery from the current directory.
+  --json         Print machine-readable profile names and default profile metadata.
+  -h, --help     Show this help.
+`)
+}
+
+func ProfileShowHelp() string {
+	return strings.TrimSpace(`
+agent-secret profile show prints one resolved project profile without resolving secret values.
+
+Usage:
+
+  agent-secret profile show [--config PATH] [--json] [NAME]
+
+If NAME is omitted, default_profile from the config is used.
+
+Flags:
+
+  --config PATH  Profile config path. Defaults to upward discovery from the current directory.
+  --json         Print machine-readable profile details.
+  -h, --help     Show this help.
+`)
+}
+
 func ExecHelp() string {
 	return strings.TrimSpace(`
 agent-secret exec validates a command request, asks the local daemon for approved secrets, and then runs the wrapped command.
@@ -144,6 +211,9 @@ Flags:
   --ttl DURATION      Approval TTL. Defaults to profile ttl or 2m. Allowed range: 10s through 10m.
   --override-env      Allow approved aliases to replace existing child environment variables.
   --force-refresh     For matching reusable approvals, refetch approved refs before delivery.
+  --dry-run           Validate request and print preflight output without prompting or spawning.
+  --reuse-only        Use an existing reusable approval or fail without prompting.
+  --json              Print JSON output. Only valid with --dry-run.
   -h, --help          Show this help.
 
 Project profiles:
@@ -212,7 +282,6 @@ Default account:
 
 Unsupported by design:
 
-  --json              exec passes stdin/stdout/stderr through unchanged and has no JSON mode.
   --reuse             The approver decides whether an approval is reusable.
 
 Examples:
@@ -228,9 +297,14 @@ Examples:
     --secret DNS_TOKEN=op://Example/DNS/token \
     -- sh -c 'terraform plan && terraform apply'
 
+  agent-secret exec --dry-run --json --profile terraform-cloudflare -- terraform plan
+
+  agent-secret exec --reuse-only --profile terraform-cloudflare -- terraform plan
+
 Exit behavior:
 
   If approval, audit, daemon connection, or secret fetch fails before payload delivery, the child is not spawned.
+  If --reuse-only has no matching reusable approval, the child is not spawned and no new approval prompt opens.
   After the child starts, stdin, stdout, and stderr are passed through. The wrapper returns the child exit status.
   Audit metadata is written to ~/Library/Logs/agent-secret/audit.jsonl.
 `)
@@ -242,9 +316,9 @@ agent-secret daemon is for troubleshooting the hidden per-user daemon.
 
 Usage:
 
-  agent-secret daemon status
-  agent-secret daemon start
-  agent-secret daemon stop
+  agent-secret daemon status [--json]
+  agent-secret daemon start [--json]
+  agent-secret daemon stop [--json]
 
 Normal agent-secret exec use starts the daemon automatically and does not print daemon lifecycle details unless something fails.
 Daemon stop clears daemon-owned in-memory reusable approvals, use counters, nonces, and cached values. It does not signal or manage already-running child processes.
@@ -255,6 +329,21 @@ func DoctorHelp() string {
 	return strings.TrimSpace(`
 agent-secret doctor starts the daemon if needed and prints non-secret local diagnostics: platform, socket directory privacy, audit log writability, daemon status, native approver health, and 1Password desktop integration readiness.
 It never prints secret values or resolves 1Password item references.
+
+Usage:
+
+  agent-secret doctor [--json]
+`)
+}
+
+func VersionHelp() string {
+	return strings.TrimSpace(`
+agent-secret version prints the installed agent-secret version.
+
+Usage:
+
+  agent-secret version [--json]
+  agent-secret --version
 `)
 }
 
@@ -282,6 +371,7 @@ Flags:
 
   --bin-dir DIR  Directory that should contain the agent-secret command. Defaults to ~/.local/bin.
   --force        Replace an existing regular file or different symlink at DIR/agent-secret.
+  --json         Print machine-readable install result.
 `)
 }
 
@@ -309,5 +399,6 @@ Flags:
 
   --skills-dir DIR  Directory that should contain the agent-secret skill. Defaults to ~/.agents/skills.
   --force           Replace an existing regular file or different symlink at DIR/agent-secret.
+  --json            Print machine-readable install result.
 `)
 }

--- a/internal/cli/item_parse.go
+++ b/internal/cli/item_parse.go
@@ -29,7 +29,11 @@ func (p Parser) parseItem(args []string, fullArgs []string) (Command, error) {
 		return Command{Kind: KindHelp, HelpText: ItemHelp()}, ErrHelpRequested
 	}
 	if args[0] != "describe" {
-		return Command{}, fmt.Errorf("%w: unknown item subcommand %q", ErrInvalidArguments, args[0])
+		return Command{}, fmt.Errorf(
+			"%w: unknown item subcommand %q; expected one of: describe",
+			ErrInvalidArguments,
+			args[0],
+		)
 	}
 	return p.parseItemDescribe(args[1:], fullArgs)
 }

--- a/internal/cli/request_builder.go
+++ b/internal/cli/request_builder.go
@@ -22,6 +22,7 @@ type execRequestBuildOptions struct {
 	ttl          time.Duration
 	overrideEnv  bool
 	forceRefresh bool
+	reuseOnly    bool
 }
 
 func buildExecRequest(opts execRequestBuildOptions) (request.ExecRequest, error) {
@@ -63,6 +64,7 @@ func buildExecRequest(opts execRequestBuildOptions) (request.ExecRequest, error)
 		OverrideEnv:            opts.overrideEnv,
 		OverriddenAliases:      overriddenAliases,
 		ForceRefresh:           opts.forceRefresh,
+		ReuseOnly:              opts.reuseOnly,
 	})
 }
 

--- a/internal/cli/system_parse.go
+++ b/internal/cli/system_parse.go
@@ -4,9 +4,127 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/kovyrin/agent-secret/internal/buildinfo"
 	"github.com/kovyrin/agent-secret/internal/install"
 )
+
+type ConfigCommandOptions struct {
+	ConfigPath string
+}
+
+type ProfileCommandOptions struct {
+	ConfigPath string
+	Name       string
+}
+
+func parseVersion(args []string) (Command, error) {
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
+		return Command{Kind: KindHelp, HelpText: VersionHelp()}, ErrHelpRequested
+	}
+	fs := flag.NewFlagSet("version", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOutput := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() != 0 {
+		return Command{}, fmt.Errorf("%w: version accepts no positional arguments", ErrInvalidArguments)
+	}
+	return Command{Kind: KindVersion, OutputJSON: *jsonOutput, VersionText: buildinfo.DisplayVersion()}, nil
+}
+
+func parseAgentContext(args []string) (Command, error) {
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
+		return Command{Kind: KindHelp, HelpText: AgentContextHelp()}, ErrHelpRequested
+	}
+	fs := flag.NewFlagSet("agent-context", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("config", "", "profile config path")
+	fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() != 0 {
+		return Command{}, fmt.Errorf("%w: agent-context accepts no positional arguments", ErrInvalidArguments)
+	}
+	return Command{
+		Kind:                KindAgentContext,
+		OutputJSON:          true,
+		AgentContextOptions: ConfigCommandOptions{ConfigPath: *configPath},
+	}, nil
+}
+
+func parseProfile(args []string) (Command, error) {
+	if len(args) == 0 {
+		return Command{}, fmt.Errorf("%w: profile requires list or show", ErrInvalidArguments)
+	}
+	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		return Command{Kind: KindHelp, HelpText: ProfileHelp()}, ErrHelpRequested
+	}
+	switch args[0] {
+	case "list":
+		return parseProfileList(args[1:])
+	case "show":
+		return parseProfileShow(args[1:])
+	default:
+		return Command{}, fmt.Errorf(
+			"%w: unknown profile subcommand %q; expected one of: list, show",
+			ErrInvalidArguments,
+			args[0],
+		)
+	}
+}
+
+func parseProfileList(args []string) (Command, error) {
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
+		return Command{Kind: KindHelp, HelpText: ProfileListHelp()}, ErrHelpRequested
+	}
+	fs := flag.NewFlagSet("profile list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("config", "", "profile config path")
+	jsonOutput := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() != 0 {
+		return Command{}, fmt.Errorf("%w: profile list accepts no positional arguments", ErrInvalidArguments)
+	}
+	return Command{
+		Kind:           KindProfileList,
+		OutputJSON:     *jsonOutput,
+		ProfileOptions: ProfileCommandOptions{ConfigPath: *configPath},
+	}, nil
+}
+
+func parseProfileShow(args []string) (Command, error) {
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
+		return Command{Kind: KindHelp, HelpText: ProfileShowHelp()}, ErrHelpRequested
+	}
+	fs := flag.NewFlagSet("profile show", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("config", "", "profile config path")
+	jsonOutput := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() > 1 {
+		return Command{}, fmt.Errorf("%w: profile show accepts at most one profile name", ErrInvalidArguments)
+	}
+	name := ""
+	if fs.NArg() == 1 {
+		name = strings.TrimSpace(fs.Arg(0))
+		if name == "" {
+			return Command{}, fmt.Errorf("%w: profile show requires a non-empty profile name", ErrInvalidArguments)
+		}
+	}
+	return Command{
+		Kind:           KindProfileShow,
+		OutputJSON:     *jsonOutput,
+		ProfileOptions: ProfileCommandOptions{ConfigPath: *configPath, Name: name},
+	}, nil
+}
 
 func parseDaemon(args []string) (Command, error) {
 	if len(args) == 0 {
@@ -15,18 +133,29 @@ func parseDaemon(args []string) (Command, error) {
 	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
 		return Command{Kind: KindHelp, HelpText: DaemonHelp()}, ErrHelpRequested
 	}
-	if len(args) != 1 {
-		return Command{}, fmt.Errorf("%w: daemon accepts exactly one subcommand", ErrInvalidArguments)
+	subcommand := args[0]
+	fs := flag.NewFlagSet("daemon "+subcommand, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOutput := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args[1:]); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
 	}
-	switch args[0] {
+	if fs.NArg() != 0 {
+		return Command{}, fmt.Errorf("%w: daemon %s accepts no positional arguments", ErrInvalidArguments, subcommand)
+	}
+	switch subcommand {
 	case "status":
-		return Command{Kind: KindDaemonStatus}, nil
+		return Command{Kind: KindDaemonStatus, OutputJSON: *jsonOutput}, nil
 	case "start":
-		return Command{Kind: KindDaemonStart}, nil
+		return Command{Kind: KindDaemonStart, OutputJSON: *jsonOutput}, nil
 	case "stop":
-		return Command{Kind: KindDaemonStop}, nil
+		return Command{Kind: KindDaemonStop, OutputJSON: *jsonOutput}, nil
 	default:
-		return Command{}, fmt.Errorf("%w: unknown daemon subcommand %q", ErrInvalidArguments, args[0])
+		return Command{}, fmt.Errorf(
+			"%w: unknown daemon subcommand %q; expected one of: status, start, stop",
+			ErrInvalidArguments,
+			subcommand,
+		)
 	}
 }
 
@@ -34,31 +163,32 @@ func parseDoctor(args []string) (Command, error) {
 	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
 		return Command{Kind: KindHelp, HelpText: DoctorHelp()}, ErrHelpRequested
 	}
-	if len(args) != 0 {
-		return Command{}, fmt.Errorf("%w: doctor accepts no arguments", ErrInvalidArguments)
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOutput := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
 	}
-	return Command{Kind: KindDoctor}, nil
+	if fs.NArg() != 0 {
+		return Command{}, fmt.Errorf("%w: doctor accepts no positional arguments", ErrInvalidArguments)
+	}
+	return Command{Kind: KindDoctor, OutputJSON: *jsonOutput}, nil
 }
 
 func parseInstallCLI(args []string) (Command, error) {
 	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
 		return Command{Kind: KindHelp, HelpText: InstallCLIHelp()}, ErrHelpRequested
 	}
-	fs := flag.NewFlagSet("install-cli", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	binDir := fs.String("bin-dir", "", "command symlink directory")
-	force := fs.Bool("force", false, "replace an existing command file or different symlink")
-	if err := fs.Parse(args); err != nil {
-		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
-	}
-	if fs.NArg() != 0 {
-		return Command{}, fmt.Errorf("%w: install-cli accepts no positional arguments", ErrInvalidArguments)
+	flags, err := parseInstallLinkFlags(args, "install-cli", "bin-dir", "command symlink directory")
+	if err != nil {
+		return Command{}, err
 	}
 	return Command{
-		Kind: KindInstallCLI,
+		Kind:       KindInstallCLI,
+		OutputJSON: flags.jsonOutput,
 		InstallCLIOptions: install.CLIOptions{
-			BinDir: *binDir,
-			Force:  *force,
+			BinDir: flags.path,
+			Force:  flags.force,
 		},
 	}, nil
 }
@@ -67,21 +197,37 @@ func parseSkillInstall(args []string) (Command, error) {
 	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
 		return Command{Kind: KindHelp, HelpText: SkillInstallHelp()}, ErrHelpRequested
 	}
-	fs := flag.NewFlagSet("skill-install", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	skillsDir := fs.String("skills-dir", "", "agent skills directory")
-	force := fs.Bool("force", false, "replace an existing skill file or different symlink")
-	if err := fs.Parse(args); err != nil {
-		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
-	}
-	if fs.NArg() != 0 {
-		return Command{}, fmt.Errorf("%w: skill-install accepts no positional arguments", ErrInvalidArguments)
+	flags, err := parseInstallLinkFlags(args, "skill-install", "skills-dir", "agent skills directory")
+	if err != nil {
+		return Command{}, err
 	}
 	return Command{
-		Kind: KindSkillInstall,
+		Kind:       KindSkillInstall,
+		OutputJSON: flags.jsonOutput,
 		InstallSkillOptions: install.SkillOptions{
-			SkillsDir: *skillsDir,
-			Force:     *force,
+			SkillsDir: flags.path,
+			Force:     flags.force,
 		},
 	}, nil
+}
+
+type installLinkFlags struct {
+	path       string
+	force      bool
+	jsonOutput bool
+}
+
+func parseInstallLinkFlags(args []string, commandName string, pathFlag string, pathUsage string) (installLinkFlags, error) {
+	fs := flag.NewFlagSet(commandName, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String(pathFlag, "", pathUsage)
+	force := fs.Bool("force", false, "replace an existing skill file or different symlink")
+	jsonOutput := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return installLinkFlags{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() != 0 {
+		return installLinkFlags{}, fmt.Errorf("%w: %s accepts no positional arguments", ErrInvalidArguments, commandName)
+	}
+	return installLinkFlags{path: *path, force: *force, jsonOutput: *jsonOutput}, nil
 }

--- a/internal/daemon/broker/broker.go
+++ b/internal/daemon/broker/broker.go
@@ -19,6 +19,7 @@ import (
 var (
 	ErrAuditRequired             = errors.New("audit required")
 	ErrMissingCache              = errors.New("approved secret cache entry missing")
+	ErrNoReusableApproval        = errors.New("no reusable approval matches request")
 	ErrNoResolver                = errors.New("secret resolver unavailable")
 	ErrSecretResolveFailed       = errors.New("secret resolve failed")
 	ErrItemMetadataResolveFailed = errors.New("item metadata resolve failed")

--- a/internal/daemon/broker/grant_issuer.go
+++ b/internal/daemon/broker/grant_issuer.go
@@ -121,6 +121,12 @@ func (g *grantIssuer) issue(
 		return issuedGrant{}, g.requestError(ctx, req, err)
 	}
 	if issued.grant.Env == nil {
+		if req.ReuseOnly {
+			if err := g.recordReusableMiss(ctx, correlation.RequestID, req); err != nil {
+				return issuedGrant{}, g.requestError(ctx, req, err)
+			}
+			return issuedGrant{}, ErrNoReusableApproval
+		}
 		issued, err = g.freshGrant(ctx, correlation, req)
 		if err != nil {
 			return issuedGrant{}, g.requestError(ctx, req, err)
@@ -271,6 +277,12 @@ func (g *grantIssuer) recordReusableRefresh(
 ) error {
 	event := audit.FromExecRequest(audit.EventApprovalRefreshed, "", req)
 	event.ApprovalID = approval.ID
+	return recordRequiredAudit(ctx, g.audit, event)
+}
+
+func (g *grantIssuer) recordReusableMiss(ctx context.Context, requestID string, req request.ExecRequest) error {
+	event := audit.FromExecRequest(audit.EventApprovalReuseMissed, requestID, req)
+	event.ErrorCode = auditErrorCode(protocol.ErrorCodeNoReusableApproval)
 	return recordRequiredAudit(ctx, g.audit, event)
 }
 

--- a/internal/daemon/broker/reusable_grants_test.go
+++ b/internal/daemon/broker/reusable_grants_test.go
@@ -78,6 +78,51 @@ func TestBrokerReusableApprovalUsesCacheAndForceRefreshRefetches(t *testing.T) {
 	}
 }
 
+func TestBrokerReuseOnlyUsesExistingApprovalOrFailsWithoutPrompt(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	approver := &mockApprover{decision: approval.Decision{Approved: true, Reusable: true, ReusableUses: 3}}
+	resolver := &mockResolver{values: map[string]string{ref: "first"}}
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, Options{Approver: approver, Resolver: resolver, Audit: aud})
+	req := testExecRequest(t, []request.SecretSpec{{Alias: "TOKEN", Ref: ref}})
+
+	reuseOnly := req
+	reuseOnly.ReuseOnly = true
+	if _, err := deliverExecForTest(context.Background(), broker, testCorrelation("req_1", "nonce_1"), reuseOnly); !errors.Is(err, ErrNoReusableApproval) {
+		t.Fatalf("reuse-only without match error = %v, want ErrNoReusableApproval", err)
+	}
+	if approver.calls != 0 {
+		t.Fatalf("reuse-only miss opened approval prompt; calls = %d", approver.calls)
+	}
+	if len(resolver.Calls()) != 0 {
+		t.Fatalf("reuse-only miss resolved secrets: %v", resolver.Calls())
+	}
+	if !containsAuditEvent(aud.Events(), audit.EventApprovalReuseMissed) {
+		t.Fatalf("reuse-only miss did not emit audit event: %+v", aud.Events())
+	}
+
+	first, err := deliverExecForTest(context.Background(), broker, testCorrelation("req_2", "nonce_2"), req)
+	if err != nil {
+		t.Fatalf("normal reusable approval returned error: %v", err)
+	}
+	if first.approvalID == "" {
+		t.Fatal("expected reusable approval id")
+	}
+	resolver.values[ref] = "second"
+	second, err := deliverExecForTest(context.Background(), broker, testCorrelation("req_3", "nonce_3"), reuseOnly)
+	if err != nil {
+		t.Fatalf("reuse-only match returned error: %v", err)
+	}
+	if second.Env["TOKEN"] != "first" {
+		t.Fatalf("reuse-only did not use cached value: %+v", second.Env)
+	}
+	if approver.calls != 1 {
+		t.Fatalf("reuse-only match opened another approval prompt; calls = %d", approver.calls)
+	}
+}
+
 func TestBrokerReusableApprovalUsesApprovedUseLimit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/protocol/protocol.go
+++ b/internal/daemon/protocol/protocol.go
@@ -50,6 +50,7 @@ const (
 	ErrorCodeFrameTooLarge            ErrorCode = "frame_too_large"
 	ErrorCodeInvalidNonce             ErrorCode = "invalid_nonce"
 	ErrorCodeNoPendingApproval        ErrorCode = "no_pending_approval"
+	ErrorCodeNoReusableApproval       ErrorCode = "no_reusable_approval"
 	ErrorCodePeerRejected             ErrorCode = "peer_rejected"
 	ErrorCodeRequestActive            ErrorCode = "request_active"
 	ErrorCodeRequestExpired           ErrorCode = "request_expired"

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -764,6 +764,8 @@ func codeForError(err error) protocol.ErrorCode {
 		return protocol.ErrorCodeApproverIdentityMismatch
 	case errors.Is(err, approval.ErrNoPendingApproval):
 		return protocol.ErrorCodeNoPendingApproval
+	case errors.Is(err, daemonbroker.ErrNoReusableApproval):
+		return protocol.ErrorCodeNoReusableApproval
 	case errors.Is(err, ErrRequestAlreadyActive):
 		return protocol.ErrorCodeRequestActive
 	case errors.Is(err, daemonbroker.ErrDaemonStopped):

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1674,6 +1674,7 @@ func TestCodeForErrorMapsProtocolFailures(t *testing.T) {
 		{err: approval.ErrApproverPeerMismatch, want: protocol.ErrorCodeApproverPeerMismatch},
 		{err: approval.ErrApproverIdentity, want: protocol.ErrorCodeApproverIdentityMismatch},
 		{err: approval.ErrNoPendingApproval, want: protocol.ErrorCodeNoPendingApproval},
+		{err: daemonbroker.ErrNoReusableApproval, want: protocol.ErrorCodeNoReusableApproval},
 		{err: ErrRequestAlreadyActive, want: protocol.ErrorCodeRequestActive},
 		{err: daemonbroker.ErrDaemonStopped, want: protocol.ErrorCodeDaemonStopped},
 		{err: approval.ErrRequestExpired, want: protocol.ErrorCodeRequestExpired},

--- a/internal/itemmetadata/itemmetadata.go
+++ b/internal/itemmetadata/itemmetadata.go
@@ -58,7 +58,7 @@ func ParseFormat(value string) (Format, error) {
 	case FormatJSON, FormatEnvRefs:
 		return format, nil
 	default:
-		return "", fmt.Errorf("%w: %q", ErrInvalidFormat, value)
+		return "", fmt.Errorf("%w: must be one of: text, json, env-refs (got: %q)", ErrInvalidFormat, value)
 	}
 }
 

--- a/internal/profileconfig/profileconfig.go
+++ b/internal/profileconfig/profileconfig.go
@@ -34,6 +34,24 @@ type Metadata struct {
 	Account    string
 }
 
+type ConfigInfo struct {
+	SourcePath     string        `json:"source_path"`
+	Version        int           `json:"version"`
+	Account        string        `json:"account,omitempty"`
+	DefaultProfile string        `json:"default_profile,omitempty"`
+	Profiles       []ProfileInfo `json:"profiles"`
+}
+
+type ProfileInfo struct {
+	Name    string               `json:"name"`
+	Default bool                 `json:"default"`
+	Account string               `json:"account,omitempty"`
+	Reason  string               `json:"reason,omitempty"`
+	TTL     string               `json:"ttl,omitempty"`
+	Include []string             `json:"include,omitempty"`
+	Secrets []request.SecretSpec `json:"secrets,omitempty"`
+}
+
 type Profile struct {
 	Name       string
 	SourcePath string
@@ -157,6 +175,50 @@ func LoadMetadata(opts LoadOptions) (Metadata, error) {
 		SourcePath: path,
 		Account:    strings.TrimSpace(doc.Account),
 	}, nil
+}
+
+func Inspect(opts LoadOptions) (ConfigInfo, error) {
+	path, doc, err := loadConfigFile(opts)
+	if err != nil {
+		return ConfigInfo{}, err
+	}
+
+	info := ConfigInfo{
+		SourcePath:     path,
+		Version:        doc.Version,
+		Account:        strings.TrimSpace(doc.Account),
+		DefaultProfile: strings.TrimSpace(doc.DefaultProfile),
+		Profiles:       make([]ProfileInfo, 0, len(doc.Profiles)),
+	}
+	names := make([]string, 0, len(doc.Profiles))
+	for name := range doc.Profiles {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		rawProfile := doc.Profiles[name]
+		resolved, err := resolveProfile(doc, path, name, nil)
+		if err != nil {
+			return ConfigInfo{}, err
+		}
+		secrets, err := sortedSecrets(resolved.secrets, path, name)
+		if err != nil {
+			return ConfigInfo{}, err
+		}
+		profile := ProfileInfo{
+			Name:    name,
+			Default: name == info.DefaultProfile,
+			Account: resolved.account,
+			Reason:  resolved.reason,
+			Include: trimmedList(rawProfile.Include),
+			Secrets: secrets,
+		}
+		if resolved.ttl != 0 {
+			profile.TTL = resolved.ttl.String()
+		}
+		info.Profiles = append(info.Profiles, profile)
+	}
+	return info, nil
 }
 
 func loadConfigFile(opts LoadOptions) (string, configFile, error) {
@@ -344,4 +406,14 @@ func effectiveAccount(defaultAccount string, overrideAccount string) string {
 		return override
 	}
 	return strings.TrimSpace(defaultAccount)
+}
+
+func trimmedList(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }

--- a/internal/profileconfig/profileconfig_test.go
+++ b/internal/profileconfig/profileconfig_test.go
@@ -245,6 +245,55 @@ profiles:
 	}
 }
 
+func TestInspectReturnsResolvedProfilesWithoutValues(t *testing.T) {
+	root := t.TempDir()
+	writeConfig(t, filepath.Join(root, "agent-secret.yml"), `
+version: 1
+account: Default Account
+default_profile: deploy
+profiles:
+  base:
+    reason: Base reason
+    ttl: 5m
+    secrets:
+      BASE_TOKEN: op://Example/Base/token
+  deploy:
+    include:
+      - base
+    account: Deploy Account
+    reason: Deploy reason
+    secrets:
+      DEPLOY_TOKEN: op://Example/Deploy/token
+`)
+
+	info, err := Inspect(LoadOptions{StartDir: root})
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+	if info.SourcePath != filepath.Join(root, "agent-secret.yml") || info.DefaultProfile != "deploy" {
+		t.Fatalf("unexpected config info: %+v", info)
+	}
+	if len(info.Profiles) != 2 || info.Profiles[0].Name != "base" || info.Profiles[1].Name != "deploy" {
+		t.Fatalf("profiles not sorted: %+v", info.Profiles)
+	}
+	deploy := info.Profiles[1]
+	if !deploy.Default || deploy.Account != "Deploy Account" || deploy.Reason != "Deploy reason" {
+		t.Fatalf("deploy profile metadata mismatch: %+v", deploy)
+	}
+	if len(deploy.Include) != 1 || deploy.Include[0] != "base" {
+		t.Fatalf("include metadata mismatch: %+v", deploy.Include)
+	}
+	if len(deploy.Secrets) != 2 {
+		t.Fatalf("deploy secrets = %+v", deploy.Secrets)
+	}
+	if deploy.Secrets[0].Alias != "BASE_TOKEN" || deploy.Secrets[0].Ref != "op://Example/Base/token" {
+		t.Fatalf("included secret missing: %+v", deploy.Secrets)
+	}
+	if deploy.Secrets[1].Alias != "DEPLOY_TOKEN" || deploy.Secrets[1].Account != "Deploy Account" {
+		t.Fatalf("local secret mismatch: %+v", deploy.Secrets)
+	}
+}
+
 func TestLoadUsesExplicitConfigPath(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "custom.yml")
 	writeConfig(t, path, `

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -70,6 +70,7 @@ type ExecOptions struct {
 	OverrideEnv            bool
 	OverriddenAliases      []string
 	ForceRefresh           bool
+	ReuseOnly              bool
 }
 
 type ExecRequest struct {
@@ -87,6 +88,7 @@ type ExecRequest struct {
 	OverrideEnv            bool                  `json:"override_env"`
 	OverriddenAliases      []string              `json:"overridden_aliases"`
 	ForceRefresh           bool                  `json:"force_refresh"`
+	ReuseOnly              bool                  `json:"reuse_only,omitempty"`
 }
 
 func SecretAliases(secrets []Secret) []string {
@@ -243,6 +245,7 @@ func NewExec(opts ExecOptions) (ExecRequest, error) {
 		OverrideEnv:            opts.OverrideEnv,
 		OverriddenAliases:      overriddenAliases,
 		ForceRefresh:           opts.ForceRefresh,
+		ReuseOnly:              opts.ReuseOnly,
 	}, nil
 }
 
@@ -326,7 +329,7 @@ func ParseSecrets(specs []SecretSpec) ([]Secret, error) {
 	secrets := make([]Secret, 0, len(specs))
 	for _, spec := range specs {
 		if !aliasPattern.MatchString(spec.Alias) {
-			return nil, fmt.Errorf("%w: %q", ErrInvalidAlias, spec.Alias)
+			return nil, fmt.Errorf("%w: alias must match [A-Z_][A-Z0-9_]*, for example API_TOKEN (got: %q)", ErrInvalidAlias, spec.Alias)
 		}
 		if _, exists := seenAliases[spec.Alias]; exists {
 			return nil, fmt.Errorf("%w: duplicate alias %q", ErrInvalidAlias, spec.Alias)

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -206,6 +206,7 @@ func TestExecRequestJSONOmitsRawEnvironmentValues(t *testing.T) {
 	dir := t.TempDir()
 	req, err := NewExec(mutate(baseOptions(dir, "reason"), func(o *ExecOptions) {
 		o.EnvironmentFingerprint = EnvironmentFingerprint([]string{"CANARY_SECRET_ENV=do-not-serialize"})
+		o.ReuseOnly = true
 	}))
 	if err != nil {
 		t.Fatalf("NewExec returned error: %v", err)
@@ -235,6 +236,7 @@ func TestExecRequestJSONOmitsRawEnvironmentValues(t *testing.T) {
 		"override_env",
 		"overridden_aliases",
 		"force_refresh",
+		"reuse_only",
 	} {
 		if _, ok := fields[field]; !ok {
 			t.Fatalf("request JSON omitted snake_case field %q: %s", field, raw)


### PR DESCRIPTION
## Summary
- add `agent-secret agent-context --json` as a versioned machine-readable CLI capability map
- add JSON output for operational diagnostics plus `profile list/show` config introspection
- add `exec --dry-run --json` preflight output and `exec --reuse-only` no-prompt execution mode
- improve invalid command/subcommand/format/alias errors with valid choices and examples
- document the agent-facing flows and update the bundled Agent Secret skill

## Local verification
- `mise run lint`
- `mise run build`
- `mise run test`
- `npx --no-install markdownlint README.md docs/configuration.md CHANGELOG.md .agents/skills/agent-secret/SKILL.md`
- smoke-tested `agent-context --json`, `profile show --json`, `exec --dry-run --json`, `exec --dry-run --reuse-only`, JSON error output, and invalid enum errors
