### PR TITLE
[codex] Fix pre-release security batch 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,18 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Check out trusted release guards
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+          path: _trusted-main
+          fetch-depth: 0
 
       - name: Verify release tag ancestry
-        run: scripts/release/check-release-ancestry.sh "$GITHUB_REF_NAME"
+        run: _trusted-main/scripts/release/check-release-ancestry.sh "$GITHUB_REF_NAME"
+
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Verify changelog release notes
         run: scripts/release/extract-release-notes.sh "$GITHUB_REF_NAME" "$RUNNER_TEMP/release-notes.md"
@@ -115,13 +122,17 @@ jobs:
 
       - name: Build release artifacts
         env:
-          AGENT_SECRET_IN_MISE: "1"
           AGENT_SECRET_CODESIGN_IDENTITY: ${{ secrets.AGENT_SECRET_CODESIGN_IDENTITY }}
           AGENT_SECRET_NOTARIZE: ${{ secrets.AGENT_SECRET_NOTARIZE }}
           AGENT_SECRET_NOTARY_ISSUER_ID: ${{ secrets.AGENT_SECRET_NOTARY_ISSUER_ID }}
           AGENT_SECRET_NOTARY_KEY: ${{ secrets.AGENT_SECRET_NOTARY_KEY }}
           AGENT_SECRET_NOTARY_KEY_ID: ${{ secrets.AGENT_SECRET_NOTARY_KEY_ID }}
-        run: mise exec -- scripts/release/build-release.sh "$GITHUB_REF_NAME" --require-production-signing
+        run: |
+          trusted_mise="$HOME/.local/bin/mise"
+          test -x "$trusted_mise"
+          AGENT_SECRET_IN_MISE=1 \
+            AGENT_SECRET_TRUSTED_MISE="$trusted_mise" \
+            "$trusted_mise" exec -- scripts/release/build-release.sh "$GITHUB_REF_NAME" --require-production-signing
 
       - name: Verify release artifact architecture
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ version numbers for public releases.
 - Fixed pre-release hardening issues in audit-failure handling, explicit
   1Password account precedence, uninstall trust checks, and committed public
   documentation guardrails.
+- Hardened release builds so production signing and notarization use an
+  explicit trusted `mise` toolchain path, and release tag ancestry checks run
+  from trusted `main` content.
+- Kept the temporary 1Password SDK fork as a documented release exception
+  because upstream SDK replacement still needs live desktop-integration proof
+  before public release.
 
 ## [0.0.13] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ version numbers for public releases.
 - Kept the temporary 1Password SDK fork as a documented release exception
   because upstream SDK replacement still needs live desktop-integration proof
   before public release.
+- Added an opt-in live 1Password Desktop fork-removal matrix and confirmed the
+  temporary fork still passes a multi-account case that upstream `v0.4.0`
+  fails.
 
 ## [0.0.13] - 2026-05-27
 

--- a/docs/dependency-notes.md
+++ b/docs/dependency-notes.md
@@ -39,10 +39,14 @@ Release decision for `0.0.14`:
 - On 2026-06-03, upstream `github.com/1password/onepassword-sdk-go` `v0.4.0`
   was compile-checked against `internal/opresolver`; normal unit tests passed
   with fake SDK behavior.
-- That does not satisfy the fork removal criteria because the live opt-in
-  desktop-integration tests were not run against upstream.
+- The live opt-in fork-removal matrix in
+  `internal/opresolver/fork_matrix_integration_test.go` passed against the fork
+  with `AGENT_SECRET_LIVE_FORK_MATRIX=1`.
+- The same matrix failed against upstream `v0.4.0` in the multi-account
+  resolver case: after resolving the primary account, the fixture-account ref
+  could not find its vault/item.
 - Keep the fork for `0.0.14`; treat the scanner finding as an accepted
-  temporary dependency exception until live tests prove the criteria below.
+  temporary dependency exception until upstream passes the matrix.
 
 Removal criteria:
 

--- a/docs/dependency-notes.md
+++ b/docs/dependency-notes.md
@@ -34,6 +34,16 @@ Upstream tracking:
 - Validate a fork update with `go mod tidy`, `mise exec -- go test ./...`, and
   `mise run lint:go` from this repository.
 
+Release decision for `0.0.14`:
+
+- On 2026-06-03, upstream `github.com/1password/onepassword-sdk-go` `v0.4.0`
+  was compile-checked against `internal/opresolver`; normal unit tests passed
+  with fake SDK behavior.
+- That does not satisfy the fork removal criteria because the live opt-in
+  desktop-integration tests were not run against upstream.
+- Keep the fork for `0.0.14`; treat the scanner finding as an accepted
+  temporary dependency exception until live tests prove the criteria below.
+
 Removal criteria:
 
 - the upstream SDK exposes the item metadata APIs Agent Secret uses;

--- a/internal/opresolver/fork_matrix_integration_test.go
+++ b/internal/opresolver/fork_matrix_integration_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package opresolver
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/itemmetadata"
+)
+
+const (
+	defaultLiveForkPrimaryAccount = "my.1password.com"
+	defaultLiveForkPrimaryRef     = "op://Agent Secret Integration/Test Secret/password"
+	defaultLiveForkPrimaryItemRef = "op://Agent Secret Integration/Test Secret"
+	defaultLiveForkPrimaryTextRef = "op://Agent Secret Integration/Test Secret/test.txt"
+	defaultLiveForkFixtureAccount = "fixture.1password.com"
+	defaultLiveForkFixtureRef     = "op://Employee/Agent Secret Test/password"
+)
+
+type liveForkMatrixConfig struct {
+	primaryAccount string
+	primaryRef     string
+	primaryItemRef string
+	primaryTextRef string
+	fixtureAccount string
+	fixtureRef     string
+}
+
+func TestLiveDesktopForkRemovalMatrix(t *testing.T) {
+	cfg := loadLiveForkMatrixConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	pool := NewDesktopPoolWithOptions(DesktopPoolOptions{
+		IntegrationName:    "Agent Secret Broker SDK Fork Removal Matrix",
+		IntegrationVersion: "integration-test",
+		InitTimeout:        45 * time.Second,
+	})
+
+	primary := resolveLiveMatrixSecret(t, ctx, pool, cfg.primaryRef, cfg.primaryAccount)
+	fixture := resolveLiveMatrixSecret(t, ctx, pool, cfg.fixtureRef, cfg.fixtureAccount)
+	if primary == fixture {
+		t.Fatalf("primary and fixture refs resolved to the same value; use distinct synthetic fixture values to prove account isolation")
+	}
+
+	againPrimary := resolveLiveMatrixSecret(t, ctx, pool, cfg.primaryRef, cfg.primaryAccount)
+	if againPrimary != primary {
+		t.Fatalf("primary ref changed after resolving fixture account; account switching is not stable")
+	}
+
+	againFixture := resolveLiveMatrixSecret(t, ctx, pool, cfg.fixtureRef, cfg.fixtureAccount)
+	if againFixture != fixture {
+		t.Fatalf("fixture ref changed after switching back to primary account; account switching is not stable")
+	}
+
+	itemRef, err := itemmetadata.ParseRef(cfg.primaryItemRef)
+	if err != nil {
+		t.Fatalf("parse primary item ref: %v", err)
+	}
+	metadata, err := pool.DescribeItem(ctx, itemRef, cfg.primaryAccount)
+	if err != nil {
+		t.Fatalf("describe primary item metadata: %v", err)
+	}
+	assertLiveMatrixMetadata(t, metadata, cfg.primaryAccount, itemRef)
+	assertLiveMatrixField(t, metadata, cfg.primaryRef)
+
+	text := resolveLiveMatrixSecret(t, ctx, pool, cfg.primaryTextRef, cfg.primaryAccount)
+	if text == "" {
+		t.Fatalf("text file ref resolved to an empty value")
+	}
+}
+
+func TestLiveDesktopResolverOutlivesInitializationContext(t *testing.T) {
+	cfg := loadLiveForkMatrixConfig(t)
+
+	initCtx, cancelInit := context.WithTimeout(context.Background(), 45*time.Second)
+	resolver, err := NewDesktopResolver(initCtx, ClientOptions{
+		Account:            cfg.primaryAccount,
+		IntegrationName:    "Agent Secret Broker SDK Lifetime Matrix",
+		IntegrationVersion: "integration-test",
+	})
+	cancelInit()
+	if err != nil {
+		t.Fatalf("create desktop resolver: %v", err)
+	}
+
+	resolveCtx, cancelResolve := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancelResolve()
+
+	secret, err := resolver.ResolveSecret(resolveCtx, cfg.primaryRef)
+	if err != nil {
+		t.Fatalf("resolve after initialization context cancellation: %v", err)
+	}
+	metadata := secret.Metadata()
+	if metadata.Length == 0 || metadata.SHA256 == "" {
+		t.Fatalf("resolved secret metadata is incomplete after initialization context cancellation: %+v", metadata)
+	}
+
+	itemRef, err := itemmetadata.ParseRef(cfg.primaryItemRef)
+	if err != nil {
+		t.Fatalf("parse primary item ref: %v", err)
+	}
+	item, err := resolver.DescribeItem(resolveCtx, itemRef, cfg.primaryAccount)
+	if err != nil {
+		t.Fatalf("describe metadata after initialization context cancellation: %v", err)
+	}
+	assertLiveMatrixMetadata(t, item, cfg.primaryAccount, itemRef)
+}
+
+func loadLiveForkMatrixConfig(t *testing.T) liveForkMatrixConfig {
+	t.Helper()
+	if os.Getenv("AGENT_SECRET_LIVE_FORK_MATRIX") != "1" {
+		t.Skip("set AGENT_SECRET_LIVE_FORK_MATRIX=1 to run maintainer live 1Password desktop SDK fork-removal matrix")
+	}
+
+	cfg := liveForkMatrixConfig{
+		primaryAccount: envOrDefault("AGENT_SECRET_LIVE_PRIMARY_ACCOUNT", defaultLiveForkPrimaryAccount),
+		primaryRef:     envOrDefault("AGENT_SECRET_LIVE_PRIMARY_REF", defaultLiveForkPrimaryRef),
+		primaryItemRef: envOrDefault("AGENT_SECRET_LIVE_PRIMARY_ITEM_REF", defaultLiveForkPrimaryItemRef),
+		primaryTextRef: envOrDefault("AGENT_SECRET_LIVE_PRIMARY_TEXT_REF", defaultLiveForkPrimaryTextRef),
+		fixtureAccount: envOrDefault("AGENT_SECRET_LIVE_FIXTURE_ACCOUNT", defaultLiveForkFixtureAccount),
+		fixtureRef:     envOrDefault("AGENT_SECRET_LIVE_FIXTURE_REF", defaultLiveForkFixtureRef),
+	}
+
+	for name, value := range map[string]string{
+		"AGENT_SECRET_LIVE_PRIMARY_ACCOUNT":  cfg.primaryAccount,
+		"AGENT_SECRET_LIVE_PRIMARY_REF":      cfg.primaryRef,
+		"AGENT_SECRET_LIVE_PRIMARY_ITEM_REF": cfg.primaryItemRef,
+		"AGENT_SECRET_LIVE_PRIMARY_TEXT_REF": cfg.primaryTextRef,
+		"AGENT_SECRET_LIVE_FIXTURE_ACCOUNT":  cfg.fixtureAccount,
+		"AGENT_SECRET_LIVE_FIXTURE_REF":      cfg.fixtureRef,
+	} {
+		if strings.TrimSpace(value) == "" {
+			t.Fatalf("%s must be non-empty", name)
+		}
+	}
+
+	return cfg
+}
+
+func envOrDefault(name string, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func resolveLiveMatrixSecret(
+	t *testing.T,
+	ctx context.Context,
+	pool *DesktopPool,
+	ref string,
+	account string,
+) string {
+	t.Helper()
+	value, err := pool.Resolve(ctx, ref, account)
+	if err != nil {
+		t.Fatalf("resolve %s with account %s: %v", ref, account, err)
+	}
+	metadata := Secret{value: value}.Metadata()
+	if metadata.Length == 0 || metadata.SHA256 == "" {
+		t.Fatalf("resolved secret metadata is incomplete for %s with account %s: %+v", ref, account, metadata)
+	}
+	return value
+}
+
+func assertLiveMatrixMetadata(
+	t *testing.T,
+	metadata itemmetadata.Metadata,
+	account string,
+	ref itemmetadata.Ref,
+) {
+	t.Helper()
+	if metadata.Account != account {
+		t.Fatalf("metadata account = %q, want %q", metadata.Account, account)
+	}
+	if metadata.Vault != ref.Vault {
+		t.Fatalf("metadata vault = %q, want %q", metadata.Vault, ref.Vault)
+	}
+	if metadata.Item != ref.Item {
+		t.Fatalf("metadata item = %q, want %q", metadata.Item, ref.Item)
+	}
+	if metadata.Category == "" {
+		t.Fatalf("metadata category is empty")
+	}
+	if len(metadata.Fields) == 0 {
+		t.Fatalf("metadata fields are empty")
+	}
+}
+
+func assertLiveMatrixField(t *testing.T, metadata itemmetadata.Metadata, wantRef string) {
+	t.Helper()
+	for _, field := range metadata.Fields {
+		if field.Ref == wantRef {
+			if field.Label == "" || field.Type == "" || field.Alias == "" {
+				t.Fatalf("metadata field for %s is incomplete: %+v", wantRef, field)
+			}
+			return
+		}
+	}
+	t.Fatalf("metadata did not include expected field ref %s", wantRef)
+}

--- a/scripts/build/build-app-bundle.sh
+++ b/scripts/build/build-app-bundle.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+original_args=("$@")
+
 usage() {
   cat <<'USAGE'
 Usage:
@@ -26,10 +28,40 @@ project_root="$(cd -- "$script_dir/../.." && pwd)"
 # shellcheck disable=SC1091
 source "$project_root/scripts/lib/bundle-metadata.sh"
 
+production_toolchain_requested() {
+  [[ "${AGENT_SECRET_CODESIGN_IDENTITY:-"-"}" != "" && "${AGENT_SECRET_CODESIGN_IDENTITY:-"-"}" != "-" ]] ||
+    [[ "${AGENT_SECRET_NOTARIZE:-0}" == "1" ]]
+}
+
+require_trusted_mise() {
+  local path="${AGENT_SECRET_TRUSTED_MISE:-}"
+
+  if [[ "$path" == "" ]]; then
+    echo "build-app-bundle: production signing requires AGENT_SECRET_TRUSTED_MISE to point at the pinned mise binary" >&2
+    exit 1
+  fi
+  if [[ "$path" != /* ]]; then
+    echo "build-app-bundle: AGENT_SECRET_TRUSTED_MISE must be absolute: $path" >&2
+    exit 1
+  fi
+  if [[ ! -x "$path" ]]; then
+    echo "build-app-bundle: AGENT_SECRET_TRUSTED_MISE is not executable: $path" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$path"
+}
+
 if [[ "${AGENT_SECRET_IN_MISE:-}" != "1" ]]; then
+  if production_toolchain_requested; then
+    trusted_mise="$(require_trusted_mise)"
+    export AGENT_SECRET_IN_MISE=1
+    exec "$trusted_mise" exec -- "$0" "${original_args[@]}"
+  fi
+
   if command -v mise >/dev/null 2>&1; then
     export AGENT_SECRET_IN_MISE=1
-    exec mise exec -- "$0" "$@"
+    exec mise exec -- "$0" "${original_args[@]}"
   fi
 fi
 
@@ -113,7 +145,35 @@ resolve_path_tool() {
   printf '%s\n' "$path"
 }
 
-tool_go="$(resolve_path_tool go)"
+resolve_mise_tool() {
+  local name="$1"
+  local path=""
+  local trusted_mise=""
+
+  trusted_mise="$(require_trusted_mise)"
+  if ! path="$("$trusted_mise" which "$name")"; then
+    echo "build-app-bundle: trusted mise could not resolve required command: $name" >&2
+    exit 1
+  fi
+  if [[ "$path" != /* ]]; then
+    echo "build-app-bundle: trusted mise returned a non-absolute command path for $name: $path" >&2
+    exit 1
+  fi
+
+  require_tool "$name" "$path"
+  printf '%s\n' "$path"
+}
+
+resolve_go_tool() {
+  if production_toolchain_requested; then
+    resolve_mise_tool go
+    return
+  fi
+
+  resolve_path_tool go
+}
+
+tool_go="$(resolve_go_tool)"
 tool_swift="/usr/bin/swift"
 tool_mktemp="/usr/bin/mktemp"
 tool_rm="/bin/rm"

--- a/scripts/release/build-release.sh
+++ b/scripts/release/build-release.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+original_args=("$@")
+
 usage() {
   cat <<'USAGE'
 Usage:
@@ -25,18 +27,39 @@ project_root="$(cd -- "$script_dir/../.." && pwd)"
 output_dir="$project_root/_dist"
 require_production_signing=0
 
-if [[ "${AGENT_SECRET_IN_MISE:-}" != "1" ]]; then
-  if command -v mise >/dev/null 2>&1; then
-    export AGENT_SECRET_IN_MISE=1
-    exec mise exec -- "$0" "$@"
-  fi
-fi
-
 codesign_identity="${AGENT_SECRET_CODESIGN_IDENTITY:-"-"}"
 notarize="${AGENT_SECRET_NOTARIZE:-0}"
 notary_key="${AGENT_SECRET_NOTARY_KEY:-}"
 notary_key_id="${AGENT_SECRET_NOTARY_KEY_ID:-}"
 notary_issuer_id="${AGENT_SECRET_NOTARY_ISSUER_ID:-}"
+
+production_signing_requested() {
+  [[ "$require_production_signing" == "1" ]] ||
+    [[ "$codesign_identity" != "" && "$codesign_identity" != "-" ]] ||
+    [[ "$notarize" == "1" ]] ||
+    [[ "$notary_key" != "" ]] ||
+    [[ "$notary_key_id" != "" ]] ||
+    [[ "$notary_issuer_id" != "" ]]
+}
+
+require_trusted_mise() {
+  local path="${AGENT_SECRET_TRUSTED_MISE:-}"
+
+  if [[ "$path" == "" ]]; then
+    echo "build-release: production signing requires AGENT_SECRET_TRUSTED_MISE to point at the pinned mise binary" >&2
+    exit 1
+  fi
+  if [[ "$path" != /* ]]; then
+    echo "build-release: AGENT_SECRET_TRUSTED_MISE must be absolute: $path" >&2
+    exit 1
+  fi
+  if [[ ! -x "$path" ]]; then
+    echo "build-release: AGENT_SECRET_TRUSTED_MISE is not executable: $path" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$path"
+}
 
 if [[ $# -eq 0 ]]; then
   usage >&2
@@ -81,6 +104,19 @@ done
 if [[ "$version" == "" ]]; then
   echo "build-release: VERSION is required" >&2
   exit 2
+fi
+
+if [[ "${AGENT_SECRET_IN_MISE:-}" != "1" ]]; then
+  if production_signing_requested; then
+    trusted_mise="$(require_trusted_mise)"
+    export AGENT_SECRET_IN_MISE=1
+    exec "$trusted_mise" exec -- "$0" "${original_args[@]}"
+  fi
+
+  if command -v mise >/dev/null 2>&1; then
+    export AGENT_SECRET_IN_MISE=1
+    exec mise exec -- "$0" "${original_args[@]}"
+  fi
 fi
 
 require_production_release_signing() {

--- a/scripts/release/test-release-signing-env.sh
+++ b/scripts/release/test-release-signing-env.sh
@@ -7,6 +7,14 @@ check_script="$project_root/scripts/release/check-release-signing-env.sh"
 build_release="$project_root/scripts/release/build-release.sh"
 import_certificate="$project_root/scripts/release/import-codesign-certificate.sh"
 test_path="${PATH:-/usr/bin:/bin}"
+latest_version="$(sed -n 's/^## \[\([^]]*\)\].*/\1/p' "$project_root/CHANGELOG.md" | head -n 1)"
+if [[ "$latest_version" == "" ]]; then
+  latest_version="$(sed -n 's/^## \([^ ]*\) .*/\1/p' "$project_root/CHANGELOG.md" | head -n 1)"
+fi
+if [[ "$latest_version" == "" ]]; then
+  echo "test-release-signing-env: could not derive latest changelog version" >&2
+  exit 1
+fi
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-release-signing-test.XXXXXX")"
 cleanup() {
@@ -53,6 +61,21 @@ expect_failure "AGENT_SECRET_CODESIGN_IDENTITY must use Developer ID Team ID B6L
   "$check_script"
 
 env -i "PATH=$test_path" "${release_env[@]}" AGENT_SECRET_NOTARIZE=1 "$check_script"
+
+expect_failure "production signing requires AGENT_SECRET_TRUSTED_MISE" \
+  env -i \
+  "PATH=$test_path" \
+  "${release_env[@]}" \
+  AGENT_SECRET_NOTARIZE=1 \
+  "$build_release" "$latest_version" --require-production-signing --output "$tmp_dir/out"
+
+expect_failure "production signing requires AGENT_SECRET_TRUSTED_MISE" \
+  env -i \
+  "PATH=$test_path" \
+  AGENT_SECRET_IN_MISE=1 \
+  "${release_env[@]}" \
+  AGENT_SECRET_NOTARIZE=1 \
+  "$build_release" "$latest_version" --require-production-signing --output "$tmp_dir/out"
 
 expect_failure "production release requires AGENT_SECRET_CODESIGN_IDENTITY" \
   env -i \


### PR DESCRIPTION
## Summary

- Harden production release builds so signing/notarization require an explicit trusted `mise` binary and resolve Go through that trusted toolchain.
- Run release tag ancestry verification from trusted `main` content before executing tag-controlled release scripts.
- Keep the temporary 1Password SDK fork for this release and document why upstream replacement is not accepted.
- Add an opt-in live 1Password Desktop fork-removal matrix for the SDK behaviors that matter before switching away from the fork.

## SDK fork decision

I tested upstream `github.com/1password/onepassword-sdk-go` `v0.4.0` against `internal/opresolver`; compile/unit coverage passed, but that only proved API compatibility and fake resolver behavior.

The new live matrix was then run against both modules using maintainer 1Password Desktop fixtures:

- Current fork: passed `TestLiveDesktopForkRemovalMatrix` and `TestLiveDesktopResolverOutlivesInitializationContext`.
- Upstream `v0.4.0`: failed `TestLiveDesktopForkRemovalMatrix` in the multi-account resolver case after resolving the primary account; the fixture-account ref could not find its vault/item.

So the scanner finding remains an accepted temporary dependency exception for `0.0.14`; we should not switch to upstream until upstream passes this live matrix.

## Validation

- `mise run format`
- `mise exec -- go test ./internal/opresolver`
- `AGENT_SECRET_LIVE_FORK_MATRIX=1 mise exec -- go test -tags integration ./internal/opresolver -run 'TestLiveDesktop(ForkRemovalMatrix|ResolverOutlivesInitializationContext)$' -count=1 -timeout 6m -v`
- temporary upstream swap to `github.com/1password/onepassword-sdk-go v0.4.0` plus the same live matrix, which failed as expected in the multi-account case
- `scripts/release/test-release-signing-env.sh`
- `scripts/release/test-release-ancestry.sh`
- `scripts/checks/test-workflow-actions-pinned.sh`
- `npx --yes markdownlint-cli CHANGELOG.md docs/dependency-notes.md`
- `mise run lint && mise run build && mise run test`

Refs #286
