### PR TITLE
Fix pre-release security batch 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ version numbers for public releases.
 - Hardened the native approval prompt so Return no longer approves by default,
   large grouped requests expose exact refs immediately, and approval actions
   stay after the scrollable request context.
+- Bounded local resource use for approved secret fetches and project profile
+  loading by using a fixed secret-resolution worker pool, rejecting oversized or
+  non-regular profile config files, and capping profile include expansion.
 
 ## [0.0.13] - 2026-05-27
 

--- a/internal/daemon/broker/grant_issuer.go
+++ b/internal/daemon/broker/grant_issuer.go
@@ -416,24 +416,23 @@ func (g *grantIssuer) fetchUniqueRefs(ctx context.Context, identities []secretId
 	fetchCtx, cancelFetches := context.WithCancel(ctx)
 	defer cancelFetches()
 
-	sem := make(chan struct{}, g.fetchLimit)
-	results := make(chan uniqueRefFetchResult, len(identities))
-	for _, identity := range identities {
-		go func(identity secretIdentity) {
+	workerCount := max(min(g.fetchLimit, len(identities)), 1)
+
+	jobs := make(chan secretIdentity)
+	results := make(chan uniqueRefFetchResult, workerCount)
+	for range workerCount {
+		go g.fetchUniqueRefWorker(fetchCtx, jobs, results)
+	}
+	go func() {
+		defer close(jobs)
+		for _, identity := range identities {
 			select {
-			case sem <- struct{}{}:
+			case jobs <- identity:
 			case <-fetchCtx.Done():
 				return
 			}
-			defer func() { <-sem }()
-
-			value, err := g.resolver.Resolve(fetchCtx, identity.ref, identity.account)
-			select {
-			case results <- uniqueRefFetchResult{identity: identity, value: value, err: err}:
-			case <-fetchCtx.Done():
-			}
-		}(identity)
-	}
+		}
+	}()
 
 	resolved := make(map[secretIdentity]string, len(identities))
 	pending := make(map[secretIdentity]struct{}, len(identities))
@@ -466,6 +465,29 @@ func (g *grantIssuer) fetchUniqueRefs(ctx context.Context, identities []secretId
 	}
 
 	return uniqueRefFetch{resolved: resolved}
+}
+
+func (g *grantIssuer) fetchUniqueRefWorker(
+	ctx context.Context,
+	jobs <-chan secretIdentity,
+	results chan<- uniqueRefFetchResult,
+) {
+	for {
+		select {
+		case identity, ok := <-jobs:
+			if !ok {
+				return
+			}
+			value, err := g.resolver.Resolve(ctx, identity.ref, identity.account)
+			select {
+			case results <- uniqueRefFetchResult{identity: identity, value: value, err: err}:
+			case <-ctx.Done():
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func (g *grantIssuer) recordApprovalError(

--- a/internal/daemon/broker/grant_issuer_test.go
+++ b/internal/daemon/broker/grant_issuer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/audit"
 	"github.com/kovyrin/agent-secret/internal/daemon/approval"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
+	"github.com/kovyrin/agent-secret/internal/itemmetadata"
 	"github.com/kovyrin/agent-secret/internal/request"
 	"github.com/kovyrin/agent-secret/internal/secretcache"
 )
@@ -531,6 +533,24 @@ func assertApprovalFailureAudited(t *testing.T, tc approvalFailureAuditCase) {
 	assertAuditEventsValueFree(t, events)
 }
 
+type blockingSecretResolver struct {
+	started chan struct{}
+}
+
+func (r *blockingSecretResolver) Resolve(ctx context.Context, _ string, _ string) (string, error) {
+	r.started <- struct{}{}
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+func (r *blockingSecretResolver) DescribeItem(
+	_ context.Context,
+	_ itemmetadata.Ref,
+	_ string,
+) (itemmetadata.Metadata, error) {
+	return itemmetadata.Metadata{}, errors.New("unexpected item metadata lookup")
+}
+
 func TestBrokerDeduplicatesRefsAndPreservesEmptyValues(t *testing.T) {
 	t.Parallel()
 
@@ -674,6 +694,53 @@ func TestBrokerCancelsOutstandingFetchesAfterFirstFailure(t *testing.T) {
 	failure := events[len(events)-1]
 	if len(failure.SecretRefs) != 1 || failure.SecretRefs[0].Alias != "FAIL" || failure.SecretRefs[0].Ref != failRef {
 		t.Fatalf("fetch failure refs = %+v", failure.SecretRefs)
+	}
+}
+
+func TestBrokerSecretFetchUsesBoundedGoroutines(t *testing.T) {
+	const fetchLimit = 2
+	const refCount = 200
+
+	resolver := &blockingSecretResolver{started: make(chan struct{}, refCount)}
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, Options{
+		Approver:   &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver:   resolver,
+		Audit:      aud,
+		FetchLimit: fetchLimit,
+	})
+	secrets := make([]request.SecretSpec, 0, refCount)
+	for index := range refCount {
+		secrets = append(secrets, request.SecretSpec{
+			Alias: fmt.Sprintf("TOKEN_%03d", index),
+			Ref:   fmt.Sprintf("op://Example/Item/token-%03d", index),
+		})
+	}
+
+	before := runtime.NumGoroutine()
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := deliverExecForTest(ctx, broker, testCorrelation("req_1", "nonce_1"), testExecRequest(t, secrets))
+		errCh <- err
+	}()
+	for range fetchLimit {
+		receiveBrokerSignal(t, resolver.started, "bounded resolver did not start expected fetches")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if delta := runtime.NumGoroutine() - before; delta > 25 {
+		cancel()
+		t.Fatalf("secret fetch started too many goroutines: delta=%d for %d refs", delta, refCount)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("deliverExec returned nil error after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("deliverExec did not return after cancellation")
 	}
 }
 

--- a/internal/profileconfig/profileconfig.go
+++ b/internal/profileconfig/profileconfig.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -16,6 +17,9 @@ import (
 )
 
 const currentVersion = 1
+const maxConfigFileBytes = 1 << 20
+const maxProfileIncludeDepth = 32
+const maxProfileIncludeCount = 128
 
 var (
 	ErrConfigNotFound  = errors.New("profile config not found")
@@ -147,7 +151,7 @@ func Load(opts LoadOptions) (Profile, error) {
 		return Profile{}, fmt.Errorf("%w: %s default_profile is required when no profile name is provided", ErrProfileNotFound, path)
 	}
 
-	resolved, err := resolveProfile(doc, path, profileName, nil)
+	resolved, err := newProfileResolver(doc, path).resolve(profileName, nil)
 	if err != nil {
 		return Profile{}, err
 	}
@@ -197,7 +201,7 @@ func Inspect(opts LoadOptions) (ConfigInfo, error) {
 	slices.Sort(names)
 	for _, name := range names {
 		rawProfile := doc.Profiles[name]
-		resolved, err := resolveProfile(doc, path, name, nil)
+		resolved, err := newProfileResolver(doc, path).resolve(name, nil)
 		if err != nil {
 			return ConfigInfo{}, err
 		}
@@ -227,10 +231,9 @@ func loadConfigFile(opts LoadOptions) (string, configFile, error) {
 		return "", configFile{}, err
 	}
 
-	//nolint:gosec // G304: config path is selected from explicit project config discovery and parsed as configuration only.
-	data, err := os.ReadFile(path)
+	data, err := readConfigFile(path)
 	if err != nil {
-		return "", configFile{}, fmt.Errorf("read profile config %s: %w", path, err)
+		return "", configFile{}, err
 	}
 
 	var doc configFile
@@ -245,27 +248,95 @@ func loadConfigFile(opts LoadOptions) (string, configFile, error) {
 	return path, doc, nil
 }
 
-func resolveProfile(doc configFile, path string, profileName string, stack []string) (resolvedProfile, error) {
-	rawProfile, ok := doc.Profiles[profileName]
+func readConfigFile(path string) ([]byte, error) {
+	//nolint:gosec // G304: config path is selected from explicit project config discovery and parsed as configuration only.
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("read profile config %s: %w", path, err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat profile config %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: %s must be a regular file", ErrInvalidConfig, path)
+	}
+	if info.Size() > maxConfigFileBytes {
+		return nil, fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidConfig, path, maxConfigFileBytes)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(file, maxConfigFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read profile config %s: %w", path, err)
+	}
+	if len(data) > maxConfigFileBytes {
+		return nil, fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidConfig, path, maxConfigFileBytes)
+	}
+	return data, nil
+}
+
+type profileResolver struct {
+	doc          configFile
+	path         string
+	memo         map[string]resolvedProfile
+	includeCount int
+}
+
+func newProfileResolver(doc configFile, path string) *profileResolver {
+	return &profileResolver{
+		doc:  doc,
+		path: path,
+		memo: make(map[string]resolvedProfile),
+	}
+}
+
+func (r *profileResolver) resolve(profileName string, stack []string) (resolvedProfile, error) {
+	if cached, ok := r.memo[profileName]; ok {
+		return cloneResolvedProfile(cached), nil
+	}
+	if len(stack) >= maxProfileIncludeDepth {
+		return resolvedProfile{}, fmt.Errorf(
+			"%w: %s profile include depth exceeds %d at %q",
+			ErrInvalidConfig,
+			r.path,
+			maxProfileIncludeDepth,
+			profileName,
+		)
+	}
+
+	rawProfile, ok := r.doc.Profiles[profileName]
 	if !ok {
-		return resolvedProfile{}, fmt.Errorf("%w: %q in %s", ErrProfileNotFound, profileName, path)
+		return resolvedProfile{}, fmt.Errorf("%w: %q in %s", ErrProfileNotFound, profileName, r.path)
 	}
 	if slices.Contains(stack, profileName) {
 		cycle := append(slices.Clone(stack), profileName)
-		return resolvedProfile{}, fmt.Errorf("%w: %s profile include cycle: %s", ErrInvalidConfig, path, strings.Join(cycle, " -> "))
+		return resolvedProfile{}, fmt.Errorf("%w: %s profile include cycle: %s", ErrInvalidConfig, r.path, strings.Join(cycle, " -> "))
 	}
 
 	result := resolvedProfile{
-		account: effectiveAccount(doc.Account, rawProfile.Account),
+		account: effectiveAccount(r.doc.Account, rawProfile.Account),
 		secrets: make(map[string]resolvedSecret),
 	}
 	nextStack := append(slices.Clone(stack), profileName)
 	for _, includeName := range rawProfile.Include {
 		includeName = strings.TrimSpace(includeName)
 		if includeName == "" {
-			return resolvedProfile{}, fmt.Errorf("%w: %s profile %q has empty include", ErrInvalidConfig, path, profileName)
+			return resolvedProfile{}, fmt.Errorf("%w: %s profile %q has empty include", ErrInvalidConfig, r.path, profileName)
 		}
-		included, err := resolveProfile(doc, path, includeName, nextStack)
+		r.includeCount++
+		if r.includeCount > maxProfileIncludeCount {
+			return resolvedProfile{}, fmt.Errorf(
+				"%w: %s profile include count exceeds %d",
+				ErrInvalidConfig,
+				r.path,
+				maxProfileIncludeCount,
+			)
+		}
+		included, err := r.resolve(includeName, nextStack)
 		if err != nil {
 			return resolvedProfile{}, err
 		}
@@ -278,7 +349,7 @@ func resolveProfile(doc configFile, path string, profileName string, stack []str
 		}
 	}
 
-	ttl, err := parseTTL(rawProfile.TTL, path, profileName)
+	ttl, err := parseTTL(rawProfile.TTL, r.path, profileName)
 	if err != nil {
 		return resolvedProfile{}, err
 	}
@@ -288,13 +359,23 @@ func resolveProfile(doc configFile, path string, profileName string, stack []str
 	if ttl != 0 {
 		result.ttl = ttl
 	}
-	if err := mergeSecrets(result.secrets, rawProfile.Secrets, result.account, path, profileName); err != nil {
+	if err := mergeSecrets(result.secrets, rawProfile.Secrets, result.account, r.path, profileName); err != nil {
 		return resolvedProfile{}, err
 	}
 	if len(result.secrets) == 0 {
-		return resolvedProfile{}, fmt.Errorf("%w: %s profile %q must define or include at least one secret", ErrInvalidConfig, path, profileName)
+		return resolvedProfile{}, fmt.Errorf("%w: %s profile %q must define or include at least one secret", ErrInvalidConfig, r.path, profileName)
 	}
+	r.memo[profileName] = cloneResolvedProfile(result)
 	return result, nil
+}
+
+func cloneResolvedProfile(profile resolvedProfile) resolvedProfile {
+	return resolvedProfile{
+		account: profile.account,
+		reason:  profile.reason,
+		secrets: maps.Clone(profile.secrets),
+		ttl:     profile.ttl,
+	}
 }
 
 func Find(configPath string, startDir string) (string, error) {
@@ -319,8 +400,13 @@ func Find(configPath string, startDir string) (string, error) {
 		for _, name := range []string{"agent-secret.yml", ".agent-secret.yml"} {
 			candidate := filepath.Join(dir, name)
 			info, err := os.Stat(candidate)
-			if err == nil && !info.IsDir() {
-				return candidate, nil
+			if err == nil {
+				if info.Mode().IsRegular() {
+					return candidate, nil
+				}
+				if !info.IsDir() {
+					return "", fmt.Errorf("%w: %s must be a regular file", ErrInvalidConfig, candidate)
+				}
 			}
 			if err != nil && !errors.Is(err, os.ErrNotExist) {
 				return "", fmt.Errorf("stat profile config %s: %w", candidate, err)
@@ -347,8 +433,8 @@ func findExplicit(configPath string) (string, error) {
 		}
 		return "", fmt.Errorf("%w: %s", ErrConfigNotFound, path)
 	}
-	if info.IsDir() {
-		return "", fmt.Errorf("%w: %s is a directory", ErrInvalidConfig, path)
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%w: %s must be a regular file", ErrInvalidConfig, path)
 	}
 	return path, nil
 }

--- a/internal/profileconfig/profileconfig_test.go
+++ b/internal/profileconfig/profileconfig_test.go
@@ -2,9 +2,11 @@ package profileconfig
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -217,6 +219,39 @@ profiles:
 	_, err = Load(LoadOptions{Name: "one", StartDir: root})
 	if !errors.Is(err, ErrInvalidConfig) {
 		t.Fatalf("expected ErrInvalidConfig for include cycle, got %v", err)
+	}
+}
+
+func TestLoadRejectsExcessiveIncludeDepthAndCount(t *testing.T) {
+	root := t.TempDir()
+	var deep strings.Builder
+	deep.WriteString("version: 1\nprofiles:\n")
+	for index := range maxProfileIncludeDepth + 1 {
+		next := index + 1
+		if index == maxProfileIncludeDepth {
+			writeConfigSnippetf(t, &deep, "  p%d:\n    secrets:\n      TOKEN: op://Example/Item/token\n", index)
+			continue
+		}
+		writeConfigSnippetf(t, &deep, "  p%d:\n    include:\n      - p%d\n", index, next)
+	}
+	writeConfig(t, filepath.Join(root, "agent-secret.yml"), deep.String())
+	_, err := Load(LoadOptions{Name: "p0", StartDir: root})
+	if !errors.Is(err, ErrInvalidConfig) || !strings.Contains(err.Error(), "include depth") {
+		t.Fatalf("expected include depth ErrInvalidConfig, got %v", err)
+	}
+
+	var wide strings.Builder
+	wide.WriteString("version: 1\nprofiles:\n  deploy:\n    include:\n")
+	for index := range maxProfileIncludeCount + 1 {
+		writeConfigSnippetf(t, &wide, "      - base%d\n", index)
+	}
+	for index := range maxProfileIncludeCount + 1 {
+		writeConfigSnippetf(t, &wide, "  base%d:\n    secrets:\n      TOKEN_%d: op://Example/Item/token-%d\n", index, index, index)
+	}
+	writeConfig(t, filepath.Join(root, "agent-secret.yml"), wide.String())
+	_, err = Load(LoadOptions{Name: "deploy", StartDir: root})
+	if !errors.Is(err, ErrInvalidConfig) || !strings.Contains(err.Error(), "include count") {
+		t.Fatalf("expected include count ErrInvalidConfig, got %v", err)
 	}
 }
 
@@ -470,6 +505,27 @@ profiles:
 	}
 }
 
+func TestLoadRejectsNonRegularAndOversizedConfigFiles(t *testing.T) {
+	root := t.TempDir()
+	fifoPath := filepath.Join(root, "agent-secret.yml")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Fatalf("create fifo: %v", err)
+	}
+	_, err := Load(LoadOptions{Name: "one", ConfigPath: fifoPath})
+	if !errors.Is(err, ErrInvalidConfig) || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("expected regular-file ErrInvalidConfig, got %v", err)
+	}
+
+	largePath := filepath.Join(root, "large.yml")
+	if err := os.WriteFile(largePath, []byte(strings.Repeat("#", maxConfigFileBytes+1)), 0o600); err != nil {
+		t.Fatalf("write large config: %v", err)
+	}
+	_, err = Load(LoadOptions{Name: "one", ConfigPath: largePath})
+	if !errors.Is(err, ErrInvalidConfig) || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected oversized ErrInvalidConfig, got %v", err)
+	}
+}
+
 func TestFindPreservesExplicitConfigStatErrors(t *testing.T) {
 	root := t.TempDir()
 	filePath := filepath.Join(root, "not-a-directory")
@@ -515,5 +571,13 @@ func writeConfig(t *testing.T, path string, contents string) {
 
 	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
+	}
+}
+
+func writeConfigSnippetf(t *testing.T, builder *strings.Builder, format string, args ...any) {
+	t.Helper()
+
+	if _, err := fmt.Fprintf(builder, format, args...); err != nil {
+		t.Fatalf("write config snippet: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- replace per-secret goroutine fan-out with a fixed worker pool for approved secret resolution
- cap project profile config reads to regular files up to 1 MiB
- memoize profile include resolution and cap include depth/count to avoid exponential expansion
- add regression coverage for bounded goroutines, non-regular/oversized configs, and excessive include graphs
- update `CHANGELOG.md` for the security hardening

## Validation

- `mise exec -- go test ./internal/daemon/broker ./internal/profileconfig`
- `mise run test`
- `mise run lint`
- `mise run build`

Fixes the Batch 4 checklist items in #286 after merge.
