### PR TITLE
Fix pre-release security batch 5

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,7 +2,3 @@ title = "Agent Secret gitleaks configuration"
 
 [extend]
 useDefault = true
-
-[[allowlists]]
-description = "Ignored local desloppify tool state"
-paths = ['''^\.desloppify/''']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@ version numbers for public releases.
 - Bounded local resource use for approved secret fetches and project profile
   loading by using a fixed secret-resolution worker pool, rejecting oversized or
   non-regular profile config files, and capping profile include expansion.
+- Hardened release-adjacent scripts and installer guidance by warning about
+  stale `agent-secret` commands earlier on `PATH`, generating shell-safe zsh
+  PATH setup, keeping Cloudflare API tokens out of `curl` process arguments,
+  narrowing local secret-scan allowlists, copying git hooks instead of pointing
+  Git at tracked hook files, and pinning SSH known hosts for UTM validation.
 
 ## [0.0.13] - 2026-05-27
 

--- a/internal/cli/app_install.go
+++ b/internal/cli/app_install.go
@@ -18,8 +18,9 @@ type installOutput struct {
 }
 
 type pathWarning struct {
-	Directory string `json:"directory"`
-	Command   string `json:"command"`
+	Directory  string `json:"directory"`
+	Command    string `json:"command"`
+	ShadowedBy string `json:"shadowed_by,omitempty"`
 }
 
 func (a App) runInstallCLI(command Command) int {
@@ -42,9 +43,8 @@ func (a App) runInstallCLI(command Command) int {
 			LinkPath:      result.LinkPath,
 			TargetPath:    result.TargetPath,
 		}
-		binDir := filepath.Dir(result.LinkPath)
-		if !pathContainsDir(os.Getenv("PATH"), binDir) {
-			output.PathWarning = &pathWarning{Directory: displayHomePath(binDir), Command: zshPathSetupCommand(binDir)}
+		if warning := commandPathWarning(os.Getenv("PATH"), result.LinkPath); warning != nil {
+			output.PathWarning = warning
 		}
 		if err := a.writeJSON(output); err != nil {
 			a.stderrf("agent-secret: write install-cli json: %v\n", err)
@@ -99,29 +99,60 @@ func (a App) stderrf(format string, args ...any) {
 }
 
 func (a App) warnIfCommandDirMissingFromPath(binDir string) {
-	if pathContainsDir(os.Getenv("PATH"), binDir) {
+	warning := commandPathWarning(os.Getenv("PATH"), filepath.Join(binDir, install.CommandName))
+	if warning == nil {
+		return
+	}
+	if warning.ShadowedBy != "" {
+		a.stdoutf(
+			"\nAn earlier PATH entry contains agent-secret, so Terminal may run %s instead of %s.\n"+
+				"Remove the stale command or put %s first on PATH.\n"+
+				"For zsh, run this one-liner:\n\n"+
+				"  %s\n",
+			warning.ShadowedBy,
+			filepath.Join(warning.Directory, install.CommandName),
+			warning.Directory,
+			warning.Command,
+		)
 		return
 	}
 	a.stdoutf(
 		"\n%s is not on PATH, so `agent-secret` may not work by command name in Terminal.\n"+
 			"For zsh, run this one-liner:\n\n"+
 			"  %s\n",
-		displayHomePath(binDir),
-		zshPathSetupCommand(binDir),
+		warning.Directory,
+		warning.Command,
 	)
 }
 
-func pathContainsDir(pathValue string, dir string) bool {
-	if pathValue == "" || dir == "" {
-		return false
+func commandPathWarning(pathValue string, linkPath string) *pathWarning {
+	binDir := filepath.Dir(linkPath)
+	command := zshPathSetupCommand(binDir)
+	warning := &pathWarning{Directory: displayHomePath(binDir), Command: command}
+	if pathValue == "" || binDir == "" {
+		return warning
 	}
-	want := filepath.Clean(dir)
+	want := filepath.Clean(binDir)
 	for _, entry := range filepath.SplitList(pathValue) {
-		if entry != "" && filepath.Clean(entry) == want {
-			return true
+		if entry == "" {
+			continue
+		}
+		cleanEntry := filepath.Clean(entry)
+		if cleanEntry == want {
+			return nil
+		}
+		candidate := filepath.Join(entry, install.CommandName)
+		if executableFileExists(candidate) {
+			warning.ShadowedBy = candidate
+			return warning
 		}
 	}
-	return false
+	return warning
+}
+
+func executableFileExists(path string) bool {
+	info, err := os.Stat(path) // #nosec G703 -- probing PATH-derived candidates only checks executable existence; it does not read or execute the path.
+	return err == nil && !info.IsDir() && info.Mode()&0o111 != 0
 }
 
 func displayHomePath(path string) string {
@@ -139,23 +170,8 @@ func displayHomePath(path string) string {
 	return path
 }
 
-func shellPathPrefix(path string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return path
-	}
-	if path == home {
-		return "$HOME"
-	}
-	prefix := home + string(os.PathSeparator)
-	if suffix, ok := strings.CutPrefix(path, prefix); ok {
-		return "$HOME/" + suffix
-	}
-	return path
-}
-
 func zshPathSetupCommand(binDir string) string {
-	exportLine := fmt.Sprintf("export PATH=\"%s:$PATH\"", shellPathPrefix(binDir))
+	exportLine := fmt.Sprintf("export PATH=%s:\"$PATH\"", shellSingleQuote(binDir))
 	quotedLine := shellSingleQuote(exportLine)
 	return fmt.Sprintf(
 		"grep -qxF %s \"$HOME/.zprofile\" 2>/dev/null || printf '\\n%%s\\n' %s >> \"$HOME/.zprofile\"; exec zsh -l",

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1228,10 +1228,70 @@ func TestAppInstallCLIWarnsWhenCommandDirIsNotOnPath(t *testing.T) {
 	if !strings.Contains(stdout.String(), "is not on PATH") {
 		t.Fatalf("install-cli stdout = %q, want PATH warning", stdout.String())
 	}
-	wantOneLiner := "grep -qxF 'export PATH=\"$HOME/.local/bin:$PATH\"' \"$HOME/.zprofile\" 2>/dev/null || " +
-		"printf '\\n%s\\n' 'export PATH=\"$HOME/.local/bin:$PATH\"' >> \"$HOME/.zprofile\"; exec zsh -l"
+	wantExportLine := fmt.Sprintf("export PATH=%s:\"$PATH\"", shellSingleQuote(binDir))
+	wantQuotedLine := shellSingleQuote(wantExportLine)
+	wantOneLiner := fmt.Sprintf(
+		"grep -qxF %s \"$HOME/.zprofile\" 2>/dev/null || printf '\\n%%s\\n' %s >> \"$HOME/.zprofile\"; exec zsh -l",
+		wantQuotedLine,
+		wantQuotedLine,
+	)
 	if !strings.Contains(stdout.String(), wantOneLiner) {
 		t.Fatalf("install-cli stdout = %q, want zsh setup one-liner %q", stdout.String(), wantOneLiner)
+	}
+}
+
+func TestAppInstallCLIWarnsWhenEarlierPathEntryShadowsCommand(t *testing.T) {
+	staleBinDir := t.TempDir()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	writeExecutable(t, staleBinDir, "agent-secret")
+	t.Setenv("PATH", strings.Join([]string{staleBinDir, binDir}, string(os.PathListSeparator)))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestApp(control.Manager{}, &stdout, &stderr)
+	app.InstallCLI = func(options install.CLIOptions) (install.CLIResult, error) {
+		return install.CLIResult{
+			LinkPath:   filepath.Join(binDir, "agent-secret"),
+			TargetPath: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		}, nil
+	}
+
+	code := app.Run(context.Background(), []string{"install-cli", "--bin-dir", binDir})
+	if code != 0 {
+		t.Fatalf("install-cli exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "An earlier PATH entry contains agent-secret") ||
+		!strings.Contains(stdout.String(), filepath.Join(staleBinDir, "agent-secret")) {
+		t.Fatalf("install-cli stdout = %q, want shadowing warning", stdout.String())
+	}
+}
+
+func TestAppInstallCLIJSONReportsShadowedCommand(t *testing.T) {
+	staleBinDir := t.TempDir()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	writeExecutable(t, staleBinDir, "agent-secret")
+	t.Setenv("PATH", strings.Join([]string{staleBinDir, binDir}, string(os.PathListSeparator)))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestApp(control.Manager{}, &stdout, &stderr)
+	app.InstallCLI = func(options install.CLIOptions) (install.CLIResult, error) {
+		return install.CLIResult{
+			LinkPath:   filepath.Join(binDir, "agent-secret"),
+			TargetPath: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		}, nil
+	}
+
+	code := app.Run(context.Background(), []string{"install-cli", "--bin-dir", binDir, "--json"})
+	if code != 0 {
+		t.Fatalf("install-cli exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var output installOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("decode install output: %v", err)
+	}
+	if output.PathWarning == nil || output.PathWarning.ShadowedBy != filepath.Join(staleBinDir, "agent-secret") {
+		t.Fatalf("path warning = %+v, want shadowed command", output.PathWarning)
 	}
 }
 

--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -231,9 +231,25 @@ poll_timeout_seconds="$4"
 poll_interval_seconds="$5"
 api="https://api.cloudflare.com/client/v4"
 
+cloudflare_api() {
+  local curl_status
+  local config
+  config="$(mktemp)"
+  chmod 600 "$config"
+  {
+    printf 'header = "Authorization: Bearer %s"\n' "$CLOUDFLARE_API_TOKEN"
+    printf 'header = "Content-Type: application/json"\n'
+  } >"$config"
+  set +e
+  curl -fsS --config "$config" "$@"
+  curl_status=$?
+  set -e
+  rm -f "$config"
+  return "$curl_status"
+}
+
 account_id="$(
-  curl -fsS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    "$api/accounts" \
+  cloudflare_api "$api/accounts" \
     | jq -r '.result[0].id // empty'
 )"
 
@@ -247,8 +263,7 @@ seen_deployment=""
 
 while ((SECONDS < deadline)); do
   deployments="$(
-    curl -fsS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-      "$api/accounts/$account_id/pages/projects/$cloudflare_project/deployments?per_page=20"
+    cloudflare_api "$api/accounts/$account_id/pages/projects/$cloudflare_project/deployments?per_page=20"
   )"
 
   row="$(
@@ -284,8 +299,7 @@ while ((SECONDS < deadline)); do
   case "$stage_status" in
     success)
       zone_id="$(
-        curl -fsS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-          "$api/zones?name=$cloudflare_zone" \
+        cloudflare_api "$api/zones?name=$cloudflare_zone" \
           | jq -r '.result[0].id // empty'
       )"
 
@@ -296,9 +310,7 @@ while ((SECONDS < deadline)); do
 
       printf '[deploy-site] attempting Cloudflare cache purge for %s\n' "$cloudflare_zone"
       if ! purge_result="$(
-        curl -sS -X POST \
-          -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-          -H "Content-Type: application/json" \
+        cloudflare_api -X POST \
           --data '{"purge_everything":true}' \
           "$api/zones/$zone_id/purge_cache"
       )"; then
@@ -312,8 +324,7 @@ while ((SECONDS < deadline)); do
       ;;
     failure)
       printf '[deploy-site] Cloudflare deployment failed; build logs follow\n' >&2
-      curl -fsS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-        "$api/accounts/$account_id/pages/projects/$cloudflare_project/deployments/$deployment_id/history/logs" \
+      cloudflare_api "$api/accounts/$account_id/pages/projects/$cloudflare_project/deployments/$deployment_id/history/logs" \
         | jq -r '.result.data[]?.line // empty' >&2
       exit 1
       ;;

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -4,5 +4,15 @@ set -euo pipefail
 root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$root"
 
-git config core.hooksPath .githooks
-echo "Configured git hooks path: .githooks"
+hooks_dir="$(git rev-parse --git-path hooks)"
+mkdir -p "$hooks_dir"
+
+for hook in .githooks/*; do
+  [ -f "$hook" ] || continue
+  [ -x "$hook" ] || continue
+  cp "$hook" "$hooks_dir/$(basename "$hook")"
+  chmod 755 "$hooks_dir/$(basename "$hook")"
+done
+
+git config --unset core.hooksPath >/dev/null 2>&1 || true
+echo "Installed git hooks into $hooks_dir"

--- a/scripts/validate-utm-clean-install.sh
+++ b/scripts/validate-utm-clean-install.sh
@@ -355,12 +355,38 @@ ssh_options() {
   printf '%s\n' \
     -o BatchMode=yes \
     -o ConnectTimeout=10 \
-    -o StrictHostKeyChecking=accept-new \
+    -o StrictHostKeyChecking=yes \
     -o "Port=$ssh_port" \
     -o "UserKnownHostsFile=$report_dir/ssh-known-hosts"
   if [ -n "$ssh_key" ] && [ -f "$ssh_key" ]; then
     printf '%s\n' -i "$ssh_key"
   fi
+}
+
+ensure_ssh_known_host() {
+  local host="$1"
+  local known_hosts="$report_dir/ssh-known-hosts"
+  local lookup="$host"
+  local scan_tmp
+
+  if [ "$ssh_port" != "22" ]; then
+    lookup="[$host]:$ssh_port"
+  fi
+  mkdir -p "$(dirname -- "$known_hosts")"
+  touch "$known_hosts"
+  chmod 600 "$known_hosts"
+  if ssh-keygen -F "$lookup" -f "$known_hosts" >/dev/null 2>&1; then
+    return
+  fi
+
+  log "bootstrapping SSH host key for $lookup"
+  scan_tmp="$known_hosts.tmp.$$"
+  if ! ssh-keyscan -p "$ssh_port" -T 10 "$host" >"$scan_tmp" 2>"$report_dir/ssh-keyscan.log"; then
+    rm -f "$scan_tmp"
+    fail "could not bootstrap SSH host key for $lookup; see $report_dir/ssh-keyscan.log"
+  fi
+  cat "$scan_tmp" >>"$known_hosts"
+  rm -f "$scan_tmp"
 }
 
 ssh_target_for_host() {
@@ -376,6 +402,7 @@ ssh_probe() {
   local opts
 
   target="$(ssh_target_for_host "$host")"
+  ensure_ssh_known_host "$host"
   opts=()
   while IFS= read -r opt; do
     opts+=("$opt")


### PR DESCRIPTION
## Summary

- warn when an earlier `agent-secret` executable on `PATH` would shadow the installed command, including JSON install output
- generate shell-safe zsh PATH setup guidance for arbitrary install directories
- keep Cloudflare API tokens out of `curl` process arguments in `scripts/deploy-site.sh`
- remove the broad `.desloppify/` gitleaks allowlist
- install git hooks by copying into `.git/hooks` instead of pointing `core.hooksPath` at tracked hook code
- bootstrap a local known-hosts file for UTM validation and use `StrictHostKeyChecking=yes`

## Validation

- `mise exec -- gofmt -w internal/cli/app_install.go internal/cli/app_test.go`
- `mise run test`
- `mise run lint`
- `mise run build`

Fixes Batch 5 checklist items in #286 after merge.
