### PR TITLE
[codex] Fix pre-release security batch 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ version numbers for public releases.
   toolchain from Go `1.26.3` to Go `1.26.4`.
 - Updated the markdown lint toolchain lockfile to pick up the fixed
   `brace-expansion` release.
+- Fixed pre-release hardening issues in audit-failure handling, explicit
+  1Password account precedence, uninstall trust checks, and committed public
+  documentation guardrails.
 
 ## [0.0.13] - 2026-05-27
 

--- a/approver/Sources/AgentSecretApprover/Runtime/AppKitModalDecisionCoordinator.swift
+++ b/approver/Sources/AgentSecretApprover/Runtime/AppKitModalDecisionCoordinator.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 #if canImport(AppKit)
+    import AppKit
+
     @MainActor
     final class AppKitModalDecisionCoordinator {
         private static let modalStopRunLoopModes: [RunLoop.Mode] = [

--- a/internal/cli/app_exec.go
+++ b/internal/cli/app_exec.go
@@ -217,6 +217,7 @@ func isFatalCommandStartedAuditFailure(err error) bool {
 		return false
 	}
 	return protocolErr.Code == protocol.ErrorCodeBadCommandStarted ||
+		protocolErr.Code == protocol.ErrorCodeAuditFailed ||
 		protocolErr.Code == protocol.ErrorCodeBadEnvelope ||
 		protocolErr.Code == protocol.ErrorCodeBadType ||
 		protocolErr.Code == protocol.ErrorCodeInvalidNonce ||

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1499,6 +1499,10 @@ func TestDaemonAuditReporterFatalStartedAuditClassification(t *testing.T) {
 	if !isFatalCommandStartedAuditFailure(protocolErr) {
 		t.Fatal("invalid nonce protocol error was not classified as fatal")
 	}
+	auditErr := &control.ProtocolError{Code: protocol.ErrorCodeAuditFailed, Message: "audit failed"}
+	if !isFatalCommandStartedAuditFailure(auditErr) {
+		t.Fatal("audit_failed protocol error was not classified as fatal")
+	}
 	stoppedErr := &control.ProtocolError{Code: protocol.ErrorCodeDaemonStopped, Message: "daemon stopped"}
 	if isFatalCommandStartedAuditFailure(stoppedErr) {
 		t.Fatal("daemon stopped protocol error was classified as fatal")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -387,6 +387,37 @@ func TestParseExecAccountDefaultPrecedence(t *testing.T) {
 	}
 }
 
+func TestParseExecExplicitAccountBeatsProjectConfigForDirectSecrets(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	writeExecutable(t, binDir, "tool")
+	writeProfileConfig(t, root, `
+version: 1
+account: Project Account
+`)
+	t.Chdir(root)
+	t.Setenv("PATH", binDir)
+	parser := NewParser()
+
+	command, err := parser.Parse([]string{
+		"exec",
+		"--reason", "Deploy",
+		"--account", "CLI Account",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--",
+		"tool",
+	})
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if got := command.ExecRequest.Secrets[0].Account; got != "CLI Account" {
+		t.Fatalf("direct secret account = %q, want CLI Account: %+v", got, command.ExecRequest.Secrets)
+	}
+}
+
 func TestParseExecAccountPrecedenceInCombinedSources(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -217,7 +217,7 @@ func assembleExecSecrets(
 
 func execSecretAccountFallback(flags execFlags, sources execInputSources) string {
 	accountFallback := execAccountFallback(flags.account)
-	if !sources.loadedProfile && strings.TrimSpace(sources.configAccount) != "" {
+	if strings.TrimSpace(flags.account) == "" && !sources.loadedProfile && strings.TrimSpace(sources.configAccount) != "" {
 		return sources.configAccount
 	}
 	return accountFallback

--- a/internal/daemon/broker/broker.go
+++ b/internal/daemon/broker/broker.go
@@ -449,7 +449,8 @@ func (b *Broker) ReportCompleted(ctx context.Context, correlation protocol.Corre
 	}
 
 	event := audit.FromExecRequest(audit.EventCommandCompleted, correlation.RequestID, active.req)
-	event.ExitCode = new(exitCode)
+	exit := exitCode
+	event.ExitCode = &exit
 	event.Signal = signal
 	if err := recordRequiredAudit(ctx, b.audit, event); err != nil {
 		return err

--- a/scripts/checks/test-public-docs.sh
+++ b/scripts/checks/test-public-docs.sh
@@ -21,15 +21,15 @@ scan_files=(
 )
 
 private_terms=(
-  "account: Fixture"
-  "Fixture Preview"
-  "fixture.1password.com"
+  "account: Internal Consumer"
+  "Internal Consumer Preview"
+  "internal-consumer.1password.example"
 )
 
 for term in "${private_terms[@]}"; do
   matches="$(grep -n -F -- "$term" "${scan_files[@]}" || true)"
   if [ -n "$matches" ]; then
-    fail "public docs contain private consumer name '$term': $matches"
+    fail "public docs contain private or internal consumer name '$term': $matches"
   fi
 done
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -57,7 +57,7 @@ codesign_team_id() {
 
   details="$("$codesign_path" -dv --verbose=4 "$path" 2>&1)" || return 1
   printf '%s\n' "$details" |
-    awk -F= '$1 == "TeamIdentifier" { print $2; found = 1; exit } END { if (!found) exit 1 }'
+    /usr/bin/awk -F= '$1 == "TeamIdentifier" { print $2; found = 1; exit } END { if (!found) exit 1 }'
 }
 
 team_id_matches() {


### PR DESCRIPTION
## Summary

- fix Batch 1 pre-release security findings from #286
- fail closed when `command_started` audit recording returns `audit_failed`
- preserve explicit `--account` over project config metadata for direct secret requests
- harden uninstall TeamIdentifier parsing against shell-function `awk` hijack
- remove real private consumer identifiers from the public-doc guard script
- fix the AppKit modal coordinator import and Go audit completion pointer assignment

## Validation

- `mise exec -- go test ./internal/cli ./internal/daemon/broker`
- `scripts/checks/test-public-docs.sh`
- `npx --yes markdownlint-cli CHANGELOG.md`
- `mise run lint:go`
- `mise run lint:shell`
- `mise run lint:swift`
- `mise run lint`
- `mise run build`

Refs #286
