### PR TITLE
Add bounded session support

### DIFF
--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -15,6 +15,8 @@ needs to understand how to run `agent-secret`, or when migrating direct
 - Keep secret refs in command flags, env files, or `agent-secret.yml`; never
   store resolved values.
 - Use project-local profiles for repeated multi-secret workflows.
+- Use bounded sessions when a short workflow needs approved secrets in
+  different per-command combinations.
 - Migrate direct provider CLI usage to `agent-secret exec` while preserving
   command behavior.
 - Inspect 1Password item metadata when field names are unknown, without
@@ -32,6 +34,10 @@ needs to understand how to run `agent-secret`, or when migrating direct
   secret-backed runs.
 - Do not add long-lived plaintext `.env` files as a shortcut.
 - Do not commit rendered files that contain secrets.
+- Do not treat sessions as a raw secret-read API. Run each command through
+  `agent-secret with-session`.
+- Do not run long-lived interactive shells under a session. Use bounded
+  `with-session` invocations for specific commands.
 - Keep secret aliases stable and descriptive, such as
   `CLOUDFLARE_API_TOKEN`, `DATABASE_URL`, or `ANSIBLE_BECOME_PASSWORD`.
 - Keep reasons human-readable. They are shown in the approval UI and audit log.
@@ -96,6 +102,26 @@ Use an existing reusable approval without opening a new prompt:
 ```bash
 agent-secret exec --reuse-only --profile terraform-cloudflare -- terraform plan
 ```
+
+Approve a bounded multi-command session:
+
+```bash
+agent-secret session create --profile terraform-cloudflare --max-reads 3
+agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN -- \
+  terraform plan
+agent-secret with-session asess_123 \
+  --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
+  -- terraform apply
+agent-secret session destroy asess_123
+```
+
+Use sessions when the user approves a bag of secrets once and later commands
+need different subsets. `session create` accepts the same config, profile,
+env-file, and `--secret` inputs as `exec`, then returns only an opaque session
+ID. The daemon keeps resolved values in memory until TTL, read count, explicit
+destroy, or daemon stop clears them. `with-session` injects every approved alias
+by default; add `--only ALIAS[,ALIAS...]` to deliver only the aliases needed by
+that child command. Unknown aliases fail before the child process starts.
 
 Use a shell only when the shell is the command you actually want approved:
 
@@ -188,6 +214,10 @@ wrapper needs a subset of a larger profile:
 agent-secret exec --profile ansible --only CADDY_TOKEN,POSTGRES_PASSWORD -- \
   ansible-playbook site.yml --tags caddy
 ```
+
+Sessions can also start from a profile and project config. Prefer a profile
+when the same approved bag is reused by several short commands, then project a
+smaller child environment with `with-session --only` for each command.
 
 Account precedence is per-secret `account`, profile `account`, top-level
 `account`, CLI `--account`, `OP_ACCOUNT` / `AGENT_SECRET_1PASSWORD_ACCOUNT`,
@@ -406,6 +436,9 @@ Before reporting success, prove the migrated path works:
   metadata over `env`.
 - For profile changes, test at least one full-profile invocation and any
   `--only` wrapper that filters aliases.
+- For session workflows, test `session create`, `session list`, at least one
+  full `with-session` invocation, any `with-session --only` subsets, and
+  session exhaustion or `session destroy`.
 - For `--env-file` migrations, test that the real command receives both a
   secret-backed variable and at least one plain env-file variable without
   printing either secret value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ version numbers for public releases.
 - Added bounded session support with `agent-secret session create|list|destroy`
   and `agent-secret with-session` for multi-command workflows that keep values
   in daemon memory and inject them only into wrapped child processes.
+- Added `agent-secret with-session --only` to inject a per-command subset of an
+  approved session's aliases.
 - Added metadata-only session audit events for create, resolve, and destroy.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
+## [0.0.18] - Pending
+
+### Added
+
+- Added bounded session support with `agent-secret session create|list|destroy`
+  and `agent-secret with-session` for multi-command workflows that keep values
+  in daemon memory and inject them only into wrapped child processes.
+- Added metadata-only session audit events for create, resolve, and destroy.
+
+### Fixed
+
+- Avoided 1Password desktop account discovery when parsing Bitwarden-only
+  secret requests or invalid `exec` requests that can be rejected first.
+
 ## [0.0.17] - 2026-06-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ version numbers for public releases.
   approved session's aliases.
 - Added metadata-only session audit events for create, resolve, and destroy.
 
+### Changed
+
+- Updated the configuration reference, bundled coding-agent skill, public
+  website, and session E2E runbook links for bounded session workflows.
+
 ### Fixed
 
 - Avoided 1Password desktop account discovery when parsing Bitwarden-only

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ Use an existing reusable approval without opening a new prompt:
 agent-secret exec --reuse-only --profile terraform-cloudflare -- terraform plan
 ```
 
+Approve a bounded multi-command session and run commands through the wrapper:
+
+```bash
+agent-secret session create --profile terraform-cloudflare --max-reads 2
+agent-secret with-session asess_123 -- terraform plan
+agent-secret with-session asess_123 -- terraform apply
+agent-secret session destroy asess_123
+```
+
 Inspect item metadata without revealing values:
 
 ```bash
@@ -183,6 +192,10 @@ precedence, env-file migration, and the full schema.
 ## Commands
 
 - `agent-secret exec -- COMMAND [ARG...]`: run a command with approved secrets.
+- `agent-secret session create|list|destroy`: manage bounded daemon-held
+  sessions.
+- `agent-secret with-session SESSION_ID -- COMMAND [ARG...]`: run one command
+  with secrets from an approved session.
 - `agent-secret item describe REF`: inspect 1Password item fields without
   values.
 - `agent-secret agent-context --json`: print a machine-readable command and
@@ -221,8 +234,9 @@ Out of scope:
   app or helper, or a malicious approved child process.
 - Hiding env vars from the operating-system APIs needed to launch the approved
   child process.
-- Cross-platform secret management, background updates, session handles,
-  credential helpers, file-descriptor delivery, or socket value reads.
+- Cross-platform secret management, background updates, credential helpers,
+  file-descriptor delivery, arbitrary long-lived shells, or raw socket value
+  reads.
 
 Read [Threat Model](docs/threat-model.md) for the detailed model and review
 ledger. Use the [Security Policy](SECURITY.md) for private vulnerability
@@ -234,7 +248,8 @@ The launch build is intentionally narrow:
 
 - macOS on Apple Silicon only.
 - 1Password Desktop and Bitwarden Secrets Manager only; no other providers yet.
-- `agent-secret exec` only; no long-lived shell sessions.
+- Sessions are bounded, daemon-memory only, and usable only through
+  `agent-secret with-session`; no long-lived interactive shells.
 - No writing, updating, or rotating secrets yet.
 - No GCP Secret Manager or GCP token minting support yet.
 - No sandbox guarantee after you approve a child process.

--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ Approve a bounded multi-command session and run commands through the wrapper:
 
 ```bash
 agent-secret session create --profile terraform-cloudflare --max-reads 2
-agent-secret with-session asess_123 -- terraform plan
-agent-secret with-session asess_123 -- terraform apply
+agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN -- terraform plan
+agent-secret with-session asess_123 \
+  --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
+  -- terraform apply
 agent-secret session destroy asess_123
 ```
 
@@ -178,6 +180,7 @@ profiles:
     ttl: 10m
     secrets:
       CLOUDFLARE_API_TOKEN: op://Example/Cloudflare/token
+      STATE_TOKEN: op://Example/Terraform State/token
 ```
 
 With `default_profile`, this works from the project directory:
@@ -195,7 +198,8 @@ precedence, env-file migration, and the full schema.
 - `agent-secret session create|list|destroy`: manage bounded daemon-held
   sessions.
 - `agent-secret with-session SESSION_ID -- COMMAND [ARG...]`: run one command
-  with secrets from an approved session.
+  with secrets from an approved session. Add `--only ALIAS[,ALIAS...]` to inject
+  a per-command subset of the approved session bag.
 - `agent-secret item describe REF`: inspect 1Password item fields without
   values.
 - `agent-secret agent-context --json`: print a machine-readable command and

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ scripts/release/build-release.sh v0.0.0-dev
 ## Documentation
 
 - [Configuration Reference](docs/configuration.md)
+- [Session E2E Validation](docs/session-e2e-validation.md)
 - [Threat Model](docs/threat-model.md)
 - [Release Process](docs/release-process.md)
 - [Security Policy](SECURITY.md)

--- a/approver/Sources/AgentSecretApprover/Models/ApprovalOperation.swift
+++ b/approver/Sources/AgentSecretApprover/Models/ApprovalOperation.swift
@@ -4,4 +4,5 @@ import Foundation
 public enum ApprovalOperation: String, Codable, Equatable, Sendable {
     case exec
     case itemDescribe = "item_describe"
+    case sessionCreate = "session_create"
 }

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+Expiration.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+Expiration.swift
@@ -39,10 +39,18 @@ extension ApprovalRequestViewModel {
 
             case .itemDescribe:
                 return "This item metadata request has expired."
+
+            case .sessionCreate:
+                return "This session access request has expired."
             }
         }
         if operation == .itemDescribe {
             return "Allow this command to inspect this 1Password item?"
+        }
+        if operation == .sessionCreate {
+            return resourceCount == 1 ?
+                "Allow this session to use the following secret?" :
+                "Allow this session to use the following \(resourceCount) secrets?"
         }
         if resourceCount == 1 {
             return "Allow this command to use the following secret?"
@@ -57,6 +65,9 @@ extension ApprovalRequestViewModel {
         if operation == .itemDescribe {
             return "wants item metadata access."
         }
+        if operation == .sessionCreate {
+            return "wants short session access."
+        }
         return "wants temporary access."
     }
 
@@ -70,6 +81,12 @@ extension ApprovalRequestViewModel {
             Secret values are never shown to the agent or stored on disk.
             """
         }
+        if operation == .sessionCreate {
+            return """
+            The session keeps approved values in daemon memory only.
+            Values are injected only by with-session and are never printed.
+            """
+        }
         let noun: String = resourceCount == 1 ? "secret is" : "secrets are"
         let pronoun: String = resourceCount == 1 ? "It is" : "They are"
         return """
@@ -81,9 +98,9 @@ extension ApprovalRequestViewModel {
     static func scopeSummary(uses: Int, remaining: String, expired: Bool, allowsReusable: Bool) -> String {
         if !allowsReusable {
             if expired {
-                return "One metadata lookup only\nrequest expired"
+                return "One approved operation only\nrequest expired"
             }
-            return "One metadata lookup only\nexpires in \(remaining)"
+            return "One approved operation only\nexpires in \(remaining)"
         }
         if expired {
             return "Same command only • max \(uses) uses\nrequest expired"

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+Inspection.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+Inspection.swift
@@ -43,6 +43,9 @@ extension ApprovalRequestViewModel {
 
         case .itemDescribe:
             "Item metadata:"
+
+        case .sessionCreate:
+            "Session secrets:"
         }
     }
 

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+Operation.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+Operation.swift
@@ -8,12 +8,18 @@ extension ApprovalRequestViewModel {
 
         case .itemDescribe:
             "Item Metadata Request"
+
+        case .sessionCreate:
+            "Session Access Request"
         }
     }
 
     static func requestedResourcesHeading(operation: ApprovalOperation, resourceCount: Int) -> String {
         if operation == .itemDescribe {
             return "Requested item metadata"
+        }
+        if operation == .sessionCreate {
+            return resourceCount == 1 ? "Session secret" : "Session secrets (\(resourceCount))"
         }
         if resourceCount == 1 {
             return "Requested secret"

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel.swift
@@ -2,28 +2,6 @@ import Foundation
 
 /// Sanitized text prepared for the approval UI.
 struct ApprovalRequestViewModel: Equatable {
-    private struct ResourcePresentation {
-        let rows: [RequestedResourceRowViewModel]
-        let rowText: [String]
-        let count: Int
-        let vaultGroups: [ResourceVaultGroupViewModel]
-        let vaultCount: Int
-    }
-
-    private struct SelfRenderInput {
-        let title: String
-        let reason: String
-        let command: String
-        let commandArgumentRows: [String]
-        let cwd: String
-        let scopeSummary: String
-        let resolvedExecutable: String
-        let allowMutableExecutable: Bool
-        let resourceRows: [String]
-        let timeRemaining: String
-        let cautionMessages: [String]
-    }
-
     private static let highScopeResourceThreshold: Int = 6
     private static let commandInspectorThreshold: Int = 96
     private static let secondsPerMinute: Int = 60
@@ -67,7 +45,7 @@ struct ApprovalRequestViewModel: Equatable {
             operation: operation,
             allowsReusableApproval: allowsReusableApproval,
             reusableUses: reusableUses,
-            viewModel: SelfRenderInput(
+            viewModel: ApprovalRequestViewModelRenderInput(
                 title: title,
                 reason: reason,
                 command: command,
@@ -97,7 +75,9 @@ struct ApprovalRequestViewModel: Equatable {
         command = Self.commandDisplay(commandArguments)
         commandNeedsInspector = Self.commandNeedsInspector(command, arguments: commandArguments)
         commandInspectionText = Self.commandInspectionText(commandArguments)
-        let resourcePresentation: ResourcePresentation = Self.resourcePresentation(for: request.resources)
+        let resourcePresentation: ResourcePresentation = Self.resourcePresentation(
+            for: request.resources
+        )
         requestedResources = resourcePresentation.rows
         requestedResourcesHeading = Self.requestedResourcesHeading(
             operation: request.operation,
@@ -110,7 +90,8 @@ struct ApprovalRequestViewModel: Equatable {
         let copy: CopyPresentation = Self.copyPresentation(for: request, count: resourcePresentation.count, now: now)
         (isExpired, timeRemaining, compactTimeRemaining) = (copy.isExpired, copy.timeRemaining, copy.timeRemaining)
         (promptQuestion, accessSummary) = (copy.promptQuestion, copy.accessSummary)
-        highScopeWarning = request.operation == .exec && resourcePresentation.count >= Self.highScopeResourceThreshold
+        highScopeWarning = request.operation != .itemDescribe &&
+            resourcePresentation.count >= Self.highScopeResourceThreshold
         (reusableUses, allowsReusableApproval) = (request.reusableUses, request.allowsReusable)
         (scopeSummary, allowReusableTitle) = (copy.scopeSummary, copy.allowReusableTitle)
         let warnings: WarningPresentation = Self.warningPresentation(for: request, highScopeWarning: highScopeWarning)
@@ -134,7 +115,9 @@ struct ApprovalRequestViewModel: Equatable {
         )
     }
 
-    private static func resourcePresentation(for resources: [RequestedResource]) -> ResourcePresentation {
+    private static func resourcePresentation(
+        for resources: [RequestedResource]
+    ) -> ResourcePresentation {
         let rows: [RequestedResourceRowViewModel] = resources.map(RequestedResourceRowViewModel.init(resource:))
         let rowText: [String] = rows.map { resource -> String in
             Self.resourceRowText(resource)
@@ -176,7 +159,7 @@ struct ApprovalRequestViewModel: Equatable {
         operation: ApprovalOperation,
         allowsReusableApproval: Bool,
         reusableUses: Int,
-        viewModel: SelfRenderInput
+        viewModel: ApprovalRequestViewModelRenderInput
     ) -> String {
         var lines: [String] = [
             viewModel.title,
@@ -191,7 +174,13 @@ struct ApprovalRequestViewModel: Equatable {
         ])
         lines.append("Resolved binary: \(viewModel.resolvedExecutable)")
         lines.append("Mutable executable allowed: \(viewModel.allowMutableExecutable ? "yes" : "no")")
-        lines.append(operation == .itemDescribe ? "Item metadata:" : "Secrets:")
+        if operation == .itemDescribe {
+            lines.append("Item metadata:")
+        } else if operation == .sessionCreate {
+            lines.append("Session secrets:")
+        } else {
+            lines.append("Secrets:")
+        }
         lines.append(contentsOf: viewModel.resourceRows)
         lines.append("Time remaining: \(viewModel.timeRemaining)")
         if allowsReusableApproval {
@@ -199,8 +188,12 @@ struct ApprovalRequestViewModel: Equatable {
                 "Reusable approval keeps values in daemon memory for this window " +
                     "and is limited to \(reusableUses) uses."
             )
-        } else {
+        } else if operation == .itemDescribe {
             lines.append("Approval is limited to one metadata lookup.")
+        } else if operation == .sessionCreate {
+            lines.append("Approval creates one short session and keeps values in daemon memory.")
+        } else {
+            lines.append("Approval is limited to one operation.")
         }
         lines.append(contentsOf: viewModel.cautionMessages)
         return lines.joined(separator: "\n")

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModelRenderInput.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModelRenderInput.swift
@@ -1,0 +1,13 @@
+struct ApprovalRequestViewModelRenderInput {
+    let title: String
+    let reason: String
+    let command: String
+    let commandArgumentRows: [String]
+    let cwd: String
+    let scopeSummary: String
+    let resolvedExecutable: String
+    let allowMutableExecutable: Bool
+    let resourceRows: [String]
+    let timeRemaining: String
+    let cautionMessages: [String]
+}

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ResourcePresentation.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ResourcePresentation.swift
@@ -1,0 +1,7 @@
+struct ResourcePresentation {
+    let rows: [RequestedResourceRowViewModel]
+    let rowText: [String]
+    let count: Int
+    let vaultGroups: [ResourceVaultGroupViewModel]
+    let vaultCount: Int
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -302,6 +302,73 @@ The resolved file contents are injected into the alias environment variable
 with multiline text preserved. Agent Secret does not create a temp file for the
 value and env-var delivery does not support binary attachments with NUL bytes.
 
+## Session Commands
+
+Sessions approve one bag of secret references, keep the resolved values in
+daemon memory, and let later child commands consume that bag only through
+`agent-secret with-session`. Use them for bounded workflows where a user
+approves several secrets once and subsequent commands need those secrets in
+different combinations.
+
+```bash
+agent-secret session create [flags]
+agent-secret with-session SESSION_ID [--cwd DIR] \
+  [--only ALIAS[,ALIAS...]] [--allow-mutable-executable] -- COMMAND [ARG...]
+agent-secret session list [--json]
+agent-secret session destroy [--json] SESSION_ID
+```
+
+`session create` accepts the same secret-source flags as `exec`:
+
+- `--reason TEXT`
+- `--secret ALIAS=REF`
+- `--env-file PATH`
+- `--profile NAME`
+- `--only ALIAS[,ALIAS...]`
+- `--account ACCOUNT`
+- `--config PATH`
+- `--cwd DIR`
+- `--ttl DURATION`
+- `--override-env`
+- `--json`
+
+It also accepts `--max-reads COUNT`, which limits the number of successful
+`with-session` reads. The default is `1`; the allowed range is `1` through
+`20`.
+
+For example, approve a project profile plus a one-off CLI reference, then use
+different aliases for different commands:
+
+```bash
+agent-secret session create \
+  --profile terraform-cloudflare \
+  --secret STATE_TOKEN=op://Example/Terraform\ State/token \
+  --max-reads 3 \
+  --json
+
+agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN -- \
+  terraform plan
+
+agent-secret with-session asess_123 \
+  --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
+  -- terraform apply
+```
+
+`session create` returns only an opaque session ID and non-secret metadata. It
+does not print secret values. Without `--only`, `with-session` injects every
+approved session alias into that child process. With `--only`, it injects only
+the requested approved aliases. If any requested alias was not in the approved
+session, Agent Secret fails before spawning the child command.
+
+`with-session` accepts `--cwd DIR`, `--only ALIAS[,ALIAS...]`, and
+`--allow-mutable-executable`. The `--cwd` value defaults to the caller's current
+directory and must match the session working directory.
+
+Sessions are daemon-memory only. They expire when TTL passes, the read count is
+exhausted, `agent-secret session destroy SESSION_ID` succeeds, or the daemon
+stops. V1 sessions intentionally do not expose raw socket value reads,
+credential-helper protocols, or long-lived interactive shells.
+
 ## Agent-Friendly Introspection
 
 Agents can ask Agent Secret for a machine-readable summary of the current CLI

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -8,8 +8,9 @@ Agent Secret Broker is a local, macOS-first system for letting coding agents use
 1Password-backed secrets without making the agent a trusted secret holder. The
 agent requests exact secret references with a reason and a bounded policy. A
 local broker presents a native approval prompt, fetches approved secrets through
-the official 1Password SDK, and delivers them through CLI-supervised execution.
-Short-lived capability modes remain future work.
+the official 1Password SDK, and delivers them through CLI-supervised execution
+or bounded session wrappers. Session values stay in daemon memory and are
+injected only into approved child processes.
 
 The first user is a local developer running coding agents such as Codex, Claude
 Code, Cursor agent, or similar tools. The first practical workflow is running
@@ -19,9 +20,10 @@ local infrastructure commands, such as Terraform, that need credentials from
 ## Initial Product Stance
 
 The initial public release is a narrow macOS Apple Silicon tool for real local
-agent workflows. Success means the shipped `agent-secret exec` path is useful,
-auditable, and honest about its limits before the project expands into more
-platforms, secret backends, or delivery modes.
+agent workflows. Success means the shipped `agent-secret exec` and bounded
+`session create`/`with-session` paths are useful, auditable, and honest about
+their limits before the project expands into more platforms, secret backends, or
+delivery modes.
 
 Open-source readiness is a release constraint. The project keeps clean
 boundaries, avoids external runtime dependencies, maintains honest docs, and
@@ -42,9 +44,9 @@ agent-initiated access.
 user's 1Password account right now?
 
 Agent Secret Broker answers: is this specific agent request allowed to use these
-exact secret references for this stated reason, command, TTL, and delivery
-surface? In MVP, the delivery surface is implicit env-mode `exec`; it is kept in
-policy and reuse keys but not shown in the approval prompt.
+exact secret references for this stated reason, command or workflow, TTL, and
+delivery surface? In v1, delivery surfaces are implicit env-mode `exec` and
+bounded `with-session` wrappers; the surface is kept in policy and audit data.
 
 ## Goals
 
@@ -57,11 +59,14 @@ policy and reuse keys but not shown in the approval prompt.
 - Never print secret values to the console or return them to the agent.
 - Support command execution through `agent-secret exec` as the default delivery
   mode.
-- Leave room for future short-lived sessions, opaque per-secret handles, and
-  credential-helper integrations without shipping them in the initial release.
+- Support bounded multi-command sessions through `agent-secret session create`
+  and `agent-secret with-session`.
+- Leave room for future opaque per-secret handles, credential-helper
+  integrations, and raw socket reads without making them part of the first
+  session slice.
 - Keep secret values in memory only by default.
-- Enforce TTL, requested secret references, command, cwd, UID, strict macOS peer/process
-  checks for session/socket reads, and max reads only for session/socket reads.
+- Enforce TTL, requested secret references, command, cwd, UID, strict macOS
+  peer/process checks for session reads, and max reads for sessions.
 - Write metadata-only audit logs that never include secret values.
 - Keep the trusted core small enough to audit.
 - Keep this project independent from external project code and runtime
@@ -115,7 +120,7 @@ The same initial path should support Ansible commands that need environment-prov
 credentials, inventory access tokens, SSH-related variables, or cloud provider
 credentials. Terraform and Ansible are representative validation workflows.
 
-### Future Use Case: Multi-Step Deployment Session
+### Use Case 2: Bounded Multi-Step Deployment Session
 
 An agent requests a short session for a bounded workflow such as:
 
@@ -125,11 +130,11 @@ terraform apply
 ansible-playbook site.yml --check
 ```
 
-The user approves once for a TTL. The broker returns a session ID or opaque
-handles, and subsequent commands must run through broker wrappers such as
-`agent-secret with-session`.
-
-This is not shipped in the initial public release.
+The user approves once for a TTL and max-read count. The broker returns an
+opaque session ID, keeps values in daemon memory, and subsequent commands must
+run through `agent-secret with-session`. The wrapper resolves values over the
+daemon command channel and injects them only into the approved child process.
+V1 sessions do not add generic socket reads or credential-helper protocols.
 
 ### Use Case 3: Config-Driven Secret Sync
 
@@ -225,14 +230,16 @@ agent / Codex
 
 - Collect structured requests from agents and users.
 - Talk to `agent-secretd` over a local Unix domain socket.
-- Provide `exec`, daemon management, and `doctor` commands in MVP; add
-  `session` and `with-session` commands after the `exec` path is proven.
+- Provide `exec`, `session`, `with-session`, daemon management, and `doctor`
+  commands.
 - Never print raw secret values.
 - In `exec` mode, resolve the executable path and cwd, request an approved
   environment payload from the daemon, spawn the child process, wait for it, and
   report child lifecycle metadata back to the daemon.
+- In session mode, create/list/destroy daemon-held sessions and run each command
+  through `with-session`.
 - Preserve the target command's exit code or signal-based exit status in `exec`
-  mode.
+  and `with-session` modes.
 - Hold approved secret values only transiently in memory while preparing the
   child environment.
 
@@ -240,7 +247,7 @@ agent / Codex
 
 - Own all security policy and enforcement.
 - Own all communication with the 1Password SDK.
-- Store reusable approval secret values in memory only.
+- Store reusable approval and session secret values in memory only.
 - Return approved secret payloads to trusted CLI wrappers over the single
   per-user daemon socket.
 - Never spawn, supervise, signal, or wait for `exec` child processes.
@@ -349,10 +356,10 @@ Each approved request should bind these fields:
   max-use count
 
 The broker rejects access if the request is expired, the requested
-reference/alias is not approved, the reusable use count is exhausted, the
-command or cwd policy mismatches, the nonce is invalid, or the request was
-denied or canceled. Future session/socket modes must add session IDs,
-per-secret read counts, and strict peer-policy checks.
+reference/alias is not approved, the reusable or session read count is
+exhausted, the command or cwd policy mismatches, the nonce is invalid, the
+session ID is unknown, peer metadata mismatches, or the request was denied or
+canceled.
 
 For `agent-secret exec`, `--cwd` is operational. It sets the child process
 working directory, defaults to the caller's current cwd when omitted, and is part
@@ -512,18 +519,18 @@ Duplicate aliases are invalid. Duplicate references are allowed when different a
 need the same value. Duplicate references are deduplicated for fetch and cache
 purposes, then expanded back to the approved alias set for delivery.
 
-Future session/socket reads require peer PID and executable checks on supported
-macOS versions. A local probe on macOS 26.3 with the macOS 26.2 SDK confirmed
-that a Unix socket server can obtain peer UID/GID, peer PID, executable path, and
-cwd using public Darwin APIs (`getpeereid`, `LOCAL_PEERPID`, `LOCAL_PEERCRED`,
+Session resolution requires peer PID and executable checks on supported macOS
+versions. A local probe on macOS 26.3 with the macOS 26.2 SDK confirmed that a
+Unix socket server can obtain peer UID/GID, peer PID, executable path, and cwd
+using public Darwin APIs (`getpeereid`, `LOCAL_PEERPID`, `LOCAL_PEERCRED`,
 `proc_pidpath`, and `PROC_PIDVNODEPATHINFO`). If those fields cannot be obtained
 or do not match the approved session policy, the daemon must fail closed rather
 than silently falling back to weaker checks.
 
-`agent-secret exec` remains the strongest initial mode because the trusted CLI
-wrapper controls environment injection and child lifecycle while the daemon owns
-approval, fetch, cache, and audit policy. Future session/socket reads should
-also be strict on macOS now that the required peer metadata is available.
+`agent-secret exec` remains the strongest single-command mode because the
+trusted CLI wrapper controls environment injection and child lifecycle while the
+daemon owns approval, fetch, cache, and audit policy. Future raw socket reads
+should meet the same macOS peer-validation bar.
 
 ## Secret Storage Rules
 
@@ -558,8 +565,7 @@ Audit logs should include:
   to `agent-secret exec` but it disconnects before reporting a child PID
 - `command_started` after successful child spawn, including child PID
 - command completion, including exit code or signal
-- session IDs, read counts, and session/socket max reads for deferred session
-  modes
+- session IDs, read counts, and max reads for session modes
 - expiration and cleanup events
 - errors
 
@@ -620,10 +626,9 @@ process-supervision role.
 The validation sequence is:
 
 1. env-only `agent-secret exec`;
-2. ephemeral Unix socket reads for tools or wrappers that cannot consume
-   environment variables cleanly;
-3. sessions, credential helpers, file descriptors, and config-driven mapping
-   after the first two delivery paths are solid.
+2. bounded daemon-held sessions resolved only by `agent-secret with-session`;
+3. future credential helpers, raw socket reads, file descriptors, and
+   config-driven mapping after the wrapper paths are solid.
 
 Config-driven secret sync remains important, but it should not block the first
 delivery path unless it can be expressed through explicit env mappings.
@@ -665,23 +670,20 @@ Limitations:
 - Environment variables can still be exposed by child process behavior, crash
   reporters, debuggers, or subprocesses.
 
-### Mode 2: Session Handles
+### Mode 2: Daemon-Held Session IDs
 
-The broker creates a short-lived session and returns handles instead of values.
-Handles are only useful with the session socket, matching peer credentials,
-remaining read count, and unexpired policy.
+The broker creates a short-lived session and returns an opaque session ID
+instead of values. Values stay in daemon memory and are useful only through
+`agent-secret with-session`, matching peer credentials, cwd, remaining read
+count, and unexpired policy.
 
-Future session value reads should happen through ephemeral Unix sockets or
-equivalent local IPC and must never print values to stdout/stderr.
-Unlike same-command reuse, sessions should approve a bounded set of references
-for a session lifetime and allow those approved references to be read in
-whatever order the approved workflow needs, subject to TTL, max-read, peer, and
-destroy policy.
-On macOS, session/socket reads must fail closed unless the daemon can validate
-same UID, peer PID, executable path, cwd, session/capability nonce, TTL, and
-read count against the approved session.
-Session values must clear when TTL expires, read counts are exhausted, the daemon
-stops, or the session is destroyed.
+Unlike same-command reuse, sessions approve a bounded set of references for a
+workflow lifetime and allow those approved references to be injected into
+multiple wrapped commands, subject to TTL, max-read, peer, and destroy policy.
+On macOS, session resolution must fail closed unless the daemon can validate the
+same UID, peer PID, executable path, cwd, TTL, and read count against the
+approved session. Session values must clear when TTL expires, read counts are
+exhausted, the daemon stops, or the session is destroyed.
 
 ### Mode 3: `with-session`
 
@@ -692,7 +694,8 @@ agent-secret with-session asess_123 -- terraform apply
 ```
 
 The wrapper asks the daemon to resolve approved secrets and injects them only
-into the child process.
+into the child process. It must keep the daemon connection open while the child
+runs so command lifecycle audit events stay daemon-owned.
 
 ### Mode 4: Credential Helpers
 
@@ -829,29 +832,24 @@ Global options:
 --force-refresh              Refetch values for a matching reusable approval.
 ```
 
-Deferred session and socket-read option:
+Session option:
 
 ```text
---max-reads integer          Session/socket only. Default: 1.
+--max-reads integer          Session create only. Default: 1. Max: 20.
 ```
 
-MVP commands:
+V1 commands:
 
 ```bash
 agent-secret exec [options] -- command [args...]
-agent-secret daemon status
-agent-secret daemon start
-agent-secret daemon stop
-agent-secret doctor
-```
-
-Deferred session commands:
-
-```bash
 agent-secret session create [options]
 agent-secret with-session asess_123 -- command [args...]
 agent-secret session list
 agent-secret session destroy asess_123
+agent-secret daemon status
+agent-secret daemon start
+agent-secret daemon stop
+agent-secret doctor
 ```
 
 There is no audit viewer command in MVP. Operators can inspect the JSONL audit
@@ -906,7 +904,6 @@ Recommended macOS paths:
 
 ```text
 $TMPDIR/agent-secret/daemon.sock
-$TMPDIR/agent-secret/sessions/asess_123.sock
 ```
 
 MVP requirements:
@@ -927,24 +924,25 @@ MVP requirements:
   activated for that request, verified by socket peer PID and executable identity
 - stale socket cleanup on startup
 - request envelopes with protocol version and message type
+- session create/resolve/list/destroy over the daemon command socket, with
+  `session.resolve` restricted to `with-session` wrappers that provide complete
+  expected peer metadata
 
-Deferred session socket requirements:
+Future raw session socket requirements:
 
 - randomized private session paths
 - strict peer UID, PID, executable path, cwd, session/capability nonce, TTL, and
   read-count validation
 
-MVP endpoint types:
+V1 endpoint types:
 
 - `request.exec`
-- `approval.pending`
-- `approval.decision`
-
-Deferred session endpoint types:
-
 - `session.create`
 - `session.resolve`
 - `session.destroy`
+- `session.list`
+- `approval.pending`
+- `approval.decision`
 
 `session.resolve` should be internal to wrappers by default and must never be
 logged with values.
@@ -990,6 +988,8 @@ MVP must include:
 - Swift macOS approval app with foreground prompt
 - official 1Password Go SDK integration
 - `exec` mode with environment injection
+- bounded daemon-held sessions with `session create`, `session list`,
+  `session destroy`, and `with-session`
 - required `--reason`
 - secret references displayed before fetch
 - TTL policy for `exec`
@@ -1010,10 +1010,7 @@ MVP should include:
 
 MVP can defer:
 
-- session creation with opaque handles
-- `with-session` wrapper
-- strict session/socket peer validation, which is required when session/socket
-  reads are implemented but does not block env-only `exec`
+- raw session sockets and credential-helper protocols
 - menu bar presence for the approver
 - Git credential helper
 - AWS `credential_process`
@@ -1067,22 +1064,22 @@ Exit criteria:
 - Approval UI shows reason, secret references, command, cwd, optional command
   binary, and approval duration without audit/debug noise.
 
-### Milestone 2: Sessions And Unix Socket Reads
+### Milestone 2: Bounded Sessions And `with-session`
 
 Deliverables:
 
 - session create, list, and destroy
-- opaque handles
+- opaque session IDs
 - `with-session` wrapper
-- ephemeral Unix socket reads for approved session references
+- daemon-memory value storage and wrapper-only resolution
 - TTL and max-read enforcement
 - strict macOS peer validation for UID, PID, executable path, and cwd
 
 Exit criteria:
 
 - A multi-command workflow can be approved once and executed through wrappers.
-- Approved session references can be read in whatever order the workflow needs without
-  console output or disk writes.
+- Approved session references can be injected into wrapped child processes
+  without console output or disk writes.
 - Expired sessions cannot be used.
 - Peer metadata failures or mismatches fail closed.
 - Max-read policy works.
@@ -1170,23 +1167,24 @@ Exit criteria:
   denial, approval, and error events without secret values or environment
   payloads.
 
-### Future Session Mode Criteria
+### Session Mode Criteria
 
-- Session create returns handles only.
-- Handles cannot be resolved after TTL.
-- Handles cannot be resolved more than the allowed read count.
-- On macOS, handle resolution fails closed if peer UID, PID, executable path, or
+- Session create returns opaque session IDs only.
+- Session IDs cannot be resolved after TTL.
+- Session IDs cannot be resolved more than the allowed read count.
+- On macOS, session resolution fails closed if peer UID, PID, executable path, or
   cwd cannot be obtained or does not match the approved session policy.
-- Destroying a session invalidates all handles.
+- Destroying a session invalidates the session ID.
 
 ### Audit Criteria
 
-- V1 `exec` logs approval request, approval grant, approval denial, approval
-  timeout, reusable approval reuse/refresh, secret fetch attempt, secret fetch
-  failure, command start/start-complete/completion, post-payload disconnect,
-  post-start lifecycle disconnect, and daemon stop events.
-- Future handle/session delivery APIs must add expiry and destroy audit events
-  before those APIs are considered complete.
+- V1 `exec` and session paths log approval request, approval grant, approval
+  denial, approval timeout, reusable approval reuse/refresh, secret fetch
+  attempt, secret fetch failure, session create/resolve/destroy, command
+  start/start-complete/completion, post-payload disconnect, post-start lifecycle
+  disconnect, and daemon stop events.
+- Future raw socket or credential-helper delivery APIs must add expiry and
+  destroy audit events before those APIs are considered complete.
 - Logs contain secret references and aliases but no values.
 - Logs are readable only by the current user by default.
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -690,12 +690,17 @@ exhausted, the daemon stops, or the session is destroyed.
 The agent receives a session ID but must wrap each command:
 
 ```bash
-agent-secret with-session asess_123 -- terraform apply
+agent-secret with-session asess_123 \
+  --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
+  -- terraform apply
 ```
 
 The wrapper asks the daemon to resolve approved secrets and injects them only
-into the child process. It must keep the daemon connection open while the child
-runs so command lifecycle audit events stay daemon-owned.
+into the child process. By default it injects every approved session alias for
+that command. With `--only`, it injects only the requested aliases and fails
+before spawning when any requested alias was not part of the approved session.
+It must keep the daemon connection open while the child runs so command
+lifecycle audit events stay daemon-owned.
 
 ### Mode 4: Credential Helpers
 
@@ -843,7 +848,7 @@ V1 commands:
 ```bash
 agent-secret exec [options] -- command [args...]
 agent-secret session create [options]
-agent-secret with-session asess_123 -- command [args...]
+agent-secret with-session asess_123 [--only ALIAS[,ALIAS...]] -- command [args...]
 agent-secret session list
 agent-secret session destroy asess_123
 agent-secret daemon status

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -1,0 +1,289 @@
+# Session E2E Validation
+
+Use this runbook to manually re-test bounded sessions against the real
+CLI, daemon, native approver, provider resolver, audit log, and child-process
+environment injection path.
+
+The test uses two test-only secret references. It never prints resolved values.
+The child commands only assert whether expected environment variables are
+present.
+
+## Preconditions
+
+1. Install the current development build:
+
+   ```bash
+   mise run dev:install
+   agent-secret doctor
+   ```
+
+2. Make sure `agent-secret doctor` reports:
+
+   - `daemon startup: ok`
+   - `native approver: ok`
+   - `1password desktop integration: ok`
+
+3. Set two test-only refs:
+
+   ```bash
+   export AGENT_SECRET_E2E_PROFILE_REF='op://Example/Test Secret/password'
+   export AGENT_SECRET_E2E_CLI_REF='op://Example/Another Test Secret/password'
+   ```
+
+## Run
+
+The script creates a temporary project config with one secret from a profile and
+adds the second secret with a CLI `--secret` flag. Approve the native prompts
+when they appear.
+
+<!-- markdownlint-disable MD013 -->
+
+```bash
+set -euo pipefail
+
+: "${AGENT_SECRET_E2E_PROFILE_REF:?set a test-only profile ref}"
+: "${AGENT_SECRET_E2E_CLI_REF:?set a test-only CLI ref}"
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-session-e2e.XXXXXX")"
+SESSION_ID=""
+EXHAUST_ID=""
+
+cleanup() {
+  if [[ -n "${SESSION_ID:-}" ]]; then
+    agent-secret session destroy "$SESSION_ID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${EXHAUST_ID:-}" ]]; then
+    agent-secret session destroy "$EXHAUST_ID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+audit_log="$HOME/Library/Logs/agent-secret/audit.jsonl"
+start_lines=0
+if [[ -f "$audit_log" ]]; then
+  start_lines="$(wc -l < "$audit_log" | tr -d ' ')"
+fi
+
+cd "$workdir"
+cat > agent-secret.yml <<YAML
+version: 1
+profiles:
+  session-e2e:
+    reason: Agent Secret session E2E multi-secret validation
+    ttl: 2m
+    secrets:
+      SESSION_E2E_PROFILE_TOKEN: "$AGENT_SECRET_E2E_PROFILE_REF"
+YAML
+
+check_py='import os, sys
+mode = sys.argv[1]
+keys = ("SESSION_E2E_PROFILE_TOKEN", "SESSION_E2E_CLI_TOKEN")
+wants = {
+    "full": (True, True),
+    "profile": (True, False),
+    "cli": (False, True),
+    "both": (True, True),
+}
+want = wants[mode]
+for key, expected in zip(keys, want):
+    present = bool(os.environ.get(key))
+    if present != expected:
+        raise SystemExit(f"{mode}: {key} present={present}, want={expected}")
+print(f"{mode} ok")'
+
+run_with_session() {
+  env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
+    agent-secret with-session "$@"
+}
+
+SESSION_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
+  agent-secret session create \
+    --json \
+    --profile session-e2e \
+    --secret "SESSION_E2E_CLI_TOKEN=$AGENT_SECRET_E2E_CLI_REF" \
+    --max-reads 5)"
+SESSION_ID="$(printf '%s' "$SESSION_JSON" |
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"
+printf 'created mixed config+CLI session: %s\n' "$SESSION_ID"
+
+agent-secret session list --json |
+  SESSION_ID="$SESSION_ID" python3 -c '
+import json, os, sys
+data = json.load(sys.stdin)
+sid = os.environ["SESSION_ID"]
+matches = [s for s in data["sessions"] if s["session_id"] == sid]
+assert len(matches) == 1, matches
+s = matches[0]
+assert s["remaining_reads"] == 5, s
+assert s["secret_aliases"] == [
+    "SESSION_E2E_CLI_TOKEN",
+    "SESSION_E2E_PROFILE_TOKEN",
+], s
+print("session list ok")'
+
+run_with_session "$SESSION_ID" \
+  --allow-mutable-executable \
+  -- python3 -c "$check_py" full
+run_with_session "$SESSION_ID" \
+  --only SESSION_E2E_PROFILE_TOKEN \
+  --allow-mutable-executable \
+  -- python3 -c "$check_py" profile
+
+missing_output="$workdir/missing-alias.out"
+if run_with_session "$SESSION_ID" \
+  --only SESSION_E2E_MISSING_TOKEN \
+  --allow-mutable-executable \
+  -- python3 -c 'print("UNEXPECTED_CHILD_STARTED")' \
+  >"$missing_output" 2>&1; then
+  echo 'BUG: missing alias unexpectedly succeeded' >&2
+  exit 1
+fi
+if grep -q 'UNEXPECTED_CHILD_STARTED' "$missing_output"; then
+  echo 'BUG: missing alias spawned child' >&2
+  exit 1
+fi
+echo 'missing alias rejected before child spawn'
+
+run_with_session "$SESSION_ID" \
+  --only SESSION_E2E_CLI_TOKEN \
+  --allow-mutable-executable \
+  -- python3 -c "$check_py" cli
+run_with_session "$SESSION_ID" \
+  --only SESSION_E2E_PROFILE_TOKEN,SESSION_E2E_CLI_TOKEN \
+  --allow-mutable-executable \
+  -- python3 -c "$check_py" both
+
+agent-secret session list --json |
+  SESSION_ID="$SESSION_ID" python3 -c '
+import json, os, sys
+data = json.load(sys.stdin)
+sid = os.environ["SESSION_ID"]
+matches = [s for s in data["sessions"] if s["session_id"] == sid]
+assert len(matches) == 1, matches
+assert matches[0]["remaining_reads"] == 1, matches[0]
+print("read count after subset runs ok")'
+
+agent-secret session destroy "$SESSION_ID" >/dev/null
+destroyed_output="$workdir/destroyed.out"
+if run_with_session "$SESSION_ID" \
+  --only SESSION_E2E_PROFILE_TOKEN \
+  --allow-mutable-executable \
+  -- python3 -c 'print("UNEXPECTED_CHILD_STARTED")' \
+  >"$destroyed_output" 2>&1; then
+  echo 'BUG: destroyed session unexpectedly resolved' >&2
+  exit 1
+fi
+if grep -q 'UNEXPECTED_CHILD_STARTED' "$destroyed_output"; then
+  echo 'BUG: destroyed session spawned child' >&2
+  exit 1
+fi
+echo 'destroyed session rejected before child spawn'
+SESSION_ID=""
+
+EXHAUST_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
+  agent-secret session create \
+    --json \
+    --profile session-e2e \
+    --secret "SESSION_E2E_CLI_TOKEN=$AGENT_SECRET_E2E_CLI_REF" \
+    --max-reads 1)"
+EXHAUST_ID="$(printf '%s' "$EXHAUST_JSON" |
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"
+printf 'created one-read session: %s\n' "$EXHAUST_ID"
+run_with_session "$EXHAUST_ID" \
+  --only SESSION_E2E_PROFILE_TOKEN \
+  --allow-mutable-executable \
+  -- python3 -c "$check_py" profile
+
+exhausted_output="$workdir/exhausted.out"
+if run_with_session "$EXHAUST_ID" \
+  --only SESSION_E2E_PROFILE_TOKEN \
+  --allow-mutable-executable \
+  -- python3 -c 'print("UNEXPECTED_CHILD_STARTED")' \
+  >"$exhausted_output" 2>&1; then
+  echo 'BUG: exhausted session unexpectedly resolved' >&2
+  exit 1
+fi
+if grep -q 'UNEXPECTED_CHILD_STARTED' "$exhausted_output"; then
+  echo 'BUG: exhausted session spawned child' >&2
+  exit 1
+fi
+echo 'read exhaustion rejected before child spawn'
+EXHAUST_ID=""
+
+python3 - "$audit_log" "$start_lines" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+start = int(sys.argv[2])
+events = []
+with path.open() as f:
+    for index, line in enumerate(f, start=1):
+        if index <= start:
+            continue
+        events.append(json.loads(line))
+
+types = [event.get("type") for event in events]
+for required in (
+    "session_created",
+    "session_resolved",
+    "session_destroyed",
+    "command_started",
+    "command_completed",
+):
+    if required not in types:
+        raise SystemExit(f"missing audit event {required}; saw {types}")
+
+aliases = {
+    ref.get("alias")
+    for event in events
+    for ref in event.get("secret_refs", [])
+}
+expected = {"SESSION_E2E_PROFILE_TOKEN", "SESSION_E2E_CLI_TOKEN"}
+if not expected.issubset(aliases):
+    raise SystemExit(
+        f"audit aliases {sorted(aliases)} missing {sorted(expected)}"
+    )
+print("audit metadata ok")
+PY
+
+echo 'session E2E ok'
+```
+
+<!-- markdownlint-enable MD013 -->
+
+## Expected Output
+
+The exact session IDs vary, but a passing run prints these checkpoints:
+
+```text
+created mixed config+CLI session: asess_...
+session list ok
+full ok
+profile ok
+missing alias rejected before child spawn
+cli ok
+both ok
+read count after subset runs ok
+destroyed session rejected before child spawn
+created one-read session: asess_...
+profile ok
+read exhaustion rejected before child spawn
+audit metadata ok
+session E2E ok
+```
+
+## Coverage
+
+This E2E run proves:
+
+- `session create` accepts secrets from a project config profile and CLI args.
+- `session list` shows metadata for active sessions without values.
+- `with-session` injects the full approved bag when `--only` is omitted.
+- `with-session --only` injects config-only, CLI-only, and combined subsets.
+- Unknown aliases fail before the child process starts.
+- `session destroy` prevents further resolution.
+- Read exhaustion prevents further resolution.
+- Session and command lifecycle audit metadata is written.

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -23,12 +23,11 @@ present.
    - `native approver: ok`
    - `1password desktop integration: ok`
 
-3. Set two test-only refs:
+3. Confirm the integration test refs are available to the local 1Password
+   account:
 
-   ```bash
-   export AGENT_SECRET_E2E_PROFILE_REF='op://Example/Test Secret/password'
-   export AGENT_SECRET_E2E_CLI_REF='op://Example/Another Test Secret/password'
-   ```
+   - `op://Agent Secret Integration/Test Secret/password`
+   - `op://Agent Secret Integration/Another Test Secret/password`
 
 ## Run
 
@@ -41,8 +40,8 @@ when they appear.
 ```bash
 set -euo pipefail
 
-: "${AGENT_SECRET_E2E_PROFILE_REF:?set a test-only profile ref}"
-: "${AGENT_SECRET_E2E_CLI_REF:?set a test-only CLI ref}"
+profile_ref="${AGENT_SECRET_E2E_PROFILE_REF:-op://Agent Secret Integration/Test Secret/password}"
+cli_ref="${AGENT_SECRET_E2E_CLI_REF:-op://Agent Secret Integration/Another Test Secret/password}"
 
 workdir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-session-e2e.XXXXXX")"
 SESSION_ID=""
@@ -73,7 +72,7 @@ profiles:
     reason: Agent Secret session E2E multi-secret validation
     ttl: 2m
     secrets:
-      SESSION_E2E_PROFILE_TOKEN: "$AGENT_SECRET_E2E_PROFILE_REF"
+      SESSION_E2E_PROFILE_TOKEN: "$profile_ref"
 YAML
 
 check_py='import os, sys
@@ -101,7 +100,7 @@ SESSION_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
   agent-secret session create \
     --json \
     --profile session-e2e \
-    --secret "SESSION_E2E_CLI_TOKEN=$AGENT_SECRET_E2E_CLI_REF" \
+    --secret "SESSION_E2E_CLI_TOKEN=$cli_ref" \
     --max-reads 5)"
 SESSION_ID="$(printf '%s' "$SESSION_JSON" |
   python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"
@@ -185,7 +184,7 @@ EXHAUST_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
   agent-secret session create \
     --json \
     --profile session-e2e \
-    --secret "SESSION_E2E_CLI_TOKEN=$AGENT_SECRET_E2E_CLI_REF" \
+    --secret "SESSION_E2E_CLI_TOKEN=$cli_ref" \
     --max-reads 1)"
 EXHAUST_ID="$(printf '%s' "$EXHAUST_JSON" |
   python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -40,6 +40,9 @@ const (
 	EventItemMetadataFetchStarted           EventType = "item_metadata_fetch_started"
 	EventItemMetadataFetchCompleted         EventType = "item_metadata_fetch_completed"
 	EventItemMetadataFetchFailed            EventType = "item_metadata_fetch_failed"
+	EventSessionCreated                     EventType = "session_created"
+	EventSessionResolved                    EventType = "session_resolved"
+	EventSessionDestroyed                   EventType = "session_destroyed"
 	EventCommandStarting                    EventType = "command_starting"
 	EventCommandStarted                     EventType = "command_started"
 	EventCommandCompleted                   EventType = "command_completed"
@@ -61,6 +64,7 @@ type Event struct {
 	Type               EventType   `json:"type"`
 	RequestID          string      `json:"request_id,omitempty"`
 	ApprovalID         string      `json:"approval_id,omitempty"`
+	SessionID          string      `json:"session_id,omitempty"`
 	Reason             string      `json:"reason,omitempty"`
 	Command            []string    `json:"command,omitempty"`
 	ResolvedExecutable string      `json:"resolved_executable,omitempty"`
@@ -77,10 +81,39 @@ type Event struct {
 	RequesterPath      string      `json:"requester_path,omitempty"`
 	RemainingTTLMillis *int64      `json:"remaining_ttl_ms,omitempty"`
 	RemainingUses      *int        `json:"remaining_uses,omitempty"`
+	MaxReads           *int        `json:"max_reads,omitempty"`
+	RemainingReads     *int        `json:"remaining_reads,omitempty"`
 	ForceRefresh       bool        `json:"force_refresh,omitempty"`
 	ReuseOnly          bool        `json:"reuse_only,omitempty"`
 	OverrideEnv        bool        `json:"override_env,omitempty"`
 	OverriddenAliases  []string    `json:"overridden_aliases,omitempty"`
+}
+
+func FromSessionCreateRequest(eventType EventType, requestID string, req request.SessionCreateRequest) Event {
+	maxReads := req.MaxReads
+	return Event{
+		Type:               eventType,
+		RequestID:          requestID,
+		Reason:             req.Reason,
+		Command:            slices.Clone(req.Command),
+		ResolvedExecutable: req.ResolvedExecutable,
+		CWD:                req.CWD,
+		SecretRefs:         secretRefs(req.Secrets),
+		MaxReads:           &maxReads,
+		OverrideEnv:        req.OverrideEnv,
+	}
+}
+
+func FromSessionResolveRequest(eventType EventType, requestID string, req request.SessionResolveRequest, secretRefs []SecretRef) Event {
+	return Event{
+		Type:               eventType,
+		RequestID:          requestID,
+		SessionID:          req.SessionID,
+		Command:            slices.Clone(req.Command),
+		ResolvedExecutable: req.ResolvedExecutable,
+		CWD:                req.CWD,
+		SecretRefs:         slices.Clone(secretRefs),
+	}
 }
 
 type Writer struct {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -327,6 +327,79 @@ func TestFromItemDescribeRequestUsesMetadataOnly(t *testing.T) {
 	}
 }
 
+func TestFromSessionRequestsUseMetadataOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeExecutable(t, dir, "agent-secret")
+	executable := filepath.Join(dir, "agent-secret")
+	identity, err := fileidentity.Capture(executable)
+	if err != nil {
+		t.Fatalf("capture executable identity: %v", err)
+	}
+	createReq, err := request.NewSessionCreate(request.SessionCreateOptions{
+		Reason:             "  Deploy workflow  ",
+		Command:            []string{"agent-secret", "session", "create"},
+		CWD:                dir,
+		ResolvedExecutable: executable,
+		ExecutableIdentity: identity,
+		Secrets: []request.SecretSpec{
+			{Alias: "TOKEN", Ref: "op://Example Vault/Deploy Token/token", Account: "Work"},
+		},
+		MaxReads:    2,
+		OverrideEnv: true,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionCreate returned error: %v", err)
+	}
+	createEvent := FromSessionCreateRequest(EventSessionCreated, "req_1", createReq)
+	if createEvent.Type != EventSessionCreated ||
+		createEvent.Reason != "Deploy workflow" ||
+		createEvent.MaxReads == nil ||
+		*createEvent.MaxReads != 2 ||
+		!createEvent.OverrideEnv {
+		t.Fatalf("create event missing expected metadata: %+v", createEvent)
+	}
+	createJSON, err := json.Marshal(createEvent)
+	if err != nil {
+		t.Fatalf("marshal create event: %v", err)
+	}
+	if bytes.Contains(createJSON, []byte(canaryValue)) {
+		t.Fatalf("create event leaked synthetic value: %s", createJSON)
+	}
+
+	resolveReq, err := request.NewSessionResolve(
+		"asess_abc123",
+		[]string{"/usr/bin/env", "terraform", "plan"},
+		"/usr/bin/env",
+		fileidentity.Identity{Device: 1, Inode: 2, Mode: 0o755, Size: 64},
+		dir,
+		request.EnvironmentFingerprint([]string{"PATH=/usr/bin"}),
+	)
+	if err != nil {
+		t.Fatalf("NewSessionResolve returned error: %v", err)
+	}
+	resolveEvent := FromSessionResolveRequest(
+		EventSessionResolved,
+		"req_2",
+		resolveReq,
+		[]SecretRef{{Alias: "TOKEN", Ref: "op://Example Vault/Deploy Token/token", Account: "Work"}},
+	)
+	if resolveEvent.Type != EventSessionResolved ||
+		resolveEvent.SessionID != "asess_abc123" ||
+		resolveEvent.CWD != dir ||
+		len(resolveEvent.SecretRefs) != 1 {
+		t.Fatalf("resolve event missing expected metadata: %+v", resolveEvent)
+	}
+	resolveJSON, err := json.Marshal(resolveEvent)
+	if err != nil {
+		t.Fatalf("marshal resolve event: %v", err)
+	}
+	if bytes.Contains(resolveJSON, []byte(canaryValue)) {
+		t.Fatalf("resolve event leaked synthetic value: %s", resolveJSON)
+	}
+}
+
 func TestWriterRejectsInvalidEventsAndClosedUse(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -55,6 +55,18 @@ type daemonClient interface {
 		correlation protocol.Correlation,
 		req request.ItemDescribeRequest,
 	) (protocol.ItemDescribeResponsePayload, error)
+	CreateSession(
+		ctx context.Context,
+		correlation protocol.Correlation,
+		req request.SessionCreateRequest,
+	) (protocol.SessionCreateResponsePayload, error)
+	ResolveSession(
+		ctx context.Context,
+		correlation protocol.Correlation,
+		req request.SessionResolveRequest,
+	) (protocol.SessionResolveResponsePayload, error)
+	DestroySession(ctx context.Context, req request.SessionDestroyRequest) (protocol.SessionDestroyResponsePayload, error)
+	ListSessions(ctx context.Context) (protocol.SessionListResponsePayload, error)
 	ReportStarted(ctx context.Context, correlation protocol.Correlation, childPID int) error
 	ReportCompleted(ctx context.Context, correlation protocol.Correlation, exitCode int, signal string) error
 }
@@ -133,6 +145,14 @@ func (a App) Run(ctx context.Context, args []string) int {
 		return a.runAgentContext(command)
 	case KindExec:
 		return a.runExec(ctx, command)
+	case KindSessionCreate:
+		return a.runSessionCreate(ctx, command)
+	case KindSessionList:
+		return a.runSessionList(ctx, command)
+	case KindSessionDestroy:
+		return a.runSessionDestroy(ctx, command)
+	case KindWithSession:
+		return a.runWithSession(ctx, command)
 	case KindItemDescribe:
 		return a.runItemDescribe(ctx, command)
 	case KindProfileList:

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -106,11 +106,13 @@ func (a App) runAgentContext(command Command) int {
 				"secret values are never printed by agent-secret",
 				"exec passes child stdin/stdout/stderr through unchanged",
 				"item describe returns metadata only",
+				"session create returns opaque handles only and with-session never prints values",
 			},
 			MutationBoundary: []string{
 				"exec --dry-run validates without prompting or spawning",
 				"exec --reuse-only fails instead of opening a new approval prompt",
 				"daemon stop clears daemon-owned reusable approvals and cached values",
+				"session destroy or daemon stop clears daemon-held session values",
 			},
 		},
 	}
@@ -192,6 +194,49 @@ func agentContextCommands() map[string]commandContext {
 				{Name: "--force", Type: "bool", Description: "Replace an existing regular file or different symlink."},
 			}, jsonFlag()...),
 			Outputs: []string{"text", "json"},
+		},
+		"session": {
+			Summary: "Create, list, and destroy bounded daemon-held secret sessions.",
+			Subcommands: map[string]commandContext{
+				"create": {
+					Summary: "Ask for approval, resolve refs, and return an opaque session id.",
+					Flags: []flagContext{
+						{Name: "--reason", Type: "string", Description: "Human-readable reason shown to the approver."},
+						{Name: "--secret", Type: "mapping", Repeatable: true, Description: "Secret alias mapping: ALIAS=op://vault/item/field or ALIAS=bws://source/secret-uuid."},
+						{Name: "--profile", Type: "string", Description: "Load a named project profile."},
+						{Name: "--only", Type: "string", Repeatable: true, Description: "Filter profile/env-file aliases; comma-separated values are accepted."},
+						{Name: "--env-file", Type: "path", Repeatable: true, Description: "Load dotenv entries; op:// and bws:// values become approved refs."},
+						{Name: "--account", Type: "string", Description: "Default 1Password account for refs without a config account."},
+						{Name: "--config", Type: "path", Description: "Profile config path."},
+						{Name: "--cwd", Type: "path", Description: "Session working directory."},
+						{Name: "--ttl", Type: "duration", Default: request.DefaultSessionTTL.String(), Description: "Session TTL.", Values: []string{request.MinRequestTTL.String() + ".." + request.MaxRequestTTL.String()}},
+						{Name: "--max-reads", Type: "int", Default: "1", Values: []string{"1..20"}, Description: "Maximum with-session resolves before the session is exhausted."},
+						{Name: "--override-env", Type: "bool", Description: "Allow with-session to replace existing child env vars with approved aliases."},
+						{Name: "--json", Type: "bool", Description: "Print session metadata as JSON."},
+					},
+					Outputs: []string{"text", "json"},
+					Notes:   []string{"returns a session id only", "secret values stay in daemon memory until TTL, max reads, destroy, or daemon stop"},
+				},
+				"list": {
+					Summary: "List active session ids and non-secret metadata.",
+					Flags:   jsonFlag(),
+					Outputs: []string{"text", "json"},
+				},
+				"destroy": {
+					Summary: "Destroy one session and clear its cached values.",
+					Flags:   jsonFlag(),
+					Outputs: []string{"text", "json"},
+				},
+			},
+		},
+		"with-session": {
+			Summary: "Run one command with secrets from an approved session.",
+			Flags: []flagContext{
+				{Name: "--cwd", Type: "path", Description: "Child working directory; must match the session cwd."},
+				{Name: "--allow-mutable-executable", Type: "bool", Description: "Allow a user-owned or writable executable path after surfacing the approval warning."},
+			},
+			Outputs: []string{"child passthrough"},
+			Notes:   []string{"usage: agent-secret with-session SESSION_ID -- COMMAND [ARG...]", "session values are injected into the child environment and never printed"},
 		},
 		"bitwarden": {
 			Summary: "Manage local Bitwarden Secrets Manager token aliases.",

--- a/internal/cli/app_session.go
+++ b/internal/cli/app_session.go
@@ -1,0 +1,238 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
+	"github.com/kovyrin/agent-secret/internal/execwrap"
+	"github.com/kovyrin/agent-secret/internal/peercred"
+	"github.com/kovyrin/agent-secret/internal/request"
+)
+
+type sessionCreateOutput struct {
+	SchemaVersion  string    `json:"schema_version"`
+	SessionID      string    `json:"session_id"`
+	SecretAliases  []string  `json:"secret_aliases"`
+	ExpiresAt      time.Time `json:"expires_at"`
+	MaxReads       int       `json:"max_reads"`
+	RemainingReads int       `json:"remaining_reads"`
+}
+
+type sessionListOutput struct {
+	SchemaVersion string                        `json:"schema_version"`
+	Sessions      []protocol.SessionInfoPayload `json:"sessions"`
+}
+
+func (a App) runSessionCreate(ctx context.Context, command Command) int {
+	manager, err := a.daemonManager()
+	if err != nil {
+		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		return 1
+	}
+	if err := manager.EnsureRunning(ctx); err != nil {
+		a.stderrf("agent-secret: start daemon: %v\n", err)
+		return 1
+	}
+	correlation, err := a.newCorrelation()
+	if err != nil {
+		a.stderrf("agent-secret: %v\n", err)
+		return 1
+	}
+	client, payload, err := a.requestSessionCreate(ctx, manager, correlation, command.SessionCreateRequest)
+	if err != nil {
+		a.stderrf("agent-secret: %v\n", err)
+		return 1
+	}
+	defer func() { _ = client.Close() }()
+	output := sessionCreateOutput{
+		SchemaVersion:  "1",
+		SessionID:      payload.SessionID,
+		SecretAliases:  payload.SecretAliases,
+		ExpiresAt:      payload.ExpiresAt,
+		MaxReads:       payload.MaxReads,
+		RemainingReads: payload.RemainingReads,
+	}
+	if command.OutputJSON {
+		if err := a.writeJSON(output); err != nil {
+			a.stderrf("agent-secret: write session create json: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	a.stdoutf("session: %s\n", payload.SessionID)
+	a.stdoutf("expires: %s\n", payload.ExpiresAt.Format(time.RFC3339))
+	a.stdoutf("reads: %d/%d remaining\n", payload.RemainingReads, payload.MaxReads)
+	a.stdoutf("secrets: %s\n", strings.Join(payload.SecretAliases, ", "))
+	return 0
+}
+
+func (a App) runSessionList(ctx context.Context, command Command) int {
+	manager, err := a.daemonManager()
+	if err != nil {
+		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		return 1
+	}
+	if err := manager.EnsureRunning(ctx); err != nil {
+		a.stderrf("agent-secret: start daemon: %v\n", err)
+		return 1
+	}
+	client, payload, err := requestDaemonPayload(ctx, manager, func(client daemonClient) (protocol.SessionListResponsePayload, error) {
+		return client.ListSessions(ctx)
+	})
+	if err != nil {
+		a.stderrf("agent-secret: %v\n", err)
+		return 1
+	}
+	defer func() { _ = client.Close() }()
+	if command.OutputJSON {
+		if err := a.writeJSON(sessionListOutput{SchemaVersion: "1", Sessions: payload.Sessions}); err != nil {
+			a.stderrf("agent-secret: write session list json: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(payload.Sessions) == 0 {
+		a.stdoutln("no active sessions")
+		return 0
+	}
+	for _, session := range payload.Sessions {
+		a.stdoutf(
+			"%s expires=%s reads=%d/%d cwd=%s secrets=%s\n",
+			session.SessionID,
+			session.ExpiresAt.Format(time.RFC3339),
+			session.RemainingReads,
+			session.MaxReads,
+			session.CWD,
+			strings.Join(session.SecretAliases, ","),
+		)
+	}
+	return 0
+}
+
+func (a App) runSessionDestroy(ctx context.Context, command Command) int {
+	manager, err := a.daemonManager()
+	if err != nil {
+		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		return 1
+	}
+	if err := manager.EnsureRunning(ctx); err != nil {
+		a.stderrf("agent-secret: start daemon: %v\n", err)
+		return 1
+	}
+	client, payload, err := requestDaemonPayload(ctx, manager, func(client daemonClient) (protocol.SessionDestroyResponsePayload, error) {
+		return client.DestroySession(ctx, command.SessionDestroyRequest)
+	})
+	if err != nil {
+		a.stderrf("agent-secret: %v\n", err)
+		return 1
+	}
+	defer func() { _ = client.Close() }()
+	if command.OutputJSON {
+		if err := a.writeJSON(payload); err != nil {
+			a.stderrf("agent-secret: write session destroy json: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	a.stdoutf("destroyed session: %s\n", payload.SessionID)
+	return 0
+}
+
+func (a App) runWithSession(ctx context.Context, command Command) int {
+	if err := os.Chdir(command.SessionResolveRequest.CWD); err != nil {
+		a.stderrf("agent-secret: enter session cwd: %v\n", err)
+		return 1
+	}
+	expectedPeer, err := peercred.CurrentExpected()
+	if err != nil {
+		a.stderrf("agent-secret: inspect current peer metadata: %v\n", err)
+		return 1
+	}
+	req := command.SessionResolveRequest.WithExpectedPeer(expectedPeer)
+	manager, err := a.daemonManager()
+	if err != nil {
+		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		return 1
+	}
+	if err := manager.EnsureRunning(ctx); err != nil {
+		a.stderrf("agent-secret: start daemon: %v\n", err)
+		return 1
+	}
+	correlation, err := a.newCorrelation()
+	if err != nil {
+		a.stderrf("agent-secret: %v\n", err)
+		return 1
+	}
+	client, payload, err := a.requestSessionResolve(ctx, manager, correlation, req)
+	if err != nil {
+		a.stderrf("agent-secret: %v\n", err)
+		return 1
+	}
+	defer func() { _ = client.Close() }()
+
+	interrupts := make(chan os.Signal, 2)
+	signal.Notify(interrupts, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(interrupts)
+
+	reporter := daemonAuditReporter{
+		client:      client,
+		correlation: correlation,
+		stderr:      a.Stderr,
+	}
+	result, err := execwrap.Run(ctx, execwrap.Spec{
+		Path:         req.ResolvedExecutable,
+		PathIdentity: req.ExecutableIdentity,
+		Args:         req.Command[1:],
+		Dir:          req.CWD,
+		BaseEnv:      command.SessionEnv,
+		Env:          payload.Env,
+		OverrideEnv:  payload.OverrideEnv,
+		Stdout:       a.Stdout,
+		Stderr:       a.Stderr,
+		Lifecycle:    reporter,
+	}, interrupts)
+	if err != nil {
+		a.stderrf("agent-secret: %v\n", err)
+		return 1
+	}
+	return result.ExitCode
+}
+
+func (a App) requestSessionCreate(
+	ctx context.Context,
+	manager daemonManager,
+	correlation protocol.Correlation,
+	req request.SessionCreateRequest,
+) (daemonClient, protocol.SessionCreateResponsePayload, error) {
+	return requestDaemonPayload(ctx, manager, func(client daemonClient) (protocol.SessionCreateResponsePayload, error) {
+		return client.CreateSession(ctx, correlation, req)
+	})
+}
+
+func (a App) requestSessionResolve(
+	ctx context.Context,
+	manager daemonManager,
+	correlation protocol.Correlation,
+	req request.SessionResolveRequest,
+) (daemonClient, protocol.SessionResolveResponsePayload, error) {
+	return requestDaemonPayload(ctx, manager, func(client daemonClient) (protocol.SessionResolveResponsePayload, error) {
+		return client.ResolveSession(ctx, correlation, req)
+	})
+}
+
+func (a App) newCorrelation() (protocol.Correlation, error) {
+	requestID, err := a.randomID("req")
+	if err != nil {
+		return protocol.Correlation{}, err
+	}
+	nonce, err := a.randomID("nonce")
+	if err != nil {
+		return protocol.Correlation{}, err
+	}
+	return protocol.Correlation{RequestID: requestID, Nonce: nonce}, nil
+}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -163,6 +163,467 @@ func TestAppExecUsesManagerClientWithoutSocket(t *testing.T) {
 	}
 }
 
+func TestAppSessionCreateUsesProfileAndPrintsJSON(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	writeProfileConfig(t, root, `
+version: 1
+default_profile: deploy
+profiles:
+  deploy:
+    reason: Run deploy workflow
+    secrets:
+      TOKEN: op://Example/Item/token
+`)
+	expiresAt := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
+	client := &appFakeDaemonClient{
+		sessionCreatePayload: protocol.SessionCreateResponsePayload{
+			SessionID:      "asess_test",
+			SecretAliases:  []string{"TOKEN"},
+			ExpiresAt:      expiresAt,
+			MaxReads:       2,
+			RemainingReads: 2,
+		},
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(t.TempDir(), "d.sock"),
+		client:     client,
+		status:     protocol.StatusPayload{PID: 1234},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	code := app.Run(context.Background(), []string{
+		"session",
+		"create",
+		"--account", "Work",
+		"--max-reads", "2",
+		"--json",
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if client.sessionCreateCalls != 1 || client.closeCalls != 1 {
+		t.Fatalf("client calls: create=%d close=%d", client.sessionCreateCalls, client.closeCalls)
+	}
+	if len(client.sessionCreateRequests) != 1 {
+		t.Fatalf("session create requests = %d", len(client.sessionCreateRequests))
+	}
+	req := client.sessionCreateRequests[0]
+	if req.MaxReads != 2 || req.Secrets[0].Account != "Work" {
+		t.Fatalf("session request = %+v", req)
+	}
+	var got sessionCreateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode stdout JSON: %v; stdout=%q", err, stdout.String())
+	}
+	if got.SessionID != "asess_test" || got.RemainingReads != 2 || got.MaxReads != 2 {
+		t.Fatalf("session create json = %+v", got)
+	}
+	if strings.Contains(stdout.String(), "synthetic-secret-value") || strings.Contains(stderr.String(), "synthetic-secret-value") {
+		t.Fatalf("session create leaked secret: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestAppSessionCreatePrintsText(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	expiresAt := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
+	client := &appFakeDaemonClient{
+		sessionCreatePayload: protocol.SessionCreateResponsePayload{
+			SessionID:      "asess_text",
+			SecretAliases:  []string{"TOKEN"},
+			ExpiresAt:      expiresAt,
+			MaxReads:       1,
+			RemainingReads: 1,
+		},
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(t.TempDir(), "d.sock"),
+		client:     client,
+		status:     protocol.StatusPayload{PID: 1234},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	code := app.Run(context.Background(), []string{
+		"session",
+		"create",
+		"--reason", "Deploy",
+		"--account", "Work",
+		"--secret", "TOKEN=op://Example/Item/token",
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"session: asess_text", "reads: 1/1 remaining", "secrets: TOKEN"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("session create stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestAppSessionListAndDestroy(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
+	t.Run("list", func(t *testing.T) {
+		t.Parallel()
+
+		client := &appFakeDaemonClient{
+			sessionListPayload: protocol.SessionListResponsePayload{
+				Sessions: []protocol.SessionInfoPayload{{
+					SessionID:      "asess_test",
+					Reason:         "Deploy workflow",
+					CWD:            "/tmp/project",
+					SecretAliases:  []string{"TOKEN"},
+					ExpiresAt:      expiresAt,
+					MaxReads:       2,
+					RemainingReads: 1,
+				}},
+			},
+		}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{"session", "list"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		}
+		if client.sessionListCalls != 1 || client.closeCalls != 1 {
+			t.Fatalf("client calls: list=%d close=%d", client.sessionListCalls, client.closeCalls)
+		}
+		for _, want := range []string{"asess_test", "reads=1/2", "secrets=TOKEN"} {
+			if !strings.Contains(stdout.String(), want) {
+				t.Fatalf("session list stdout = %q, want %q", stdout.String(), want)
+			}
+		}
+	})
+
+	t.Run("list json", func(t *testing.T) {
+		t.Parallel()
+
+		client := &appFakeDaemonClient{
+			sessionListPayload: protocol.SessionListResponsePayload{
+				Sessions: []protocol.SessionInfoPayload{{
+					SessionID:      "asess_test",
+					Reason:         "Deploy workflow",
+					CWD:            "/tmp/project",
+					SecretAliases:  []string{"TOKEN"},
+					ExpiresAt:      expiresAt,
+					MaxReads:       2,
+					RemainingReads: 1,
+				}},
+			},
+		}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{"session", "list", "--json"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		}
+		var got sessionListOutput
+		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+			t.Fatalf("decode session list json: %v; stdout=%q", err, stdout.String())
+		}
+		if len(got.Sessions) != 1 || got.Sessions[0].SessionID != "asess_test" {
+			t.Fatalf("session list json = %+v", got)
+		}
+	})
+
+	t.Run("list empty", func(t *testing.T) {
+		t.Parallel()
+
+		client := &appFakeDaemonClient{}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{"session", "list"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		}
+		if strings.TrimSpace(stdout.String()) != "no active sessions" {
+			t.Fatalf("session list empty stdout = %q", stdout.String())
+		}
+	})
+
+	t.Run("destroy", func(t *testing.T) {
+		t.Parallel()
+
+		client := &appFakeDaemonClient{
+			sessionDestroyPayload: protocol.SessionDestroyResponsePayload{
+				SessionID: "asess_test",
+				Destroyed: true,
+			},
+		}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{"session", "destroy", "asess_test"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		}
+		if client.sessionDestroyCalls != 1 || client.closeCalls != 1 {
+			t.Fatalf("client calls: destroy=%d close=%d", client.sessionDestroyCalls, client.closeCalls)
+		}
+		if len(client.sessionDestroyRequests) != 1 || client.sessionDestroyRequests[0].SessionID != "asess_test" {
+			t.Fatalf("destroy requests = %+v", client.sessionDestroyRequests)
+		}
+		if !strings.Contains(stdout.String(), "destroyed session: asess_test") {
+			t.Fatalf("session destroy stdout = %q", stdout.String())
+		}
+	})
+
+	t.Run("destroy json", func(t *testing.T) {
+		t.Parallel()
+
+		client := &appFakeDaemonClient{
+			sessionDestroyPayload: protocol.SessionDestroyResponsePayload{
+				SessionID: "asess_test",
+				Destroyed: true,
+			},
+		}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{"session", "destroy", "--json", "asess_test"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		}
+		var got protocol.SessionDestroyResponsePayload
+		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+			t.Fatalf("decode session destroy json: %v; stdout=%q", err, stdout.String())
+		}
+		if got.SessionID != "asess_test" || !got.Destroyed {
+			t.Fatalf("session destroy json = %+v", got)
+		}
+	})
+}
+
+func TestAppSessionCommandFailures(t *testing.T) {
+	t.Run("create random id", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		client := &appFakeDaemonClient{}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+		app.RandomReader = failingRandomReader{err: errors.New("entropy unavailable")}
+
+		code := app.Run(context.Background(), []string{
+			"session", "create",
+			"--reason", "Deploy",
+			"--account", "Work",
+			"--secret", "TOKEN=op://Example/Item/token",
+		})
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1", code)
+		}
+		if !strings.Contains(stderr.String(), "generate random id") {
+			t.Fatalf("stderr = %q, want random id failure", stderr.String())
+		}
+		if client.sessionCreateCalls != 0 {
+			t.Fatalf("session create calls = %d, want 0", client.sessionCreateCalls)
+		}
+	})
+
+	t.Run("create daemon error", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		client := &appFakeDaemonClient{sessionCreateErr: errors.New("approval denied")}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{
+			"session", "create",
+			"--reason", "Deploy",
+			"--account", "Work",
+			"--secret", "TOKEN=op://Example/Item/token",
+		})
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1", code)
+		}
+		if !strings.Contains(stderr.String(), "approval denied") {
+			t.Fatalf("stderr = %q", stderr.String())
+		}
+		if client.sessionCreateCalls != 1 {
+			t.Fatalf("session create calls = %d, want 1", client.sessionCreateCalls)
+		}
+	})
+
+	t.Run("list daemon error", func(t *testing.T) {
+		client := &appFakeDaemonClient{sessionListErr: errors.New("daemon unavailable")}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{"session", "list"})
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1", code)
+		}
+		if !strings.Contains(stderr.String(), "daemon unavailable") {
+			t.Fatalf("stderr = %q", stderr.String())
+		}
+	})
+
+	t.Run("destroy daemon error", func(t *testing.T) {
+		client := &appFakeDaemonClient{sessionDestroyErr: errors.New("session not found")}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{"session", "destroy", "asess_missing"})
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1", code)
+		}
+		if !strings.Contains(stderr.String(), "session not found") {
+			t.Fatalf("stderr = %q", stderr.String())
+		}
+	})
+
+	t.Run("with-session resolve error", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		client := &appFakeDaemonClient{sessionResolveErr: errors.New("session expired")}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{
+			"with-session",
+			"asess_test",
+			"--cwd", root,
+			"--allow-mutable-executable",
+			"--",
+			os.Args[0], "-test.run=TestAppSessionCommandFailures", "--", "child",
+		})
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1", code)
+		}
+		if !strings.Contains(stderr.String(), "session expired") {
+			t.Fatalf("stderr = %q", stderr.String())
+		}
+		if len(client.startedPIDs) != 0 {
+			t.Fatalf("started pids = %v, want none", client.startedPIDs)
+		}
+	})
+}
+
+func TestAppWithSessionRunsChildWithResolvedEnv(t *testing.T) {
+	if os.Getenv("AGENT_SECRET_APP_EXEC_HELPER") == "1" {
+		runAppExecHelper()
+		return
+	}
+
+	root := t.TempDir()
+	t.Chdir(root)
+	client := &appFakeDaemonClient{
+		sessionResolvePayload: protocol.SessionResolveResponsePayload{
+			Env:           map[string]string{"TOKEN": "synthetic-secret-value"},
+			SecretAliases: []string{"TOKEN"},
+		},
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(t.TempDir(), "d.sock"),
+		client:     client,
+		status:     protocol.StatusPayload{PID: 1234},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	t.Setenv("AGENT_SECRET_APP_EXEC_HELPER", "1")
+
+	code := app.Run(context.Background(), []string{
+		"with-session",
+		"asess_test",
+		"--cwd", root,
+		"--allow-mutable-executable",
+		"--",
+		os.Args[0], "-test.run=TestAppWithSessionRunsChildWithResolvedEnv", "--", "child",
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "env-ok" {
+		t.Fatalf("stdout = %q, want env-ok", stdout.String())
+	}
+	if client.sessionResolveCalls != 1 || client.closeCalls != 1 {
+		t.Fatalf("client calls: resolve=%d close=%d", client.sessionResolveCalls, client.closeCalls)
+	}
+	if len(client.sessionResolveRequests) != 1 {
+		t.Fatalf("session resolve requests = %d", len(client.sessionResolveRequests))
+	}
+	req := client.sessionResolveRequests[0]
+	if req.SessionID != "asess_test" || req.ExpectedPeer.PID <= 0 || req.CWD == "" {
+		t.Fatalf("session resolve request = %+v", req)
+	}
+	if len(client.startedPIDs) != 1 || len(client.completedExitCodes) != 1 {
+		t.Fatalf("audit calls: started=%v completed=%v", client.startedPIDs, client.completedExitCodes)
+	}
+	if strings.Contains(stderr.String(), "synthetic-secret-value") {
+		t.Fatalf("stderr leaked secret: %q", stderr.String())
+	}
+}
+
 func TestAppItemDescribePrintsMetadataWithoutSecretValues(t *testing.T) {
 	t.Parallel()
 
@@ -2086,22 +2547,37 @@ func (m *appFakeDaemonManager) SocketPath() string {
 }
 
 type appFakeDaemonClient struct {
-	execPayload         protocol.ExecResponsePayload
-	itemDescribePayload protocol.ItemDescribeResponsePayload
+	execPayload           protocol.ExecResponsePayload
+	itemDescribePayload   protocol.ItemDescribeResponsePayload
+	sessionCreatePayload  protocol.SessionCreateResponsePayload
+	sessionResolvePayload protocol.SessionResolveResponsePayload
+	sessionDestroyPayload protocol.SessionDestroyResponsePayload
+	sessionListPayload    protocol.SessionListResponsePayload
 
 	requestErr         error
 	itemDescribeErr    error
+	sessionCreateErr   error
+	sessionResolveErr  error
+	sessionDestroyErr  error
+	sessionListErr     error
 	reportStartedErr   error
 	reportCompletedErr error
 	closeErr           error
 
-	requestExecCalls     int
-	itemDescribeCalls    int
-	requests             []request.ExecRequest
-	itemDescribeRequests []request.ItemDescribeRequest
-	closeCalls           int
-	startedPIDs          []int
-	completedExitCodes   []int
+	requestExecCalls       int
+	itemDescribeCalls      int
+	sessionCreateCalls     int
+	sessionResolveCalls    int
+	sessionDestroyCalls    int
+	sessionListCalls       int
+	requests               []request.ExecRequest
+	itemDescribeRequests   []request.ItemDescribeRequest
+	sessionCreateRequests  []request.SessionCreateRequest
+	sessionResolveRequests []request.SessionResolveRequest
+	sessionDestroyRequests []request.SessionDestroyRequest
+	closeCalls             int
+	startedPIDs            []int
+	completedExitCodes     []int
 }
 
 func (c *appFakeDaemonClient) Close() error {
@@ -2127,6 +2603,40 @@ func (c *appFakeDaemonClient) DescribeItem(
 	c.itemDescribeCalls++
 	c.itemDescribeRequests = append(c.itemDescribeRequests, req)
 	return c.itemDescribePayload, c.itemDescribeErr
+}
+
+func (c *appFakeDaemonClient) CreateSession(
+	_ context.Context,
+	_ protocol.Correlation,
+	req request.SessionCreateRequest,
+) (protocol.SessionCreateResponsePayload, error) {
+	c.sessionCreateCalls++
+	c.sessionCreateRequests = append(c.sessionCreateRequests, req)
+	return c.sessionCreatePayload, c.sessionCreateErr
+}
+
+func (c *appFakeDaemonClient) ResolveSession(
+	_ context.Context,
+	_ protocol.Correlation,
+	req request.SessionResolveRequest,
+) (protocol.SessionResolveResponsePayload, error) {
+	c.sessionResolveCalls++
+	c.sessionResolveRequests = append(c.sessionResolveRequests, req)
+	return c.sessionResolvePayload, c.sessionResolveErr
+}
+
+func (c *appFakeDaemonClient) DestroySession(
+	_ context.Context,
+	req request.SessionDestroyRequest,
+) (protocol.SessionDestroyResponsePayload, error) {
+	c.sessionDestroyCalls++
+	c.sessionDestroyRequests = append(c.sessionDestroyRequests, req)
+	return c.sessionDestroyPayload, c.sessionDestroyErr
+}
+
+func (c *appFakeDaemonClient) ListSessions(_ context.Context) (protocol.SessionListResponsePayload, error) {
+	c.sessionListCalls++
+	return c.sessionListPayload, c.sessionListErr
 }
 
 func (c *appFakeDaemonClient) ReportStarted(_ context.Context, _ protocol.Correlation, childPID int) error {
@@ -2447,7 +2957,13 @@ func handlePostStartStoppedDaemonConn(conn *net.UnixConn, events chan<- protocol
 			if err := writePostStartStoppedDaemonOK(encoder, env.RequestID, env.Nonce, payload); err != nil {
 				return err
 			}
-		case protocol.TypeItemDescribe, protocol.TypeCommandStarted, protocol.TypeCommandCompleted:
+		case protocol.TypeItemDescribe,
+			protocol.TypeSessionCreate,
+			protocol.TypeSessionResolve,
+			protocol.TypeSessionDestroy,
+			protocol.TypeSessionList,
+			protocol.TypeCommandStarted,
+			protocol.TypeCommandCompleted:
 			if err := writePostStartStoppedDaemonError(encoder, env.RequestID, env.Nonce, protocol.ErrorCodeDaemonStopped, daemonbroker.ErrDaemonStopped); err != nil {
 				return err
 			}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -596,6 +596,7 @@ func TestAppWithSessionRunsChildWithResolvedEnv(t *testing.T) {
 		"with-session",
 		"asess_test",
 		"--cwd", root,
+		"--only", "TOKEN",
 		"--allow-mutable-executable",
 		"--",
 		os.Args[0], "-test.run=TestAppWithSessionRunsChildWithResolvedEnv", "--", "child",
@@ -615,6 +616,9 @@ func TestAppWithSessionRunsChildWithResolvedEnv(t *testing.T) {
 	req := client.sessionResolveRequests[0]
 	if req.SessionID != "asess_test" || req.ExpectedPeer.PID <= 0 || req.CWD == "" {
 		t.Fatalf("session resolve request = %+v", req)
+	}
+	if len(req.RequestedAliases) != 1 || req.RequestedAliases[0] != "TOKEN" {
+		t.Fatalf("requested aliases = %v, want TOKEN", req.RequestedAliases)
 	}
 	if len(client.startedPIDs) != 1 || len(client.completedExitCodes) != 1 {
 		t.Fatalf("audit calls: started=%v completed=%v", client.startedPIDs, client.completedExitCodes)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -21,38 +21,46 @@ var (
 type Kind string
 
 const (
-	KindHelp         Kind = "help"
-	KindVersion      Kind = "version"
-	KindAgentContext Kind = "agent_context"
-	KindExec         Kind = "exec"
-	KindItemDescribe Kind = "item_describe"
-	KindProfileList  Kind = "profile_list"
-	KindProfileShow  Kind = "profile_show"
-	KindDoctor       Kind = "doctor"
-	KindBitwarden    Kind = "bitwarden"
-	KindInstallCLI   Kind = "install_cli"
-	KindSkillInstall Kind = "skill_install"
-	KindDaemonStart  Kind = "daemon_start"
-	KindDaemonStop   Kind = "daemon_stop"
-	KindDaemonStatus Kind = "daemon_status"
+	KindHelp           Kind = "help"
+	KindVersion        Kind = "version"
+	KindAgentContext   Kind = "agent_context"
+	KindExec           Kind = "exec"
+	KindItemDescribe   Kind = "item_describe"
+	KindSessionCreate  Kind = "session_create"
+	KindSessionList    Kind = "session_list"
+	KindSessionDestroy Kind = "session_destroy"
+	KindWithSession    Kind = "with_session"
+	KindProfileList    Kind = "profile_list"
+	KindProfileShow    Kind = "profile_show"
+	KindDoctor         Kind = "doctor"
+	KindBitwarden      Kind = "bitwarden"
+	KindInstallCLI     Kind = "install_cli"
+	KindSkillInstall   Kind = "skill_install"
+	KindDaemonStart    Kind = "daemon_start"
+	KindDaemonStop     Kind = "daemon_stop"
+	KindDaemonStatus   Kind = "daemon_status"
 )
 
 type Command struct {
-	Kind                Kind
-	OutputJSON          bool
-	ExecRequest         request.ExecRequest
-	ExecEnv             []string
-	ExecDryRun          bool
-	ItemDescribeRequest request.ItemDescribeRequest
-	ItemDescribeFormat  itemmetadata.Format
-	ItemDescribePrefix  string
-	AgentContextOptions ConfigCommandOptions
-	ProfileOptions      ProfileCommandOptions
-	BitwardenOptions    BitwardenCommandOptions
-	InstallCLIOptions   install.CLIOptions
-	InstallSkillOptions install.SkillOptions
-	HelpText            string
-	VersionText         string
+	Kind                  Kind
+	OutputJSON            bool
+	ExecRequest           request.ExecRequest
+	ExecEnv               []string
+	ExecDryRun            bool
+	SessionCreateRequest  request.SessionCreateRequest
+	SessionResolveRequest request.SessionResolveRequest
+	SessionDestroyRequest request.SessionDestroyRequest
+	SessionEnv            []string
+	ItemDescribeRequest   request.ItemDescribeRequest
+	ItemDescribeFormat    itemmetadata.Format
+	ItemDescribePrefix    string
+	AgentContextOptions   ConfigCommandOptions
+	ProfileOptions        ProfileCommandOptions
+	BitwardenOptions      BitwardenCommandOptions
+	InstallCLIOptions     install.CLIOptions
+	InstallSkillOptions   install.SkillOptions
+	HelpText              string
+	VersionText           string
 }
 
 type Parser struct {
@@ -77,6 +85,10 @@ func (p Parser) Parse(args []string) (Command, error) {
 		return parseAgentContext(args[1:])
 	case "exec":
 		return p.parseExec(args[1:])
+	case "session":
+		return p.parseSession(args[1:])
+	case "with-session":
+		return p.parseWithSession(args[1:])
 	case "item":
 		return p.parseItem(args[1:], args)
 	case "profile":
@@ -93,7 +105,7 @@ func (p Parser) Parse(args []string) (Command, error) {
 		return parseSkillInstall(args[1:])
 	default:
 		return Command{}, fmt.Errorf(
-			"%w: unknown command %q; expected one of: agent-context, bitwarden, daemon, doctor, exec, help, install-cli, item, profile, skill-install, version",
+			"%w: unknown command %q; expected one of: agent-context, bitwarden, daemon, doctor, exec, help, install-cli, item, profile, session, skill-install, version, with-session",
 			ErrInvalidArguments,
 			args[0],
 		)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1467,6 +1467,72 @@ func TestParseSkillInstallOptions(t *testing.T) {
 	}
 }
 
+func TestParseSessionListDestroyAndHelp(t *testing.T) {
+	t.Parallel()
+
+	parser := NewParser()
+	listCommand, err := parser.Parse([]string{"session", "list", "--json"})
+	if err != nil {
+		t.Fatalf("Parse session list returned error: %v", err)
+	}
+	if listCommand.Kind != KindSessionList || !listCommand.OutputJSON {
+		t.Fatalf("session list command = %+v", listCommand)
+	}
+
+	destroyCommand, err := parser.Parse([]string{"session", "destroy", "--json", "asess_abc123"})
+	if err != nil {
+		t.Fatalf("Parse session destroy returned error: %v", err)
+	}
+	if destroyCommand.Kind != KindSessionDestroy ||
+		!destroyCommand.OutputJSON ||
+		destroyCommand.SessionDestroyRequest.SessionID != "asess_abc123" {
+		t.Fatalf("session destroy command = %+v", destroyCommand)
+	}
+
+	for _, args := range [][]string{
+		{"session", "--help"},
+		{"with-session", "--help"},
+	} {
+		command, err := parser.Parse(args)
+		if !errors.Is(err, ErrHelpRequested) {
+			t.Fatalf("Parse %v error = %v, want ErrHelpRequested", args, err)
+		}
+		if command.Kind != KindHelp || !strings.Contains(command.HelpText, "session") {
+			t.Fatalf("help command for %v = %+v", args, command)
+		}
+	}
+}
+
+func TestParseSessionRejectsInvalidForms(t *testing.T) {
+	t.Parallel()
+
+	parser := NewParser()
+	tests := []struct {
+		name string
+		args []string
+		want error
+	}{
+		{name: "unknown session command", args: []string{"session", "open"}, want: ErrInvalidArguments},
+		{name: "create child command", args: []string{"session", "create", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token", "--", "tool"}, want: ErrInvalidArguments},
+		{name: "list args", args: []string{"session", "list", "asess_abc"}, want: ErrInvalidArguments},
+		{name: "destroy missing id", args: []string{"session", "destroy"}, want: ErrInvalidArguments},
+		{name: "destroy bad id", args: []string{"session", "destroy", "bad"}, want: request.ErrInvalidSessionID},
+		{name: "with-session missing boundary", args: []string{"with-session", "asess_abc", "tool"}, want: ErrShellStringCommand},
+		{name: "with-session missing command", args: []string{"with-session", "asess_abc", "--"}, want: ErrShellStringCommand},
+		{name: "with-session misplaced arg", args: []string{"with-session", "asess_abc", "extra", "--", "tool"}, want: ErrInvalidArguments},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parser.Parse(tt.args)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Parse error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestHelpIsDetailedAndValueFree(t *testing.T) {
 	t.Parallel()
 
@@ -1479,7 +1545,7 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 		{
 			name:  "top",
 			args:  []string{"--help"},
-			wants: []string{"agent-secret controls", "agent-context", "exec", "item", "profile", "install-cli", "skill-install", "daemon", "doctor", "version", "desktop account"},
+			wants: []string{"agent-secret controls", "agent-context", "exec", "session", "with-session", "item", "profile", "install-cli", "skill-install", "daemon", "doctor", "version", "desktop account"},
 		},
 		{
 			name:  "agent-context",
@@ -1500,6 +1566,16 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 			name:  "exec",
 			args:  []string{"exec", "--help"},
 			wants: []string{"--reason", "--secret", "--profile", "--only", "--env-file", "--account", "include:", "account:", "default_profile", "agent-secret.yml", "--force-refresh", "--dry-run", "--reuse-only", "--allow-mutable-executable", "Default account", "audit.jsonl", "stdin", "stdout", "stderr"},
+		},
+		{
+			name:  "session",
+			args:  []string{"session", "--help"},
+			wants: []string{"session create", "List active", "session destroy", "--max-reads", "with-session"},
+		},
+		{
+			name:  "with-session",
+			args:  []string{"with-session", "--help"},
+			wants: []string{"with-session SESSION_ID", "--cwd", "--allow-mutable-executable", "never printed"},
 		},
 		{
 			name:  "profile",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1503,6 +1503,78 @@ func TestParseSessionListDestroyAndHelp(t *testing.T) {
 	}
 }
 
+func TestParseSessionCreateBuildsMultiSecretBagFromProfileAndCLI(t *testing.T) {
+	root := t.TempDir()
+	writeProfileConfig(t, root, `
+version: 1
+profiles:
+  deploy:
+    account: Work
+    reason: Deploy workflow
+    ttl: 10m
+    secrets:
+      A_TOKEN: op://Example/A/token
+      B_TOKEN: op://Example/B/token
+`)
+	t.Chdir(root)
+
+	command, err := NewParser().Parse([]string{
+		"session",
+		"create",
+		"--profile", "deploy",
+		"--secret", "CLI_TOKEN=op://Example/CLI/token",
+		"--max-reads", "3",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("Parse session create returned error: %v", err)
+	}
+	if command.Kind != KindSessionCreate || !command.OutputJSON {
+		t.Fatalf("command = %+v, want session create json", command)
+	}
+	req := command.SessionCreateRequest
+	if req.Reason != "Deploy workflow" || req.TTL != 10*time.Minute || req.MaxReads != 3 {
+		t.Fatalf("session create policy = %+v", req)
+	}
+	aliases := make([]string, 0, len(req.Secrets))
+	for _, secret := range req.Secrets {
+		aliases = append(aliases, secret.Alias)
+		if secret.Account != "Work" {
+			t.Fatalf("secret %s account = %q, want Work", secret.Alias, secret.Account)
+		}
+	}
+	if strings.Join(aliases, ",") != "A_TOKEN,B_TOKEN,CLI_TOKEN" {
+		t.Fatalf("secret aliases = %v", aliases)
+	}
+}
+
+func TestParseWithSessionRecordsRequestedAliases(t *testing.T) {
+	root := t.TempDir()
+	writeExecutable(t, root, "tool")
+	t.Chdir(root)
+	t.Setenv("PATH", root)
+
+	command, err := NewParser().Parse([]string{
+		"with-session",
+		"asess_abc123",
+		"--cwd", root,
+		"--only", "B_TOKEN,A_TOKEN",
+		"--allow-mutable-executable",
+		"--",
+		"tool",
+	})
+	if err != nil {
+		t.Fatalf("Parse with-session returned error: %v", err)
+	}
+	if command.Kind != KindWithSession {
+		t.Fatalf("kind = %s, want with-session", command.Kind)
+	}
+	req := command.SessionResolveRequest
+	if strings.Join(req.RequestedAliases, ",") != "A_TOKEN,B_TOKEN" {
+		t.Fatalf("requested aliases = %v, want sorted A_TOKEN,B_TOKEN", req.RequestedAliases)
+	}
+}
+
 func TestParseSessionRejectsInvalidForms(t *testing.T) {
 	t.Parallel()
 
@@ -1575,7 +1647,7 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 		{
 			name:  "with-session",
 			args:  []string{"with-session", "--help"},
-			wants: []string{"with-session SESSION_ID", "--cwd", "--allow-mutable-executable", "never printed"},
+			wants: []string{"with-session SESSION_ID", "--cwd", "--only", "--allow-mutable-executable", "never printed"},
 		},
 		{
 			name:  "profile",

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -146,6 +146,9 @@ func (p Parser) resolveExecInputs(flags execFlags) (execInputs, error) {
 	if err != nil {
 		return execInputs{}, err
 	}
+	if err := request.ValidateReason(sources.reason); err != nil {
+		return execInputs{}, err
+	}
 	secrets, err := p.resolveExecSecrets(flags, sources)
 	if err != nil {
 		return execInputs{}, err
@@ -233,19 +236,66 @@ func assembleExecSecrets(
 	sources execInputSources,
 	filtered filteredExecSecretSources,
 ) []request.SecretSpec {
-	accountFallback := execSecretAccountFallback(flags, sources)
 	if sources.loadedProfile {
+		profileSecrets := append(slices.Clone(filtered.profileSecrets), flags.secrets.specs...)
+		profileSecrets = append(profileSecrets, filtered.envFileSecrets...)
+		accountFallback := profileAccountFallback(flags, sources, profileSecrets)
 		return assembleProfileExecSecrets(flags, sources, filtered, accountFallback)
 	}
+	directSecrets := append(slices.Clone(flags.secrets.specs), filtered.envFileSecrets...)
+	accountFallback := execSecretAccountFallbackForSecrets(flags, sources, directSecrets)
 	return assembleDirectExecSecrets(flags, filtered, accountFallback)
 }
 
-func execSecretAccountFallback(flags execFlags, sources execInputSources) string {
-	accountFallback := execAccountFallback(flags.account)
-	if strings.TrimSpace(flags.account) == "" && !sources.loadedProfile && strings.TrimSpace(sources.configAccount) != "" {
-		return sources.configAccount
+func profileAccountFallback(flags execFlags, sources execInputSources, secrets []request.SecretSpec) string {
+	if account := strings.TrimSpace(flags.account); account != "" {
+		return account
 	}
-	return accountFallback
+	if account := strings.TrimSpace(sources.profile.Account); account != "" {
+		return account
+	}
+	if !needsOnePasswordAccountFallback(secrets) {
+		return ""
+	}
+	return execSecretAccountFallback(flags, sources)
+}
+
+func execSecretAccountFallbackForSecrets(
+	flags execFlags,
+	sources execInputSources,
+	secrets []request.SecretSpec,
+) string {
+	if !needsOnePasswordAccountFallback(secrets) {
+		return ""
+	}
+	return execSecretAccountFallback(flags, sources)
+}
+
+func needsOnePasswordAccountFallback(secrets []request.SecretSpec) bool {
+	for _, secret := range secrets {
+		if strings.TrimSpace(secret.Account) != "" {
+			continue
+		}
+		if secretref.IsBitwardenSecretsManager(secret.Ref) {
+			continue
+		}
+		if strings.HasPrefix(secret.Ref, secretref.OnePasswordScheme) {
+			return true
+		}
+	}
+	return false
+}
+
+func execSecretAccountFallback(flags execFlags, sources execInputSources) string {
+	if account := strings.TrimSpace(flags.account); account != "" {
+		return account
+	}
+	if !sources.loadedProfile {
+		if account := strings.TrimSpace(sources.configAccount); account != "" {
+			return account
+		}
+	}
+	return execAccountFallback("")
 }
 
 func assembleProfileExecSecrets(

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -358,7 +358,7 @@ func SessionHelp() string {
 
 	  agent-secret session create --profile terraform-cloudflare --max-reads 2
 	  agent-secret with-session asess_123 -- terraform plan
-	  agent-secret with-session asess_123 -- terraform apply
+	  agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN,STATE_TOKEN -- terraform apply
 	  agent-secret session destroy asess_123
 
 	Values are never printed. Session values live in daemon memory only until TTL,
@@ -372,17 +372,19 @@ func WithSessionHelp() string {
 
 	Usage:
 
-	  agent-secret with-session SESSION_ID [--cwd DIR] -- COMMAND [ARG...]
+	  agent-secret with-session SESSION_ID [--cwd DIR] [--only ALIAS[,ALIAS...]] -- COMMAND [ARG...]
 
 	Flags:
 
 	  --cwd DIR       Child working directory. Defaults to caller cwd and must match the session cwd.
+	  --only ALIAS    Inject only selected aliases from the approved session. Repeat or pass comma-separated aliases.
 	  --allow-mutable-executable
 	                  Allow a user-owned or writable executable path after showing the approval warning.
 	  -h, --help      Show this help.
 
 	The session id must come from agent-secret session create. Secret values are
 	injected into the child environment only and are never printed by agent-secret.
+	Without --only, every approved session alias is injected for that command.
 	`)
 }
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -17,8 +17,10 @@ Secrets are never printed by agent-secret and are never written to disk. The nor
 Commands:
 
   agent-context Print a machine-readable command and config discovery schema.
-  exec       Run a command with approved secrets injected as environment variables.
-  item       Inspect 1Password item metadata without revealing secret values.
+	  exec       Run a command with approved secrets injected as environment variables.
+	  session    Create, list, and destroy bounded daemon-held secret sessions.
+	  with-session Run a command with secrets from an approved session.
+	  item       Inspect 1Password item metadata without revealing secret values.
   profile    Inspect project profiles without resolving secret values.
   bitwarden  Manage local Bitwarden Secrets Manager token aliases.
   install-cli Install or repair the agent-secret command symlink for this user.
@@ -72,15 +74,16 @@ Safety rules:
   - normal exec has no --json mode and never prints secret values.
   - exec --dry-run --json validates locally without starting the daemon, prompting, resolving values, or spawning the child.
   - exec --reuse-only uses a matching reusable approval or fails without opening a new approval prompt.
-  - Text file/document refs such as op://Example/GitHub App/key.pem are injected as env values; binary attachments are not supported.
+	  - Text file/document refs such as op://Example/GitHub App/key.pem are injected as env values; binary attachments are not supported.
+	  - session create returns an opaque handle only; values stay in daemon memory and are injected only by with-session.
   - item describe requires approval and prints item metadata only: field labels, types, concealment flags, and refs.
   - agent-secret skill-install links the bundled Agent Secret skill into ~/.agents/skills/agent-secret.
   - Reusable approval is selected only in the approval UI, not by a CLI flag.
   - Audit metadata is written to ~/Library/Logs/agent-secret/audit.jsonl.
   - Non-zero child exits are returned as child exits, not as broker failures.
 
-	Run agent-secret exec --help for flags and more examples.
-`)
+		Run agent-secret exec --help or agent-secret session --help for flags and more examples.
+	`)
 }
 
 func AgentContextHelp() string {
@@ -338,7 +341,49 @@ Exit behavior:
   If --reuse-only has no matching reusable approval, the child is not spawned and no new approval prompt opens.
   After the child starts, stdin, stdout, and stderr are passed through. The wrapper returns the child exit status.
   Audit metadata is written to ~/Library/Logs/agent-secret/audit.jsonl.
-`)
+	`)
+}
+
+func SessionHelp() string {
+	return strings.TrimSpace(`
+	agent-secret session creates short daemon-held sessions for bounded multi-command workflows.
+
+	Commands:
+
+	  create   Ask for approval, resolve requested refs, and return an opaque session id.
+	  list     List active session ids and non-secret metadata.
+	  destroy  Destroy one session and clear its cached values.
+
+	Examples:
+
+	  agent-secret session create --profile terraform-cloudflare --max-reads 2
+	  agent-secret with-session asess_123 -- terraform plan
+	  agent-secret with-session asess_123 -- terraform apply
+	  agent-secret session destroy asess_123
+
+	Values are never printed. Session values live in daemon memory only until TTL,
+	read count exhaustion, destroy, or daemon stop.
+	`)
+}
+
+func WithSessionHelp() string {
+	return strings.TrimSpace(`
+	agent-secret with-session runs one command with secrets from an approved session.
+
+	Usage:
+
+	  agent-secret with-session SESSION_ID [--cwd DIR] -- COMMAND [ARG...]
+
+	Flags:
+
+	  --cwd DIR       Child working directory. Defaults to caller cwd and must match the session cwd.
+	  --allow-mutable-executable
+	                  Allow a user-owned or writable executable path after showing the approval warning.
+	  -h, --help      Show this help.
+
+	The session id must come from agent-secret session create. Secret values are
+	injected into the child environment only and are never printed by agent-secret.
+	`)
 }
 
 func DaemonHelp() string {

--- a/internal/cli/request_builder.go
+++ b/internal/cli/request_builder.go
@@ -139,6 +139,7 @@ type sessionResolveRequestBuildOptions struct {
 	cwd                    string
 	env                    []string
 	allowMutableExecutable bool
+	requestedAliases       []string
 }
 
 func buildSessionResolveRequest(opts sessionResolveRequestBuildOptions) (request.SessionResolveRequest, error) {
@@ -163,7 +164,7 @@ func buildSessionResolveRequest(opts sessionResolveRequestBuildOptions) (request
 	if err != nil {
 		return request.SessionResolveRequest{}, fmt.Errorf("%w: capture executable identity: %w", request.ErrInvalidCommand, err)
 	}
-	return request.NewSessionResolve(
+	req, err := request.NewSessionResolve(
 		opts.sessionID,
 		command,
 		resolvedExecutable,
@@ -171,6 +172,10 @@ func buildSessionResolveRequest(opts sessionResolveRequestBuildOptions) (request
 		cwd,
 		request.EnvironmentFingerprint(env),
 	)
+	if err != nil {
+		return request.SessionResolveRequest{}, err
+	}
+	return req.WithRequestedAliases(opts.requestedAliases)
 }
 
 func buildItemDescribeRequest(opts itemDescribeRequestBuildOptions) (request.ItemDescribeRequest, error) {

--- a/internal/cli/request_builder.go
+++ b/internal/cli/request_builder.go
@@ -89,6 +89,90 @@ type itemDescribeRequestBuildOptions struct {
 	ttl                time.Duration
 }
 
+type sessionCreateRequestBuildOptions struct {
+	reason             string
+	command            []string
+	cwd                string
+	resolvedExecutable string
+	secrets            []request.SecretSpec
+	ttl                time.Duration
+	maxReads           int
+	overrideEnv        bool
+}
+
+func buildSessionCreateRequest(opts sessionCreateRequestBuildOptions) (request.SessionCreateRequest, error) {
+	cwd, err := normalizeCWD(opts.cwd)
+	if err != nil {
+		return request.SessionCreateRequest{}, err
+	}
+	resolvedExecutable := opts.resolvedExecutable
+	if resolvedExecutable == "" {
+		resolvedExecutable, err = os.Executable()
+		if err != nil {
+			return request.SessionCreateRequest{}, fmt.Errorf("resolve current executable: %w", err)
+		}
+	}
+	resolvedExecutable, err = validateExecutable(resolvedExecutable)
+	if err != nil {
+		return request.SessionCreateRequest{}, err
+	}
+	executableIdentity, err := fileidentity.Capture(resolvedExecutable)
+	if err != nil {
+		return request.SessionCreateRequest{}, fmt.Errorf("%w: capture executable identity: %w", request.ErrInvalidCommand, err)
+	}
+	return request.NewSessionCreate(request.SessionCreateOptions{
+		Reason:             opts.reason,
+		Command:            opts.command,
+		ResolvedExecutable: resolvedExecutable,
+		ExecutableIdentity: executableIdentity,
+		CWD:                cwd,
+		Secrets:            opts.secrets,
+		TTL:                opts.ttl,
+		MaxReads:           opts.maxReads,
+		OverrideEnv:        opts.overrideEnv,
+	})
+}
+
+type sessionResolveRequestBuildOptions struct {
+	sessionID              string
+	command                []string
+	cwd                    string
+	env                    []string
+	allowMutableExecutable bool
+}
+
+func buildSessionResolveRequest(opts sessionResolveRequestBuildOptions) (request.SessionResolveRequest, error) {
+	cwd, err := normalizeCWD(opts.cwd)
+	if err != nil {
+		return request.SessionResolveRequest{}, err
+	}
+	env := slices.Clone(opts.env)
+	command, resolvedExecutable, err := resolveCommand(cwd, env, opts.command)
+	if err != nil {
+		return request.SessionResolveRequest{}, err
+	}
+	if !opts.allowMutableExecutable {
+		if err := executabletrust.ValidateStableExecutable(resolvedExecutable); err != nil {
+			return request.SessionResolveRequest{}, fmt.Errorf(
+				"%w: rerun with --allow-mutable-executable only if you trust the executable path",
+				err,
+			)
+		}
+	}
+	executableIdentity, err := fileidentity.Capture(resolvedExecutable)
+	if err != nil {
+		return request.SessionResolveRequest{}, fmt.Errorf("%w: capture executable identity: %w", request.ErrInvalidCommand, err)
+	}
+	return request.NewSessionResolve(
+		opts.sessionID,
+		command,
+		resolvedExecutable,
+		executableIdentity,
+		cwd,
+		request.EnvironmentFingerprint(env),
+	)
+}
+
 func buildItemDescribeRequest(opts itemDescribeRequestBuildOptions) (request.ItemDescribeRequest, error) {
 	cwd, err := normalizeCWD(opts.cwd)
 	if err != nil {

--- a/internal/cli/session_parse.go
+++ b/internal/cli/session_parse.go
@@ -28,6 +28,7 @@ type sessionCreateFlags struct {
 type withSessionFlags struct {
 	cwd                    string
 	allowMutableExecutable bool
+	only                   onlyFlags
 }
 
 func (p Parser) parseSession(args []string) (Command, error) {
@@ -157,6 +158,7 @@ func (p Parser) parseWithSession(args []string) (Command, error) {
 		false,
 		"allow a user-owned or writable executable path after showing the approval warning",
 	)
+	fs.Var(&flags.only, "only", "session alias filter")
 	if err := fs.Parse(args[1:boundary]); err != nil {
 		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
 	}
@@ -170,6 +172,7 @@ func (p Parser) parseWithSession(args []string) (Command, error) {
 		cwd:                    flags.cwd,
 		env:                    env,
 		allowMutableExecutable: flags.allowMutableExecutable,
+		requestedAliases:       flags.only.aliases,
 	})
 	if err != nil {
 		return Command{}, fmt.Errorf("build with-session request: %w", err)

--- a/internal/cli/session_parse.go
+++ b/internal/cli/session_parse.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/request"
+)
+
+type sessionCreateFlags struct {
+	reason      string
+	cwd         string
+	ttl         time.Duration
+	maxReads    int
+	profileName string
+	configPath  string
+	account     string
+	overrideEnv bool
+	json        bool
+	secrets     secretFlags
+	only        onlyFlags
+	envFiles    envFileFlags
+}
+
+type withSessionFlags struct {
+	cwd                    string
+	allowMutableExecutable bool
+}
+
+func (p Parser) parseSession(args []string) (Command, error) {
+	if len(args) == 0 {
+		return Command{}, fmt.Errorf("%w: session requires create, list, or destroy", ErrInvalidArguments)
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		return Command{Kind: KindHelp, HelpText: SessionHelp()}, ErrHelpRequested
+	case "create":
+		return p.parseSessionCreate(args[1:])
+	case "list":
+		return parseSessionList(args[1:])
+	case "destroy":
+		return parseSessionDestroy(args[1:])
+	default:
+		return Command{}, fmt.Errorf("%w: unknown session command %q; expected create, list, or destroy", ErrInvalidArguments, args[0])
+	}
+}
+
+func (p Parser) parseSessionCreate(args []string) (Command, error) {
+	var flags sessionCreateFlags
+	fs := flag.NewFlagSet("session create", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&flags.reason, "reason", "", "approval reason")
+	fs.StringVar(&flags.cwd, "cwd", "", "session working directory")
+	fs.DurationVar(&flags.ttl, "ttl", 0, "session ttl")
+	fs.IntVar(&flags.maxReads, "max-reads", 0, "session read count")
+	fs.StringVar(&flags.profileName, "profile", "", "profile name")
+	fs.StringVar(&flags.configPath, "config", "", "profile config path")
+	fs.StringVar(&flags.account, "account", "", "1Password account")
+	fs.BoolVar(&flags.overrideEnv, "override-env", false, "allow with-session to override existing env aliases")
+	fs.BoolVar(&flags.json, "json", false, "print json")
+	fs.Var(&flags.secrets, "secret", "secret mapping")
+	fs.Var(&flags.only, "only", "profile alias filter")
+	fs.Var(&flags.envFiles, "env-file", "dotenv env file")
+	if err := fs.Parse(args); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() != 0 {
+		return Command{}, fmt.Errorf("%w: session create does not accept a child command", ErrInvalidArguments)
+	}
+
+	inputs, err := p.resolveExecInputs(execFlags{
+		reason:      flags.reason,
+		cwd:         flags.cwd,
+		ttl:         flags.ttl,
+		profileName: flags.profileName,
+		configPath:  flags.configPath,
+		account:     flags.account,
+		overrideEnv: flags.overrideEnv,
+		secrets:     flags.secrets,
+		only:        flags.only,
+		envFiles:    flags.envFiles,
+	})
+	if err != nil {
+		return Command{}, err
+	}
+	req, err := buildSessionCreateRequest(sessionCreateRequestBuildOptions{
+		reason:      inputs.reason,
+		command:     []string{"agent-secret", "session", "create"},
+		cwd:         flags.cwd,
+		secrets:     inputs.secrets,
+		ttl:         inputs.ttl,
+		maxReads:    flags.maxReads,
+		overrideEnv: flags.overrideEnv,
+	})
+	if err != nil {
+		return Command{}, fmt.Errorf("build session create request: %w", err)
+	}
+	return Command{Kind: KindSessionCreate, OutputJSON: flags.json, SessionCreateRequest: req}, nil
+}
+
+func parseSessionList(args []string) (Command, error) {
+	fs := flag.NewFlagSet("session list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOutput := fs.Bool("json", false, "print json")
+	if err := fs.Parse(args); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() != 0 {
+		return Command{}, fmt.Errorf("%w: session list does not accept arguments", ErrInvalidArguments)
+	}
+	return Command{Kind: KindSessionList, OutputJSON: *jsonOutput}, nil
+}
+
+func parseSessionDestroy(args []string) (Command, error) {
+	fs := flag.NewFlagSet("session destroy", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOutput := fs.Bool("json", false, "print json")
+	if err := fs.Parse(args); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() != 1 {
+		return Command{}, fmt.Errorf("%w: session destroy requires one session id", ErrInvalidArguments)
+	}
+	req, err := request.NewSessionDestroy(fs.Arg(0))
+	if err != nil {
+		return Command{}, err
+	}
+	return Command{Kind: KindSessionDestroy, OutputJSON: *jsonOutput, SessionDestroyRequest: req}, nil
+}
+
+func (p Parser) parseWithSession(args []string) (Command, error) {
+	if len(args) == 0 {
+		return Command{}, fmt.Errorf("%w: with-session requires a session id and -- command", ErrInvalidArguments)
+	}
+	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		return Command{Kind: KindHelp, HelpText: WithSessionHelp()}, ErrHelpRequested
+	}
+	boundary := indexOf(args, "--")
+	if boundary < 0 {
+		return Command{}, ErrShellStringCommand
+	}
+	commandArgs := args[boundary+1:]
+	if len(commandArgs) == 0 {
+		return Command{}, ErrShellStringCommand
+	}
+	sessionID := args[0]
+	var flags withSessionFlags
+	fs := flag.NewFlagSet("with-session", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&flags.cwd, "cwd", "", "working directory")
+	fs.BoolVar(
+		&flags.allowMutableExecutable,
+		"allow-mutable-executable",
+		false,
+		"allow a user-owned or writable executable path after showing the approval warning",
+	)
+	if err := fs.Parse(args[1:boundary]); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() != 0 {
+		return Command{}, fmt.Errorf("%w: with-session flags must appear after the session id and before --", ErrInvalidArguments)
+	}
+	env := os.Environ()
+	req, err := buildSessionResolveRequest(sessionResolveRequestBuildOptions{
+		sessionID:              sessionID,
+		command:                commandArgs,
+		cwd:                    flags.cwd,
+		env:                    env,
+		allowMutableExecutable: flags.allowMutableExecutable,
+	})
+	if err != nil {
+		return Command{}, fmt.Errorf("build with-session request: %w", err)
+	}
+	return Command{Kind: KindWithSession, SessionResolveRequest: req, SessionEnv: env}, nil
+}

--- a/internal/daemon/approval/approval_protocol.go
+++ b/internal/daemon/approval/approval_protocol.go
@@ -29,8 +29,9 @@ type ApprovalRequestPayload struct {
 type ApprovalOperation string
 
 const (
-	ApprovalOperationExec         ApprovalOperation = "exec"
-	ApprovalOperationItemDescribe ApprovalOperation = "item_describe"
+	ApprovalOperationExec          ApprovalOperation = "exec"
+	ApprovalOperationItemDescribe  ApprovalOperation = "item_describe"
+	ApprovalOperationSessionCreate ApprovalOperation = "session_create"
 )
 
 type ApprovalRequestedResource struct {
@@ -116,6 +117,35 @@ func NewItemDescribePayload(
 		OverrideEnv:       false,
 		OverriddenAliases: []string{},
 		ReusableUses:      1,
+	}
+}
+
+func NewSessionCreatePayload(correlation protocol.Correlation, req request.SessionCreateRequest) ApprovalRequestPayload {
+	resources := make([]ApprovalRequestedResource, 0, len(req.Secrets))
+	for _, secret := range req.Secrets {
+		resources = append(resources, ApprovalRequestedResource{
+			Alias:               secret.Alias,
+			Ref:                 secret.Ref.Raw,
+			Account:             secret.Account,
+			Source:              secret.Source,
+			BitwardenTokenAlias: secret.Bitwarden.TokenAlias,
+		})
+	}
+	return ApprovalRequestPayload{
+		Operation:              ApprovalOperationSessionCreate,
+		AllowsReusable:         false,
+		RequestID:              correlation.RequestID,
+		Nonce:                  correlation.Nonce,
+		Reason:                 req.Reason,
+		Command:                slices.Clone(req.Command),
+		CWD:                    req.CWD,
+		ResolvedExecutable:     req.ResolvedExecutable,
+		AllowMutableExecutable: false,
+		ExpiresAt:              req.ExpiresAt,
+		Resources:              resources,
+		OverrideEnv:            req.OverrideEnv,
+		OverriddenAliases:      []string{},
+		ReusableUses:           1,
 	}
 }
 

--- a/internal/daemon/broker/broker.go
+++ b/internal/daemon/broker/broker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/approval"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 	"github.com/kovyrin/agent-secret/internal/itemmetadata"
+	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/policy"
 	"github.com/kovyrin/agent-secret/internal/request"
 	"github.com/kovyrin/agent-secret/internal/secretcache"
@@ -48,6 +50,7 @@ type Broker struct {
 	mu       sync.Mutex
 	now      func() time.Time
 	grants   *grantIssuer
+	sessions *sessionStore
 	approver approval.Approver
 	resolver Resolver
 	audit    AuditSink
@@ -112,6 +115,7 @@ func New(opts Options) (*Broker, error) {
 		active:   make(map[string]*activeExec),
 		stop:     make(chan struct{}),
 	}
+	broker.sessions = newSessionStore(now)
 	broker.grants = newGrantIssuer(
 		now,
 		store,
@@ -123,6 +127,198 @@ func New(opts Options) (*Broker, error) {
 		broker.stopped,
 	)
 	return broker, nil
+}
+
+func (b *Broker) HandleSessionCreate(
+	ctx context.Context,
+	correlation protocol.Correlation,
+	req request.SessionCreateRequest,
+) (protocol.SessionCreateResponsePayload, error) {
+	if correlation.RequestID == "" || correlation.Nonce == "" {
+		return protocol.SessionCreateResponsePayload{}, protocol.ErrInvalidNonce
+	}
+	if b.stopped() {
+		return protocol.SessionCreateResponsePayload{}, ErrDaemonStopped
+	}
+	if err := preflightRequiredAudit(ctx, b.audit); err != nil {
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	if req.Expired(b.now()) {
+		return protocol.SessionCreateResponsePayload{}, approval.ErrRequestExpired
+	}
+	sessionCtx, cancelSession := b.requestContext(ctx, req.ExpiresAt)
+	defer cancelSession()
+
+	if err := recordRequiredAudit(sessionCtx, b.audit, audit.FromSessionCreateRequest(audit.EventApprovalRequested, correlation.RequestID, req)); err != nil {
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	decision, err := b.approver.Approve(sessionCtx, approval.NewSessionCreatePayload(correlation, req))
+	if err != nil {
+		if auditErr := b.recordSessionCreateApprovalError(ctx, correlation.RequestID, req, err); auditErr != nil {
+			return protocol.SessionCreateResponsePayload{}, auditErr
+		}
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	if !decision.Approved {
+		if err := b.recordSessionCreateDenied(ctx, correlation.RequestID, req); err != nil {
+			return protocol.SessionCreateResponsePayload{}, err
+		}
+		return protocol.SessionCreateResponsePayload{}, approval.DenialError(decision.DenialReason)
+	}
+	if err := b.ensureSessionCreateActive(sessionCtx, req); err != nil {
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	if err := recordRequiredAudit(sessionCtx, b.audit, audit.FromSessionCreateRequest(audit.EventApprovalGranted, correlation.RequestID, req)); err != nil {
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	refValues, err := b.grants.resolveUniqueRefs(sessionCtx, correlation.RequestID, execRequestFromSessionCreate(req))
+	if err != nil {
+		return protocol.SessionCreateResponsePayload{}, b.grants.requestError(sessionCtx, execRequestFromSessionCreate(req), err)
+	}
+	if err := b.ensureSessionCreateActive(sessionCtx, req); err != nil {
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	values := fanoutValues(req.Secrets, refValues)
+	summary, err := b.sessions.create(req, values)
+	if err != nil {
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	event := audit.FromSessionCreateRequest(audit.EventSessionCreated, correlation.RequestID, req)
+	event.SessionID = summary.SessionID
+	event.RemainingReads = &summary.RemainingReads
+	event.MaxReads = &summary.MaxReads
+	if err := recordRequiredAudit(sessionCtx, b.audit, event); err != nil {
+		b.sessions.destroy(summary.SessionID)
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	return sessionCreatePayload(summary), nil
+}
+
+func (b *Broker) PrepareSessionResolve(
+	ctx context.Context,
+	correlation protocol.Correlation,
+	req request.SessionResolveRequest,
+	peer peercred.Info,
+) (*SessionResolveDelivery, error) {
+	if correlation.RequestID == "" || correlation.Nonce == "" {
+		return nil, protocol.ErrInvalidNonce
+	}
+	if b.stopped() {
+		return nil, ErrDaemonStopped
+	}
+	if err := preflightRequiredAudit(ctx, b.audit); err != nil {
+		return nil, err
+	}
+	reservation, err := b.sessions.reserve(req, peer)
+	if err != nil {
+		return nil, err
+	}
+	activeReq := execRequestFromSessionResolve(req, reservation)
+	if err := b.activateExec(correlation, activeReq); err != nil {
+		b.sessions.finishReservation(reservation.SessionID, false)
+		return nil, err
+	}
+	delivery := &SessionResolveDelivery{
+		broker:      b,
+		correlation: correlation,
+		req:         req,
+		activeReq:   activeReq,
+		reservation: reservation,
+		payload: protocol.SessionResolveResponsePayload{
+			Env:           reservation.Env,
+			SecretAliases: reservation.SecretAliases,
+			OverrideEnv:   reservation.OverrideEnv,
+		},
+	}
+	return delivery, nil
+}
+
+type SessionResolveDelivery struct {
+	broker       *Broker
+	correlation  protocol.Correlation
+	req          request.SessionResolveRequest
+	activeReq    request.ExecRequest
+	reservation  sessionReservation
+	payload      protocol.SessionResolveResponsePayload
+	finalizeOnce sync.Once
+}
+
+func (d *SessionResolveDelivery) Payload() protocol.SessionResolveResponsePayload {
+	return d.payload
+}
+
+func (d *SessionResolveDelivery) ExpiresAt() time.Time {
+	return d.reservation.ExpiresAt
+}
+
+func (d *SessionResolveDelivery) BeforeWrite(ctx context.Context) error {
+	event := audit.FromSessionResolveRequest(
+		audit.EventSessionResolved,
+		d.correlation.RequestID,
+		d.req,
+		auditRefsForIdentities(d.reservation.Secrets, uniqueSecretIdentities(d.reservation.Secrets)),
+	)
+	event.RemainingReads = &d.reservation.RemainingReads
+	event.MaxReads = &d.reservation.MaxReads
+	if err := recordRequiredAudit(ctx, d.broker.audit, event); err != nil {
+		return err
+	}
+	if err := recordRequiredAudit(ctx, d.broker.audit, audit.FromExecRequest(audit.EventCommandStarting, d.correlation.RequestID, d.activeReq)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *SessionResolveDelivery) CommitDelivered() {
+	d.finalizeOnce.Do(func() {
+		d.broker.sessions.finishReservation(d.reservation.SessionID, true)
+	})
+}
+
+func (d *SessionResolveDelivery) AbortBeforePayload() {
+	d.finalizeOnce.Do(func() {
+		d.broker.deactivateExec(d.correlation)
+		d.broker.sessions.finishReservation(d.reservation.SessionID, false)
+	})
+}
+
+func (b *Broker) HandleSessionDestroy(ctx context.Context, req request.SessionDestroyRequest) (protocol.SessionDestroyResponsePayload, error) {
+	if b.stopped() {
+		return protocol.SessionDestroyResponsePayload{}, ErrDaemonStopped
+	}
+	if err := preflightRequiredAudit(ctx, b.audit); err != nil {
+		return protocol.SessionDestroyResponsePayload{}, err
+	}
+	destroyed := b.sessions.destroy(req.SessionID)
+	event := audit.Event{
+		Type:      audit.EventSessionDestroyed,
+		SessionID: req.SessionID,
+	}
+	if !destroyed {
+		event.ErrorCode = audit.ErrorCode(protocol.ErrorCodeSessionNotFound)
+	}
+	if err := recordRequiredAudit(ctx, b.audit, event); err != nil {
+		return protocol.SessionDestroyResponsePayload{}, err
+	}
+	if !destroyed {
+		return protocol.SessionDestroyResponsePayload{}, ErrSessionNotFound
+	}
+	return protocol.SessionDestroyResponsePayload{SessionID: req.SessionID, Destroyed: true}, nil
+}
+
+func (b *Broker) HandleSessionList(ctx context.Context) (protocol.SessionListResponsePayload, error) {
+	if b.stopped() {
+		return protocol.SessionListResponsePayload{}, ErrDaemonStopped
+	}
+	if err := preflightRequiredAudit(ctx, b.audit); err != nil {
+		return protocol.SessionListResponsePayload{}, err
+	}
+	summaries := b.sessions.list()
+	sessions := make([]protocol.SessionInfoPayload, 0, len(summaries))
+	for _, summary := range summaries {
+		sessions = append(sessions, sessionInfoPayload(summary))
+	}
+	return protocol.SessionListResponsePayload{Sessions: sessions}, nil
 }
 
 func (b *Broker) Now() time.Time {
@@ -489,6 +685,7 @@ func (b *Broker) StopWithAuditEvent(ctx context.Context, event audit.Event) {
 	b.active = make(map[string]*activeExec)
 	b.mu.Unlock()
 	b.grants.clearReusableGrants()
+	b.sessions.clear()
 }
 
 func (b *Broker) RecordStopAttempt(ctx context.Context, event audit.Event) {
@@ -562,5 +759,98 @@ func (b *Broker) stopped() bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func (b *Broker) ensureSessionCreateActive(ctx context.Context, req request.SessionCreateRequest) error {
+	if err := ctx.Err(); err != nil {
+		if errors.Is(context.Cause(ctx), ErrDaemonStopped) {
+			return ErrDaemonStopped
+		}
+		if errors.Is(err, context.DeadlineExceeded) && req.Expired(b.now()) {
+			return approval.ErrRequestExpired
+		}
+		return err
+	}
+	if b.stopped() {
+		return ErrDaemonStopped
+	}
+	if req.Expired(b.now()) {
+		return approval.ErrRequestExpired
+	}
+	return nil
+}
+
+func (b *Broker) recordSessionCreateApprovalError(
+	ctx context.Context,
+	requestID string,
+	req request.SessionCreateRequest,
+	err error,
+) error {
+	if errors.Is(err, approval.ErrRequestExpired) {
+		event := audit.FromSessionCreateRequest(audit.EventApprovalTimedOut, requestID, req)
+		event.ErrorCode = auditErrorCode(protocol.ErrorCodeRequestExpired)
+		return recordTerminalRequiredAudit(ctx, b.audit, event)
+	}
+	return nil
+}
+
+func (b *Broker) recordSessionCreateDenied(ctx context.Context, requestID string, req request.SessionCreateRequest) error {
+	event := audit.FromSessionCreateRequest(audit.EventApprovalDenied, requestID, req)
+	event.ErrorCode = auditErrorCode(protocol.ErrorCodeApprovalDenied)
+	return recordTerminalRequiredAudit(ctx, b.audit, event)
+}
+
+func execRequestFromSessionCreate(req request.SessionCreateRequest) request.ExecRequest {
+	return request.ExecRequest{
+		Reason:             req.Reason,
+		Command:            slices.Clone(req.Command),
+		ResolvedExecutable: req.ResolvedExecutable,
+		ExecutableIdentity: req.ExecutableIdentity,
+		CWD:                req.CWD,
+		Secrets:            slices.Clone(req.Secrets),
+		TTL:                req.TTL,
+		ReceivedAt:         req.ReceivedAt,
+		ExpiresAt:          req.ExpiresAt,
+		OverrideEnv:        req.OverrideEnv,
+	}
+}
+
+func execRequestFromSessionResolve(req request.SessionResolveRequest, reservation sessionReservation) request.ExecRequest {
+	return request.ExecRequest{
+		Reason:                 reservation.Reason,
+		Command:                slices.Clone(req.Command),
+		ResolvedExecutable:     req.ResolvedExecutable,
+		ExecutableIdentity:     req.ExecutableIdentity,
+		CWD:                    req.CWD,
+		EnvironmentFingerprint: req.EnvironmentFingerprint,
+		Secrets:                slices.Clone(reservation.Secrets),
+		TTL:                    time.Until(reservation.ExpiresAt),
+		ReceivedAt:             time.Now(),
+		ExpiresAt:              reservation.ExpiresAt,
+		OverrideEnv:            reservation.OverrideEnv,
+	}
+}
+
+func sessionCreatePayload(summary request.SessionSummary) protocol.SessionCreateResponsePayload {
+	return protocol.SessionCreateResponsePayload{
+		SessionID:      summary.SessionID,
+		SecretAliases:  slices.Clone(summary.SecretAliases),
+		ExpiresAt:      summary.ExpiresAt,
+		MaxReads:       summary.MaxReads,
+		RemainingReads: summary.RemainingReads,
+	}
+}
+
+func sessionInfoPayload(summary request.SessionSummary) protocol.SessionInfoPayload {
+	return protocol.SessionInfoPayload{
+		SessionID:      summary.SessionID,
+		Reason:         summary.Reason,
+		CWD:            summary.CWD,
+		SecretAliases:  slices.Clone(summary.SecretAliases),
+		ExpiresAt:      summary.ExpiresAt,
+		MaxReads:       summary.MaxReads,
+		RemainingReads: summary.RemainingReads,
+		OverrideEnv:    summary.OverrideEnv,
 	}
 }

--- a/internal/daemon/broker/broker_test.go
+++ b/internal/daemon/broker/broker_test.go
@@ -621,6 +621,14 @@ func auditEventTypes(events []audit.Event) []audit.EventType {
 	return types
 }
 
+func secretRefAliases(refs []audit.SecretRef) []string {
+	aliases := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		aliases = append(aliases, ref.Alias)
+	}
+	return aliases
+}
+
 func assertAuditEventsValueFree(t *testing.T, events []audit.Event) {
 	t.Helper()
 	encoded, err := json.Marshal(events)

--- a/internal/daemon/broker/session_store.go
+++ b/internal/daemon/broker/session_store.go
@@ -1,0 +1,230 @@
+package broker
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/daemon/approval"
+	"github.com/kovyrin/agent-secret/internal/peercred"
+	"github.com/kovyrin/agent-secret/internal/randid"
+	"github.com/kovyrin/agent-secret/internal/request"
+)
+
+var (
+	ErrSessionNotFound      = errors.New("session not found")
+	ErrSessionReadExhausted = errors.New("session read count exhausted")
+	ErrSessionPeerMismatch  = errors.New("session peer mismatch")
+)
+
+type sessionStore struct {
+	mu       sync.Mutex
+	now      func() time.Time
+	random   io.Reader
+	sessions map[string]*sessionRecord
+}
+
+type sessionRecord struct {
+	ID            string
+	Reason        string
+	CWD           string
+	Secrets       []request.Secret
+	Env           map[string]string
+	SecretAliases []string
+	ExpiresAt     time.Time
+	MaxReads      int
+	Reads         int
+	ReservedReads int
+	OverrideEnv   bool
+}
+
+type sessionReservation struct {
+	SessionID      string
+	Reason         string
+	CWD            string
+	Secrets        []request.Secret
+	Env            map[string]string
+	SecretAliases  []string
+	ExpiresAt      time.Time
+	MaxReads       int
+	RemainingReads int
+	OverrideEnv    bool
+}
+
+func newSessionStore(now func() time.Time) *sessionStore {
+	if now == nil {
+		now = time.Now
+	}
+	return &sessionStore{
+		now:      now,
+		random:   rand.Reader,
+		sessions: make(map[string]*sessionRecord),
+	}
+}
+
+func (s *sessionStore) create(req request.SessionCreateRequest, env map[string]string) (request.SessionSummary, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id, err := s.randomID()
+	if err != nil {
+		return request.SessionSummary{}, err
+	}
+	record := &sessionRecord{
+		ID:            id,
+		Reason:        req.Reason,
+		CWD:           req.CWD,
+		Secrets:       slices.Clone(req.Secrets),
+		Env:           cloneEnv(env),
+		SecretAliases: request.SecretAliases(req.Secrets),
+		ExpiresAt:     req.ExpiresAt,
+		MaxReads:      req.MaxReads,
+		OverrideEnv:   req.OverrideEnv,
+	}
+	s.sessions[id] = record
+	return record.summary(), nil
+}
+
+func (s *sessionStore) reserve(req request.SessionResolveRequest, peer peercred.Info) (sessionReservation, error) {
+	if err := peercred.Validate(peer, req.ExpectedPeer); err != nil {
+		return sessionReservation{}, fmt.Errorf("%w: %w", ErrSessionPeerMismatch, err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return sessionReservation{}, ErrSessionNotFound
+	}
+	if !s.now().Before(record.ExpiresAt) {
+		delete(s.sessions, record.ID)
+		return sessionReservation{}, approval.ErrRequestExpired
+	}
+	if record.CWD != req.CWD {
+		return sessionReservation{}, fmt.Errorf("%w: cwd %q != %q", ErrSessionPeerMismatch, req.CWD, record.CWD)
+	}
+	if record.Reads+record.ReservedReads >= record.MaxReads {
+		delete(s.sessions, record.ID)
+		return sessionReservation{}, ErrSessionReadExhausted
+	}
+
+	record.ReservedReads++
+	return sessionReservation{
+		SessionID:      record.ID,
+		Reason:         record.Reason,
+		CWD:            record.CWD,
+		Secrets:        slices.Clone(record.Secrets),
+		Env:            cloneEnv(record.Env),
+		SecretAliases:  slices.Clone(record.SecretAliases),
+		ExpiresAt:      record.ExpiresAt,
+		MaxReads:       record.MaxReads,
+		RemainingReads: record.remainingReads(),
+		OverrideEnv:    record.OverrideEnv,
+	}, nil
+}
+
+func (s *sessionStore) finishReservation(sessionID string, delivered bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[sessionID]
+	if !ok || record.ReservedReads <= 0 {
+		return
+	}
+	record.ReservedReads--
+	if delivered {
+		record.Reads++
+	}
+	if record.Reads >= record.MaxReads || !s.now().Before(record.ExpiresAt) {
+		delete(s.sessions, sessionID)
+	}
+}
+
+func (s *sessionStore) destroy(sessionID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.sessions[sessionID]; !ok {
+		return false
+	}
+	delete(s.sessions, sessionID)
+	return true
+}
+
+func (s *sessionStore) list() []request.SessionSummary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	summaries := make([]request.SessionSummary, 0, len(s.sessions))
+	for id, record := range s.sessions {
+		if !now.Before(record.ExpiresAt) || record.Reads+record.ReservedReads >= record.MaxReads {
+			delete(s.sessions, id)
+			continue
+		}
+		summaries = append(summaries, record.summary())
+	}
+	slices.SortFunc(summaries, func(a request.SessionSummary, b request.SessionSummary) int {
+		if a.ExpiresAt.Before(b.ExpiresAt) {
+			return -1
+		}
+		if b.ExpiresAt.Before(a.ExpiresAt) {
+			return 1
+		}
+		return stringsCompare(a.SessionID, b.SessionID)
+	})
+	return summaries
+}
+
+func (s *sessionStore) clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions = make(map[string]*sessionRecord)
+}
+
+func (s *sessionStore) randomID() (string, error) {
+	return randid.Generate(s.random, "asess")
+}
+
+func (s sessionRecord) summary() request.SessionSummary {
+	return request.SessionSummary{
+		SessionID:      s.ID,
+		Reason:         s.Reason,
+		CWD:            s.CWD,
+		SecretAliases:  slices.Clone(s.SecretAliases),
+		ExpiresAt:      s.ExpiresAt,
+		MaxReads:       s.MaxReads,
+		RemainingReads: s.remainingReads(),
+		OverrideEnv:    s.OverrideEnv,
+	}
+}
+
+func (s sessionRecord) remainingReads() int {
+	remaining := s.MaxReads - s.Reads - s.ReservedReads
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func cloneEnv(env map[string]string) map[string]string {
+	out := make(map[string]string, len(env))
+	maps.Copy(out, env)
+	return out
+}
+
+func stringsCompare(a string, b string) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}

--- a/internal/daemon/broker/session_store.go
+++ b/internal/daemon/broker/session_store.go
@@ -114,14 +114,18 @@ func (s *sessionStore) reserve(req request.SessionResolveRequest, peer peercred.
 		return sessionReservation{}, ErrSessionReadExhausted
 	}
 
+	secrets, env, aliases, err := selectSessionAliases(record, req.RequestedAliases)
+	if err != nil {
+		return sessionReservation{}, err
+	}
 	record.ReservedReads++
 	return sessionReservation{
 		SessionID:      record.ID,
 		Reason:         record.Reason,
 		CWD:            record.CWD,
-		Secrets:        slices.Clone(record.Secrets),
-		Env:            cloneEnv(record.Env),
-		SecretAliases:  slices.Clone(record.SecretAliases),
+		Secrets:        secrets,
+		Env:            env,
+		SecretAliases:  aliases,
 		ExpiresAt:      record.ExpiresAt,
 		MaxReads:       record.MaxReads,
 		RemainingReads: record.remainingReads(),
@@ -211,6 +215,37 @@ func (s sessionRecord) remainingReads() int {
 		return 0
 	}
 	return remaining
+}
+
+func selectSessionAliases(record *sessionRecord, requested []string) ([]request.Secret, map[string]string, []string, error) {
+	aliases, err := request.NormalizeAliases(requested)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(aliases) == 0 {
+		aliases = slices.Clone(record.SecretAliases)
+	}
+	slices.Sort(aliases)
+
+	secretByAlias := make(map[string]request.Secret, len(record.Secrets))
+	for _, secret := range record.Secrets {
+		secretByAlias[secret.Alias] = secret
+	}
+	secrets := make([]request.Secret, 0, len(aliases))
+	env := make(map[string]string, len(aliases))
+	for _, alias := range aliases {
+		secret, ok := secretByAlias[alias]
+		if !ok {
+			return nil, nil, nil, fmt.Errorf("%w: session has no approved alias %q", request.ErrInvalidAlias, alias)
+		}
+		value, ok := record.Env[alias]
+		if !ok {
+			return nil, nil, nil, fmt.Errorf("%w: session value missing for alias %q", request.ErrInvalidAlias, alias)
+		}
+		secrets = append(secrets, secret)
+		env[alias] = value
+	}
+	return secrets, env, aliases, nil
 }
 
 func cloneEnv(env map[string]string) map[string]string {

--- a/internal/daemon/broker/session_test.go
+++ b/internal/daemon/broker/session_test.go
@@ -1,0 +1,366 @@
+package broker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/audit"
+	"github.com/kovyrin/agent-secret/internal/daemon/approval"
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
+	"github.com/kovyrin/agent-secret/internal/peercred"
+	"github.com/kovyrin/agent-secret/internal/request"
+)
+
+func TestBrokerSessionCreateResolveConsumesReadAndAuditsCommand(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
+	ref := "op://Example/Item/token"
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, Options{
+		Now:      func() time.Time { return now },
+		Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+		Audit:    aud,
+	})
+
+	createReq := testSessionCreateRequest(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}}, 1)
+	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	if err != nil {
+		t.Fatalf("HandleSessionCreate returned error: %v", err)
+	}
+	if created.SessionID == "" || created.RemainingReads != 1 {
+		t.Fatalf("created session payload = %+v", created)
+	}
+
+	peer := testSessionPeer(t, createReq.CWD)
+	resolveReq := testSessionResolveRequest(t, created.SessionID, createReq.CWD, peer)
+	delivery, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), resolveReq, peer)
+	if err != nil {
+		t.Fatalf("PrepareSessionResolve returned error: %v", err)
+	}
+	if delivery.Payload().Env["TOKEN"] != "value" {
+		t.Fatalf("session env = %+v", delivery.Payload().Env)
+	}
+	if err := delivery.BeforeWrite(context.Background()); err != nil {
+		t.Fatalf("BeforeWrite returned error: %v", err)
+	}
+	delivery.CommitDelivered()
+
+	if err := broker.ReportStarted(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), 1234); err != nil {
+		t.Fatalf("ReportStarted returned error: %v", err)
+	}
+	if err := broker.ReportCompleted(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), 0, ""); err != nil {
+		t.Fatalf("ReportCompleted returned error: %v", err)
+	}
+
+	if _, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_again", "nonce_again"), resolveReq, peer); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("second PrepareSessionResolve error = %v, want ErrSessionNotFound", err)
+	}
+	got := auditEventTypes(aud.Events())
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventSessionCreated,
+		audit.EventSessionResolved,
+		audit.EventCommandStarting,
+		audit.EventCommandStarted,
+		audit.EventCommandCompleted,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+}
+
+func TestBrokerSessionResolveAbortRestoresRead(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
+	ref := "op://Example/Item/token"
+	broker := newTestBroker(t, Options{
+		Now:      func() time.Time { return now },
+		Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+		Audit:    &memoryAudit{},
+	})
+	createReq := testSessionCreateRequest(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}}, 1)
+	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	if err != nil {
+		t.Fatalf("HandleSessionCreate returned error: %v", err)
+	}
+	peer := testSessionPeer(t, createReq.CWD)
+	resolveReq := testSessionResolveRequest(t, created.SessionID, createReq.CWD, peer)
+
+	first, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), resolveReq, peer)
+	if err != nil {
+		t.Fatalf("first PrepareSessionResolve returned error: %v", err)
+	}
+	first.AbortBeforePayload()
+
+	second, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_retry", "nonce_retry"), resolveReq, peer)
+	if err != nil {
+		t.Fatalf("second PrepareSessionResolve returned error after abort: %v", err)
+	}
+	second.AbortBeforePayload()
+}
+
+func TestBrokerSessionListAndDestroy(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
+	ref := "op://Example/Item/token"
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, Options{
+		Now:      func() time.Time { return now },
+		Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+		Audit:    aud,
+	})
+
+	createReq := testSessionCreateRequest(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}}, 2)
+	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	if err != nil {
+		t.Fatalf("HandleSessionCreate returned error: %v", err)
+	}
+
+	listed, err := broker.HandleSessionList(context.Background())
+	if err != nil {
+		t.Fatalf("HandleSessionList returned error: %v", err)
+	}
+	if len(listed.Sessions) != 1 || listed.Sessions[0].SessionID != created.SessionID {
+		t.Fatalf("listed sessions = %+v, want created session %s", listed.Sessions, created.SessionID)
+	}
+	if listed.Sessions[0].RemainingReads != 2 || listed.Sessions[0].SecretAliases[0] != "TOKEN" {
+		t.Fatalf("listed session metadata = %+v", listed.Sessions[0])
+	}
+
+	destroyed, err := broker.HandleSessionDestroy(context.Background(), request.SessionDestroyRequest{SessionID: created.SessionID})
+	if err != nil {
+		t.Fatalf("HandleSessionDestroy returned error: %v", err)
+	}
+	if destroyed.SessionID != created.SessionID || !destroyed.Destroyed {
+		t.Fatalf("destroyed payload = %+v", destroyed)
+	}
+	listed, err = broker.HandleSessionList(context.Background())
+	if err != nil {
+		t.Fatalf("HandleSessionList after destroy returned error: %v", err)
+	}
+	if len(listed.Sessions) != 0 {
+		t.Fatalf("listed sessions after destroy = %+v, want empty", listed.Sessions)
+	}
+	if _, err := broker.HandleSessionDestroy(context.Background(), request.SessionDestroyRequest{SessionID: created.SessionID}); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("second HandleSessionDestroy error = %v, want ErrSessionNotFound", err)
+	}
+
+	got := auditEventTypes(aud.Events())
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventSessionCreated,
+		audit.EventSessionDestroyed,
+		audit.EventSessionDestroyed,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+}
+
+func TestBrokerSessionCreateRecordsTerminalApprovalFailures(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
+	ref := "op://Example/Item/token"
+	tests := []struct {
+		name     string
+		approver approval.Approver
+		wantErr  error
+		wantType audit.EventType
+	}{
+		{
+			name:     "denied",
+			approver: &mockApprover{decision: approval.Decision{Approved: false, DenialReason: approval.DenialReasonComputerLocked}},
+			wantType: audit.EventApprovalDenied,
+		},
+		{
+			name:     "expired",
+			approver: &mockApprover{err: approval.ErrRequestExpired},
+			wantErr:  approval.ErrRequestExpired,
+			wantType: audit.EventApprovalTimedOut,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			aud := &memoryAudit{}
+			broker := newTestBroker(t, Options{
+				Now:      func() time.Time { return now },
+				Approver: tt.approver,
+				Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+				Audit:    aud,
+			})
+			createReq := testSessionCreateRequest(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}}, 1)
+
+			_, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+			if err == nil {
+				t.Fatal("HandleSessionCreate unexpectedly succeeded")
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("HandleSessionCreate error = %v, want %v", err, tt.wantErr)
+			}
+			got := auditEventTypes(aud.Events())
+			want := []audit.EventType{audit.EventApprovalRequested, tt.wantType}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("audit events = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestSessionStoreListPrunesExpiredAndExhaustedSessions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
+	store := newSessionStore(func() time.Time { return now })
+	store.sessions["asess_live_b"] = &sessionRecord{
+		ID:            "asess_live_b",
+		Reason:        "Deploy",
+		CWD:           "/tmp/project",
+		SecretAliases: []string{"TOKEN"},
+		ExpiresAt:     now.Add(time.Minute),
+		MaxReads:      2,
+		Reads:         1,
+	}
+	store.sessions["asess_live_a"] = &sessionRecord{
+		ID:            "asess_live_a",
+		Reason:        "Deploy",
+		CWD:           "/tmp/project",
+		SecretAliases: []string{"TOKEN"},
+		ExpiresAt:     now.Add(time.Minute),
+		MaxReads:      2,
+	}
+	store.sessions["asess_expired"] = &sessionRecord{
+		ID:            "asess_expired",
+		Reason:        "Deploy",
+		CWD:           "/tmp/project",
+		SecretAliases: []string{"TOKEN"},
+		ExpiresAt:     now,
+		MaxReads:      2,
+	}
+	store.sessions["asess_exhausted"] = &sessionRecord{
+		ID:            "asess_exhausted",
+		Reason:        "Deploy",
+		CWD:           "/tmp/project",
+		SecretAliases: []string{"TOKEN"},
+		ExpiresAt:     now.Add(time.Minute),
+		MaxReads:      1,
+		Reads:         1,
+	}
+
+	summaries := store.list()
+	if len(summaries) != 2 {
+		t.Fatalf("list returned %d sessions: %+v", len(summaries), summaries)
+	}
+	if summaries[0].SessionID != "asess_live_a" || summaries[1].SessionID != "asess_live_b" {
+		t.Fatalf("sessions not sorted by id for equal expiry: %+v", summaries)
+	}
+	if summaries[0].RemainingReads != 2 || summaries[1].RemainingReads != 1 {
+		t.Fatalf("remaining reads mismatch: %+v", summaries)
+	}
+	if _, ok := store.sessions["asess_expired"]; ok {
+		t.Fatal("expired session was not pruned")
+	}
+	if _, ok := store.sessions["asess_exhausted"]; ok {
+		t.Fatal("exhausted session was not pruned")
+	}
+}
+
+func testSessionCreateRequest(
+	t *testing.T,
+	now time.Time,
+	secrets []request.SecretSpec,
+	maxReads int,
+) request.SessionCreateRequest {
+	t.Helper()
+	cwd, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+	exe := currentTestExecutable(t)
+	identity, err := fileidentity.Capture(exe)
+	if err != nil {
+		t.Fatalf("capture executable identity: %v", err)
+	}
+	req, err := request.NewSessionCreate(request.SessionCreateOptions{
+		Reason:             "Run deploy workflow",
+		Command:            []string{"agent-secret", "session", "create"},
+		ResolvedExecutable: exe,
+		ExecutableIdentity: identity,
+		CWD:                cwd,
+		Secrets:            secrets,
+		TTL:                10 * time.Minute,
+		ReceivedAt:         now,
+		MaxReads:           maxReads,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionCreate returned error: %v", err)
+	}
+	return req
+}
+
+func testSessionResolveRequest(
+	t *testing.T,
+	sessionID string,
+	cwd string,
+	peer peercred.Info,
+) request.SessionResolveRequest {
+	t.Helper()
+	exe := currentTestExecutable(t)
+	identity, err := fileidentity.Capture(exe)
+	if err != nil {
+		t.Fatalf("capture executable identity: %v", err)
+	}
+	req, err := request.NewSessionResolve(
+		sessionID,
+		[]string{exe, "-test.run=TestBrokerSessionCreateResolveConsumesReadAndAuditsCommand", "--", "child"},
+		exe,
+		identity,
+		cwd,
+		request.EnvironmentFingerprint([]string{"PATH=/usr/bin"}),
+	)
+	if err != nil {
+		t.Fatalf("NewSessionResolve returned error: %v", err)
+	}
+	return req.WithExpectedPeer(peercred.Expected(peer))
+}
+
+func testSessionPeer(t *testing.T, cwd string) peercred.Info {
+	t.Helper()
+	return peercred.Info{
+		UID:            os.Getuid(),
+		GID:            os.Getgid(),
+		PID:            os.Getpid(),
+		ExecutablePath: currentTestExecutable(t),
+		CWD:            cwd,
+	}
+}
+
+func currentTestExecutable(t *testing.T) string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		t.Fatalf("resolve executable: %v", err)
+	}
+	return exe
+}

--- a/internal/daemon/broker/session_test.go
+++ b/internal/daemon/broker/session_test.go
@@ -78,6 +78,86 @@ func TestBrokerSessionCreateResolveConsumesReadAndAuditsCommand(t *testing.T) {
 	}
 }
 
+func TestBrokerSessionResolveFiltersRequestedAliases(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
+	specs := []request.SecretSpec{
+		{Alias: "A_TOKEN", Ref: "op://Example/Item/a", Account: "Work"},
+		{Alias: "B_TOKEN", Ref: "op://Example/Item/b", Account: "Work"},
+		{Alias: "C_TOKEN", Ref: "op://Example/Item/c", Account: "Work"},
+	}
+	aud := &memoryAudit{}
+	broker := newTestBroker(t, Options{
+		Now:      func() time.Time { return now },
+		Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{
+			resolverCallKey("op://Example/Item/a", "Work"): "a-value",
+			resolverCallKey("op://Example/Item/b", "Work"): "b-value",
+			resolverCallKey("op://Example/Item/c", "Work"): "c-value",
+		}},
+		Audit: aud,
+	})
+
+	createReq := testSessionCreateRequest(t, now, specs, 2)
+	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	if err != nil {
+		t.Fatalf("HandleSessionCreate returned error: %v", err)
+	}
+	if !reflect.DeepEqual(created.SecretAliases, []string{"A_TOKEN", "B_TOKEN", "C_TOKEN"}) {
+		t.Fatalf("created secret aliases = %v", created.SecretAliases)
+	}
+
+	peer := testSessionPeer(t, createReq.CWD)
+	missingReq := testSessionResolveRequest(t, created.SessionID, createReq.CWD, peer)
+	missingReq, err = missingReq.WithRequestedAliases([]string{"MISSING_TOKEN"})
+	if err != nil {
+		t.Fatalf("WithRequestedAliases returned error: %v", err)
+	}
+	if _, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_missing", "nonce_missing"), missingReq, peer); !errors.Is(err, request.ErrInvalidAlias) {
+		t.Fatalf("missing alias PrepareSessionResolve error = %v, want ErrInvalidAlias", err)
+	}
+
+	resolveReq := testSessionResolveRequest(t, created.SessionID, createReq.CWD, peer)
+	resolveReq, err = resolveReq.WithRequestedAliases([]string{"B_TOKEN", "A_TOKEN"})
+	if err != nil {
+		t.Fatalf("WithRequestedAliases returned error: %v", err)
+	}
+	delivery, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), resolveReq, peer)
+	if err != nil {
+		t.Fatalf("PrepareSessionResolve returned error: %v", err)
+	}
+	payload := delivery.Payload()
+	wantAliases := []string{"A_TOKEN", "B_TOKEN"}
+	if !reflect.DeepEqual(payload.SecretAliases, wantAliases) {
+		t.Fatalf("payload secret aliases = %v, want %v", payload.SecretAliases, wantAliases)
+	}
+	if !reflect.DeepEqual(payload.Env, map[string]string{"A_TOKEN": "a-value", "B_TOKEN": "b-value"}) {
+		t.Fatalf("payload env = %+v", payload.Env)
+	}
+	if err := delivery.BeforeWrite(context.Background()); err != nil {
+		t.Fatalf("BeforeWrite returned error: %v", err)
+	}
+	delivery.CommitDelivered()
+
+	var resolvedRefs []audit.SecretRef
+	var commandRefs []audit.SecretRef
+	for _, event := range aud.Events() {
+		if event.Type == audit.EventSessionResolved {
+			resolvedRefs = event.SecretRefs
+		}
+		if event.Type == audit.EventCommandStarting {
+			commandRefs = event.SecretRefs
+		}
+	}
+	if !reflect.DeepEqual(secretRefAliases(resolvedRefs), wantAliases) {
+		t.Fatalf("session_resolved refs = %+v, want aliases %v", resolvedRefs, wantAliases)
+	}
+	if !reflect.DeepEqual(secretRefAliases(commandRefs), wantAliases) {
+		t.Fatalf("command_starting refs = %+v, want aliases %v", commandRefs, wantAliases)
+	}
+}
+
 func TestBrokerSessionResolveAbortRestoresRead(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/control/client.go
+++ b/internal/daemon/control/client.go
@@ -172,7 +172,7 @@ func (c *Client) ResolveSession(
 	if err != nil {
 		return protocol.SessionResolveResponsePayload{}, err
 	}
-	if err := validateSessionResolveResponsePayload(payload); err != nil {
+	if err := validateSessionResolveResponsePayload(payload, req); err != nil {
 		return protocol.SessionResolveResponsePayload{}, err
 	}
 	return payload, nil
@@ -342,12 +342,15 @@ func validateSessionCreateResponsePayload(payload protocol.SessionCreateResponse
 	return nil
 }
 
-func validateSessionResolveResponsePayload(payload protocol.SessionResolveResponsePayload) error {
+func validateSessionResolveResponsePayload(payload protocol.SessionResolveResponsePayload, req request.SessionResolveRequest) error {
 	if payload.Env == nil {
 		return fmt.Errorf("%w: session.resolve response missing env", protocol.ErrMalformedEnvelope)
 	}
 	if gotAliases := envAliases(payload.Env); !slices.Equal(gotAliases, payload.SecretAliases) {
 		return fmt.Errorf("%w: session.resolve response env aliases do not match secret aliases", protocol.ErrMalformedEnvelope)
+	}
+	if len(req.RequestedAliases) > 0 && !slices.Equal(payload.SecretAliases, req.RequestedAliases) {
+		return fmt.Errorf("%w: session.resolve response secret aliases do not match requested aliases", protocol.ErrMalformedEnvelope)
 	}
 	return nil
 }

--- a/internal/daemon/control/client.go
+++ b/internal/daemon/control/client.go
@@ -148,6 +148,51 @@ func (c *Client) DescribeItem(
 	return payload, nil
 }
 
+func (c *Client) CreateSession(
+	ctx context.Context,
+	correlation protocol.Correlation,
+	req request.SessionCreateRequest,
+) (protocol.SessionCreateResponsePayload, error) {
+	payload, err := roundTripPayload[protocol.SessionCreateResponsePayload](ctx, c, protocol.TypeSessionCreate, correlation, req)
+	if err != nil {
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	if err := validateSessionCreateResponsePayload(payload, req); err != nil {
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	return payload, nil
+}
+
+func (c *Client) ResolveSession(
+	ctx context.Context,
+	correlation protocol.Correlation,
+	req request.SessionResolveRequest,
+) (protocol.SessionResolveResponsePayload, error) {
+	payload, err := roundTripPayload[protocol.SessionResolveResponsePayload](ctx, c, protocol.TypeSessionResolve, correlation, req)
+	if err != nil {
+		return protocol.SessionResolveResponsePayload{}, err
+	}
+	if err := validateSessionResolveResponsePayload(payload); err != nil {
+		return protocol.SessionResolveResponsePayload{}, err
+	}
+	return payload, nil
+}
+
+func (c *Client) DestroySession(ctx context.Context, req request.SessionDestroyRequest) (protocol.SessionDestroyResponsePayload, error) {
+	payload, err := roundTripPayload[protocol.SessionDestroyResponsePayload](ctx, c, protocol.TypeSessionDestroy, protocol.Correlation{}, req)
+	if err != nil {
+		return protocol.SessionDestroyResponsePayload{}, err
+	}
+	if payload.SessionID != req.SessionID || !payload.Destroyed {
+		return protocol.SessionDestroyResponsePayload{}, fmt.Errorf("%w: session.destroy response does not match request", protocol.ErrMalformedEnvelope)
+	}
+	return payload, nil
+}
+
+func (c *Client) ListSessions(ctx context.Context) (protocol.SessionListResponsePayload, error) {
+	return roundTripPayload[protocol.SessionListResponsePayload](ctx, c, protocol.TypeSessionList, protocol.Correlation{}, nil)
+}
+
 func (c *Client) ReportStarted(ctx context.Context, correlation protocol.Correlation, childPID int) error {
 	return roundTripAck(ctx, c, protocol.TypeCommandStarted, correlation, protocol.CommandStartedPayload{ChildPID: childPID})
 }
@@ -280,6 +325,33 @@ func validateExecResponsePayload(payload protocol.ExecResponsePayload, req reque
 	return nil
 }
 
+func validateSessionCreateResponsePayload(payload protocol.SessionCreateResponsePayload, req request.SessionCreateRequest) error {
+	if err := request.ValidateSessionID(payload.SessionID); err != nil {
+		return fmt.Errorf("%w: invalid session id in session.create response: %w", protocol.ErrMalformedEnvelope, err)
+	}
+	expectedAliases := request.SecretAliases(req.Secrets)
+	if !slices.Equal(payload.SecretAliases, expectedAliases) {
+		return fmt.Errorf("%w: session.create response secret aliases do not match request", protocol.ErrMalformedEnvelope)
+	}
+	if payload.MaxReads != req.MaxReads {
+		return fmt.Errorf("%w: session.create response max reads does not match request", protocol.ErrMalformedEnvelope)
+	}
+	if payload.RemainingReads != req.MaxReads {
+		return fmt.Errorf("%w: session.create response remaining reads does not match request", protocol.ErrMalformedEnvelope)
+	}
+	return nil
+}
+
+func validateSessionResolveResponsePayload(payload protocol.SessionResolveResponsePayload) error {
+	if payload.Env == nil {
+		return fmt.Errorf("%w: session.resolve response missing env", protocol.ErrMalformedEnvelope)
+	}
+	if gotAliases := envAliases(payload.Env); !slices.Equal(gotAliases, payload.SecretAliases) {
+		return fmt.Errorf("%w: session.resolve response env aliases do not match secret aliases", protocol.ErrMalformedEnvelope)
+	}
+	return nil
+}
+
 func envAliases(env map[string]string) []string {
 	aliases := make([]string, 0, len(env))
 	for alias := range env {
@@ -314,6 +386,9 @@ func protocolRequestTiming(messageType protocol.MessageType, payload any) (time.
 		return req.ExpiresAt, req.TTL, ok
 	case protocol.TypeItemDescribe:
 		req, ok := payload.(request.ItemDescribeRequest)
+		return req.ExpiresAt, req.TTL, ok
+	case protocol.TypeSessionCreate:
+		req, ok := payload.(request.SessionCreateRequest)
 		return req.ExpiresAt, req.TTL, ok
 	default:
 		return time.Time{}, 0, false

--- a/internal/daemon/control/client_test.go
+++ b/internal/daemon/control/client_test.go
@@ -617,6 +617,10 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 		t.Parallel()
 
 		req := testSessionResolveRequest(t)
+		req, err := req.WithRequestedAliases([]string{"TOKEN"})
+		if err != nil {
+			t.Fatalf("WithRequestedAliases returned error: %v", err)
+		}
 		requests := make(chan protocol.Envelope, 1)
 		client, cleanup := startRespondingDaemonClient(t, func(env protocol.Envelope) []byte {
 			requests <- env
@@ -645,6 +649,30 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 		}
 		if got.SessionID != req.SessionID || got.CWD != req.CWD {
 			t.Fatalf("unexpected session resolve request: %+v", got)
+		}
+		if len(got.RequestedAliases) != 1 || got.RequestedAliases[0] != "TOKEN" {
+			t.Fatalf("requested aliases = %v, want TOKEN", got.RequestedAliases)
+		}
+	})
+
+	t.Run("resolve rejects wrong projected aliases", func(t *testing.T) {
+		t.Parallel()
+
+		req := testSessionResolveRequest(t)
+		req, err := req.WithRequestedAliases([]string{"TOKEN"})
+		if err != nil {
+			t.Fatalf("WithRequestedAliases returned error: %v", err)
+		}
+		client, cleanup := startRespondingDaemonClient(t, func(env protocol.Envelope) []byte {
+			return okResponseFrame(t, env, protocol.SessionResolveResponsePayload{
+				Env:           map[string]string{"OTHER_TOKEN": "synthetic-secret-value"},
+				SecretAliases: []string{"OTHER_TOKEN"},
+			})
+		})
+		defer cleanup()
+
+		if _, err := client.ResolveSession(context.Background(), testCorrelation("req_1", "nonce_1"), req); !errors.Is(err, protocol.ErrMalformedEnvelope) {
+			t.Fatalf("ResolveSession error = %v, want ErrMalformedEnvelope", err)
 		}
 	})
 

--- a/internal/daemon/control/client_test.go
+++ b/internal/daemon/control/client_test.go
@@ -76,6 +76,44 @@ func testItemDescribeRequestAt(now time.Time) request.ItemDescribeRequest {
 	}
 }
 
+func testSessionCreateRequestAt(t *testing.T, now time.Time) request.SessionCreateRequest {
+	t.Helper()
+
+	req, err := request.NewSessionCreate(request.SessionCreateOptions{
+		Reason:             "Deploy workflow",
+		Command:            []string{"agent-secret", "session", "create"},
+		ResolvedExecutable: "/opt/homebrew/bin/agent-secret",
+		ExecutableIdentity: fileidentity.Identity{Device: 1, Inode: 1, Mode: 0o755},
+		CWD:                "/tmp/project",
+		ReceivedAt:         now,
+		MaxReads:           2,
+		Secrets: []request.SecretSpec{
+			{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewSessionCreate returned error: %v", err)
+	}
+	return req
+}
+
+func testSessionResolveRequest(t *testing.T) request.SessionResolveRequest {
+	t.Helper()
+
+	req, err := request.NewSessionResolve(
+		"asess_abc123",
+		[]string{"/opt/homebrew/bin/terraform", "plan"},
+		"/opt/homebrew/bin/terraform",
+		fileidentity.Identity{Device: 2, Inode: 2, Mode: 0o755},
+		"/tmp/project",
+		request.EnvironmentFingerprint([]string{"PATH=/opt/homebrew/bin"}),
+	)
+	if err != nil {
+		t.Fatalf("NewSessionResolve returned error: %v", err)
+	}
+	return req
+}
+
 func TestClientProtocolErrorsAndCloseNil(t *testing.T) {
 	t.Parallel()
 
@@ -320,6 +358,8 @@ func TestClientValidatesPayloadOKResponseShape(t *testing.T) {
 	execReq := testExecRequest(t, []request.SecretSpec{
 		{Alias: "TOKEN", Ref: "op://Example/Item/token", Account: "Work"},
 	})
+	sessionCreateReq := testSessionCreateRequestAt(t, time.Now())
+	sessionResolveReq := testSessionResolveRequest(t)
 	tests := []struct {
 		name       string
 		frame      func(t *testing.T, env protocol.Envelope) []byte
@@ -386,6 +426,91 @@ func TestClientValidatesPayloadOKResponseShape(t *testing.T) {
 			},
 			wantErrMsg: "missing env",
 		},
+		{
+			name: "session create id",
+			frame: func(t *testing.T, env protocol.Envelope) []byte {
+				t.Helper()
+
+				return okResponseFrame(t, env, protocol.SessionCreateResponsePayload{
+					SessionID:      "bad",
+					SecretAliases:  []string{"TOKEN"},
+					MaxReads:       sessionCreateReq.MaxReads,
+					RemainingReads: sessionCreateReq.MaxReads,
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.CreateSession(ctx, testCorrelation("req_1", "nonce_1"), sessionCreateReq)
+				return err
+			},
+			wantErrMsg: "invalid session id",
+		},
+		{
+			name: "session create aliases",
+			frame: func(t *testing.T, env protocol.Envelope) []byte {
+				t.Helper()
+
+				return okResponseFrame(t, env, protocol.SessionCreateResponsePayload{
+					SessionID:      "asess_abc123",
+					SecretAliases:  []string{"OTHER"},
+					MaxReads:       sessionCreateReq.MaxReads,
+					RemainingReads: sessionCreateReq.MaxReads,
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.CreateSession(ctx, testCorrelation("req_1", "nonce_1"), sessionCreateReq)
+				return err
+			},
+			wantErrMsg: "secret aliases do not match",
+		},
+		{
+			name: "session create reads",
+			frame: func(t *testing.T, env protocol.Envelope) []byte {
+				t.Helper()
+
+				return okResponseFrame(t, env, protocol.SessionCreateResponsePayload{
+					SessionID:      "asess_abc123",
+					SecretAliases:  []string{"TOKEN"},
+					MaxReads:       sessionCreateReq.MaxReads,
+					RemainingReads: 1,
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.CreateSession(ctx, testCorrelation("req_1", "nonce_1"), sessionCreateReq)
+				return err
+			},
+			wantErrMsg: "remaining reads",
+		},
+		{
+			name: "session resolve env",
+			frame: func(t *testing.T, env protocol.Envelope) []byte {
+				t.Helper()
+
+				return okResponseFrame(t, env, protocol.SessionResolveResponsePayload{
+					Env:           map[string]string{"TOKEN": "value", "OTHER": "value"},
+					SecretAliases: []string{"TOKEN"},
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.ResolveSession(ctx, testCorrelation("req_1", "nonce_1"), sessionResolveReq)
+				return err
+			},
+			wantErrMsg: "env aliases",
+		},
+		{
+			name: "session resolve missing env",
+			frame: func(t *testing.T, env protocol.Envelope) []byte {
+				t.Helper()
+
+				return okResponseFrame(t, env, protocol.SessionResolveResponsePayload{
+					SecretAliases: []string{"TOKEN"},
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.ResolveSession(ctx, testCorrelation("req_1", "nonce_1"), sessionResolveReq)
+				return err
+			},
+			wantErrMsg: "missing env",
+		},
 	}
 
 	for _, tc := range tests {
@@ -446,6 +571,142 @@ func TestClientDescribeItemRoundTripsPayload(t *testing.T) {
 	if got.Ref.Raw != req.Ref.Raw || got.Account != req.Account {
 		t.Fatalf("unexpected item describe request: %+v", got)
 	}
+}
+
+func TestClientSessionRoundTripsPayloads(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create", func(t *testing.T) {
+		t.Parallel()
+
+		req := testSessionCreateRequestAt(t, time.Now())
+		requests := make(chan protocol.Envelope, 1)
+		client, cleanup := startRespondingDaemonClient(t, func(env protocol.Envelope) []byte {
+			requests <- env
+			return okResponseFrame(t, env, protocol.SessionCreateResponsePayload{
+				SessionID:      "asess_abc123",
+				SecretAliases:  []string{"TOKEN"},
+				ExpiresAt:      req.ExpiresAt,
+				MaxReads:       2,
+				RemainingReads: 2,
+			})
+		})
+		defer cleanup()
+
+		payload, err := client.CreateSession(context.Background(), testCorrelation("req_1", "nonce_1"), req)
+		if err != nil {
+			t.Fatalf("CreateSession returned error: %v", err)
+		}
+		if payload.SessionID != "asess_abc123" || payload.RemainingReads != 2 {
+			t.Fatalf("unexpected create payload: %+v", payload)
+		}
+		env := receiveStalledRequest(t, requests)
+		if env.Type != protocol.TypeSessionCreate {
+			t.Fatalf("request type = %s, want %s", env.Type, protocol.TypeSessionCreate)
+		}
+		got, err := protocol.DecodeRequiredPayload[request.SessionCreateRequest](env)
+		if err != nil {
+			t.Fatalf("decode session create request: %v", err)
+		}
+		if got.Reason != req.Reason || got.MaxReads != req.MaxReads {
+			t.Fatalf("unexpected session create request: %+v", got)
+		}
+	})
+
+	t.Run("resolve", func(t *testing.T) {
+		t.Parallel()
+
+		req := testSessionResolveRequest(t)
+		requests := make(chan protocol.Envelope, 1)
+		client, cleanup := startRespondingDaemonClient(t, func(env protocol.Envelope) []byte {
+			requests <- env
+			return okResponseFrame(t, env, protocol.SessionResolveResponsePayload{
+				Env:           map[string]string{"TOKEN": "synthetic-secret-value"},
+				SecretAliases: []string{"TOKEN"},
+				OverrideEnv:   true,
+			})
+		})
+		defer cleanup()
+
+		payload, err := client.ResolveSession(context.Background(), testCorrelation("req_1", "nonce_1"), req)
+		if err != nil {
+			t.Fatalf("ResolveSession returned error: %v", err)
+		}
+		if payload.Env["TOKEN"] == "" || !payload.OverrideEnv {
+			t.Fatalf("unexpected resolve payload: %+v", payload)
+		}
+		env := receiveStalledRequest(t, requests)
+		if env.Type != protocol.TypeSessionResolve {
+			t.Fatalf("request type = %s, want %s", env.Type, protocol.TypeSessionResolve)
+		}
+		got, err := protocol.DecodeRequiredPayload[request.SessionResolveRequest](env)
+		if err != nil {
+			t.Fatalf("decode session resolve request: %v", err)
+		}
+		if got.SessionID != req.SessionID || got.CWD != req.CWD {
+			t.Fatalf("unexpected session resolve request: %+v", got)
+		}
+	})
+
+	t.Run("destroy", func(t *testing.T) {
+		t.Parallel()
+
+		req := request.SessionDestroyRequest{SessionID: "asess_abc123"}
+		requests := make(chan protocol.Envelope, 1)
+		client, cleanup := startRespondingDaemonClient(t, func(env protocol.Envelope) []byte {
+			requests <- env
+			return okResponseFrame(t, env, protocol.SessionDestroyResponsePayload{
+				SessionID: "asess_abc123",
+				Destroyed: true,
+			})
+		})
+		defer cleanup()
+
+		payload, err := client.DestroySession(context.Background(), req)
+		if err != nil {
+			t.Fatalf("DestroySession returned error: %v", err)
+		}
+		if !payload.Destroyed {
+			t.Fatalf("unexpected destroy payload: %+v", payload)
+		}
+		env := receiveStalledRequest(t, requests)
+		if env.Type != protocol.TypeSessionDestroy {
+			t.Fatalf("request type = %s, want %s", env.Type, protocol.TypeSessionDestroy)
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		t.Parallel()
+
+		requests := make(chan protocol.Envelope, 1)
+		client, cleanup := startRespondingDaemonClient(t, func(env protocol.Envelope) []byte {
+			requests <- env
+			return okResponseFrame(t, env, protocol.SessionListResponsePayload{
+				Sessions: []protocol.SessionInfoPayload{{
+					SessionID:      "asess_abc123",
+					Reason:         "Deploy workflow",
+					CWD:            "/tmp/project",
+					SecretAliases:  []string{"TOKEN"},
+					ExpiresAt:      time.Now().Add(time.Minute),
+					MaxReads:       2,
+					RemainingReads: 1,
+				}},
+			})
+		})
+		defer cleanup()
+
+		payload, err := client.ListSessions(context.Background())
+		if err != nil {
+			t.Fatalf("ListSessions returned error: %v", err)
+		}
+		if len(payload.Sessions) != 1 || payload.Sessions[0].SessionID != "asess_abc123" {
+			t.Fatalf("unexpected list payload: %+v", payload)
+		}
+		env := receiveStalledRequest(t, requests)
+		if env.Type != protocol.TypeSessionList {
+			t.Fatalf("request type = %s, want %s", env.Type, protocol.TypeSessionList)
+		}
+	})
 }
 
 func TestClientRejectsOversizedDaemonResponseFrame(t *testing.T) {

--- a/internal/daemon/protocol/protocol.go
+++ b/internal/daemon/protocol/protocol.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/kovyrin/agent-secret/internal/itemmetadata"
 )
@@ -24,6 +25,10 @@ const (
 	TypeApprovalDecision  MessageType = "approval.decision"
 	TypeRequestExec       MessageType = "request.exec"
 	TypeItemDescribe      MessageType = "item.describe"
+	TypeSessionCreate     MessageType = "session.create"
+	TypeSessionResolve    MessageType = "session.resolve"
+	TypeSessionDestroy    MessageType = "session.destroy"
+	TypeSessionList       MessageType = "session.list"
 	TypeCommandStarted    MessageType = "command.started"
 	TypeCommandCompleted  MessageType = "command.completed"
 	TypeOK                MessageType = "ok"
@@ -56,6 +61,9 @@ const (
 	ErrorCodeRequestExpired           ErrorCode = "request_expired"
 	ErrorCodeRequestFailed            ErrorCode = "request_failed"
 	ErrorCodeResolveFailed            ErrorCode = "resolve_failed"
+	ErrorCodeSessionNotFound          ErrorCode = "session_not_found"
+	ErrorCodeSessionPeerMismatch      ErrorCode = "session_peer_mismatch"
+	ErrorCodeSessionReadExhausted     ErrorCode = "session_read_exhausted"
 	ErrorCodeStaleApproval            ErrorCode = "stale_approval"
 	ErrorCodeUntrustedClient          ErrorCode = "untrusted_client"
 )
@@ -93,6 +101,40 @@ type ErrorPayload struct {
 type ExecResponsePayload struct {
 	Env           map[string]string `json:"env"`
 	SecretAliases []string          `json:"secret_aliases"`
+}
+
+type SessionCreateResponsePayload struct {
+	SessionID      string    `json:"session_id"`
+	SecretAliases  []string  `json:"secret_aliases"`
+	ExpiresAt      time.Time `json:"expires_at"`
+	MaxReads       int       `json:"max_reads"`
+	RemainingReads int       `json:"remaining_reads"`
+}
+
+type SessionResolveResponsePayload struct {
+	Env           map[string]string `json:"env"`
+	SecretAliases []string          `json:"secret_aliases"`
+	OverrideEnv   bool              `json:"override_env"`
+}
+
+type SessionDestroyResponsePayload struct {
+	SessionID string `json:"session_id"`
+	Destroyed bool   `json:"destroyed"`
+}
+
+type SessionListResponsePayload struct {
+	Sessions []SessionInfoPayload `json:"sessions"`
+}
+
+type SessionInfoPayload struct {
+	SessionID      string    `json:"session_id"`
+	Reason         string    `json:"reason"`
+	CWD            string    `json:"cwd"`
+	SecretAliases  []string  `json:"secret_aliases"`
+	ExpiresAt      time.Time `json:"expires_at"`
+	MaxReads       int       `json:"max_reads"`
+	RemainingReads int       `json:"remaining_reads"`
+	OverrideEnv    bool      `json:"override_env"`
 }
 
 type ItemDescribeResponsePayload struct {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -924,6 +924,8 @@ func codeForError(err error) protocol.ErrorCode {
 		return protocol.ErrorCodeSessionPeerMismatch
 	case errors.Is(err, daemonbroker.ErrSessionReadExhausted):
 		return protocol.ErrorCodeSessionReadExhausted
+	case errors.Is(err, request.ErrInvalidAlias):
+		return protocol.ErrorCodeBadRequest
 	case errors.Is(err, ErrRequestAlreadyActive):
 		return protocol.ErrorCodeRequestActive
 	case errors.Is(err, daemonbroker.ErrDaemonStopped):

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -260,7 +260,7 @@ func (s *Server) retireIfExecutableChanged(ctx context.Context, encoder *json.En
 func checksExecutableIdentity(messageType protocol.MessageType) bool {
 	//nolint:exhaustive // Only new foreground work should trigger daemon executable self-checks.
 	switch messageType {
-	case protocol.TypeDaemonStatus, protocol.TypeOnePasswordStatus, protocol.TypeRequestExec, protocol.TypeItemDescribe:
+	case protocol.TypeDaemonStatus, protocol.TypeOnePasswordStatus, protocol.TypeRequestExec, protocol.TypeItemDescribe, protocol.TypeSessionCreate, protocol.TypeSessionResolve, protocol.TypeSessionDestroy, protocol.TypeSessionList:
 		return true
 	default:
 		return false
@@ -402,6 +402,22 @@ func (s *Server) dispatchClientEnvelope(
 	case protocol.TypeItemDescribe:
 		s.handleItemDescribe(ctx, conn, encoder, env)
 		return connectionDispatchAction{accepted: true}
+	case protocol.TypeSessionCreate:
+		s.handleSessionCreate(ctx, conn, encoder, env)
+		return connectionDispatchAction{accepted: true}
+	case protocol.TypeSessionResolve:
+		if state.hasActiveRequest() {
+			_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(ErrRequestAlreadyActive), ErrRequestAlreadyActive)
+			return connectionDispatchAction{}
+		}
+		requestID := s.handleSessionResolve(ctx, conn, encoder, env)
+		return connectionDispatchAction{accepted: requestID != "", beginExecRequestID: requestID}
+	case protocol.TypeSessionDestroy:
+		s.handleSessionDestroy(ctx, conn, encoder, env)
+		return connectionDispatchAction{accepted: true}
+	case protocol.TypeSessionList:
+		s.handleSessionList(ctx, conn, encoder, env)
+		return connectionDispatchAction{accepted: true}
 	case protocol.TypeCommandStarted:
 		if !s.lifecycleRequestMatchesConnection(encoder, env, state) {
 			return connectionDispatchAction{}
@@ -451,13 +467,8 @@ func (s *Server) handleItemDescribe(
 	encoder *json.Encoder,
 	env protocol.Envelope,
 ) {
-	if err := s.validateTrustedClientPeer(conn); err != nil {
-		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
-		return
-	}
-	req, err := protocol.DecodeRequiredPayload[request.ItemDescribeRequest](env)
-	if err != nil {
-		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, err)
+	req, ok := decodeTrustedClientPayload[request.ItemDescribeRequest](s, conn, encoder, env)
+	if !ok {
 		return
 	}
 	req = req.WithReceiptTime(s.broker.Now())
@@ -466,6 +477,147 @@ func (s *Server) handleItemDescribe(
 		return
 	}
 	payload, err := s.broker.HandleItemDescribe(ctx, env.Correlation(), req)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return
+	}
+	_ = writeOK(encoder, env.Correlation(), payload)
+}
+
+func (s *Server) handleSessionCreate(
+	ctx context.Context,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env protocol.Envelope,
+) {
+	req, ok := decodeTrustedClientPayload[request.SessionCreateRequest](s, conn, encoder, env)
+	if !ok {
+		return
+	}
+	req = req.WithReceiptTime(s.broker.Now())
+	if err := req.ValidateForDaemon(); err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, err)
+		return
+	}
+	payload, err := s.broker.HandleSessionCreate(ctx, env.Correlation(), req)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return
+	}
+	_ = writeOK(encoder, env.Correlation(), payload)
+}
+
+func decodeTrustedClientPayload[T any](
+	s *Server,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env protocol.Envelope,
+) (T, bool) {
+	var zero T
+	if err := s.validateTrustedClientPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return zero, false
+	}
+	req, err := protocol.DecodeRequiredPayload[T](env)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, err)
+		return zero, false
+	}
+	return req, true
+}
+
+func (s *Server) handleSessionResolve(
+	ctx context.Context,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env protocol.Envelope,
+) string {
+	if err := s.validateTrustedClientPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return ""
+	}
+	req, err := protocol.DecodeRequiredPayload[request.SessionResolveRequest](env)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, err)
+		return ""
+	}
+	if err := req.ValidateForDaemon(); err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, err)
+		return ""
+	}
+	peer, err := s.peerInfo(conn)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodePeerRejected, err)
+		return ""
+	}
+	delivery, err := s.broker.PrepareSessionResolve(ctx, env.Correlation(), req, peer)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return ""
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			delivery.AbortBeforePayload()
+		}
+	}()
+	clearWriteDeadline, err := s.setExecResponseWriteDeadline(conn, delivery.ExpiresAt())
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return ""
+	}
+	defer clearWriteDeadline()
+	if err := delivery.BeforeWrite(ctx); err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return ""
+	}
+	if err := writeOK(encoder, env.Correlation(), delivery.Payload()); err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return ""
+	}
+	delivery.CommitDelivered()
+	committed = true
+	return env.RequestID
+}
+
+func (s *Server) handleSessionDestroy(
+	ctx context.Context,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env protocol.Envelope,
+) {
+	if err := s.validateTrustedClientPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return
+	}
+	req, err := protocol.DecodeRequiredPayload[request.SessionDestroyRequest](env)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, err)
+		return
+	}
+	if err := req.ValidateForDaemon(); err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, err)
+		return
+	}
+	payload, err := s.broker.HandleSessionDestroy(ctx, req)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return
+	}
+	_ = writeOK(encoder, env.Correlation(), payload)
+}
+
+func (s *Server) handleSessionList(
+	ctx context.Context,
+	conn *net.UnixConn,
+	encoder *json.Encoder,
+	env protocol.Envelope,
+) {
+	if err := s.validateTrustedClientPeer(conn); err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
+		return
+	}
+	payload, err := s.broker.HandleSessionList(ctx)
 	if err != nil {
 		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
 		return
@@ -766,6 +918,12 @@ func codeForError(err error) protocol.ErrorCode {
 		return protocol.ErrorCodeNoPendingApproval
 	case errors.Is(err, daemonbroker.ErrNoReusableApproval):
 		return protocol.ErrorCodeNoReusableApproval
+	case errors.Is(err, daemonbroker.ErrSessionNotFound):
+		return protocol.ErrorCodeSessionNotFound
+	case errors.Is(err, daemonbroker.ErrSessionPeerMismatch):
+		return protocol.ErrorCodeSessionPeerMismatch
+	case errors.Is(err, daemonbroker.ErrSessionReadExhausted):
+		return protocol.ErrorCodeSessionReadExhausted
 	case errors.Is(err, ErrRequestAlreadyActive):
 		return protocol.ErrorCodeRequestActive
 	case errors.Is(err, daemonbroker.ErrDaemonStopped):

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -247,6 +247,76 @@ func TestServerSessionProtocolLifecycle(t *testing.T) {
 	}
 }
 
+func TestServerSessionResolveRejectsUnapprovedAliasProjection(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	client, cleanup := startSocketPairTestServer(t, daemonbroker.Options{
+		Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+		Audit:    &memoryAudit{},
+	})
+	defer cleanup()
+
+	cwd, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("absolute cwd: %v", err)
+	}
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		t.Fatalf("resolve cwd: %v", err)
+	}
+	peerExe := currentExecutable(t)
+	exe, err := filepath.EvalSymlinks(peerExe)
+	if err != nil {
+		t.Fatalf("resolve executable: %v", err)
+	}
+	identity, err := fileidentity.Capture(exe)
+	if err != nil {
+		t.Fatalf("capture executable identity: %v", err)
+	}
+	createReq, err := request.NewSessionCreate(request.SessionCreateOptions{
+		Reason:             "Run deploy workflow",
+		Command:            []string{"agent-secret", "session", "create"},
+		ResolvedExecutable: exe,
+		ExecutableIdentity: identity,
+		CWD:                cwd,
+		Secrets:            []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}},
+		TTL:                time.Minute,
+		MaxReads:           1,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionCreate returned error: %v", err)
+	}
+	created, err := client.CreateSession(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	resolveReq, err := request.NewSessionResolve(
+		created.SessionID,
+		[]string{exe, "-test.run=TestServerSessionResolveRejectsUnapprovedAliasProjection", "--", "child"},
+		exe,
+		identity,
+		cwd,
+		request.EnvironmentFingerprint([]string{"PATH=/usr/bin"}),
+	)
+	if err != nil {
+		t.Fatalf("NewSessionResolve returned error: %v", err)
+	}
+	resolveReq, err = resolveReq.WithRequestedAliases([]string{"MISSING_TOKEN"})
+	if err != nil {
+		t.Fatalf("WithRequestedAliases returned error: %v", err)
+	}
+	peer := peerInfoForTest(t, os.Getpid(), peerExe)
+	peer.CWD = cwd
+	resolveReq = resolveReq.WithExpectedPeer(peercred.Expected(peer))
+
+	_, err = client.ResolveSession(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), resolveReq)
+	if !control.IsProtocolError(err, protocol.ErrorCodeBadRequest) {
+		t.Fatalf("ResolveSession error = %v, want bad_request", err)
+	}
+}
+
 func TestServerSessionListAndDestroyProtocol(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/peertrust"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 	"github.com/kovyrin/agent-secret/internal/daemon/socket"
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
 	"github.com/kovyrin/agent-secret/internal/secretcache"
@@ -153,6 +154,222 @@ func TestServerItemDescribeProtocolLifecycle(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+}
+
+func TestServerSessionProtocolLifecycle(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	aud := &memoryAudit{}
+	client, cleanup := startSocketPairTestServer(t, daemonbroker.Options{
+		Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+		Audit:    aud,
+	})
+	defer cleanup()
+
+	cwd, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("absolute cwd: %v", err)
+	}
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		t.Fatalf("resolve cwd: %v", err)
+	}
+	peerExe := currentExecutable(t)
+	exe, err := filepath.EvalSymlinks(peerExe)
+	if err != nil {
+		t.Fatalf("resolve executable: %v", err)
+	}
+	identity, err := fileidentity.Capture(exe)
+	if err != nil {
+		t.Fatalf("capture executable identity: %v", err)
+	}
+	createReq, err := request.NewSessionCreate(request.SessionCreateOptions{
+		Reason:             "Run deploy workflow",
+		Command:            []string{"agent-secret", "session", "create"},
+		ResolvedExecutable: exe,
+		ExecutableIdentity: identity,
+		CWD:                cwd,
+		Secrets:            []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}},
+		TTL:                time.Minute,
+		MaxReads:           1,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionCreate returned error: %v", err)
+	}
+	created, err := client.CreateSession(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	peer := peerInfoForTest(t, os.Getpid(), peerExe)
+	peer.CWD = cwd
+	resolveReq, err := request.NewSessionResolve(
+		created.SessionID,
+		[]string{exe, "-test.run=TestServerSessionProtocolLifecycle", "--", "child"},
+		exe,
+		identity,
+		cwd,
+		request.EnvironmentFingerprint([]string{"PATH=/usr/bin"}),
+	)
+	if err != nil {
+		t.Fatalf("NewSessionResolve returned error: %v", err)
+	}
+	resolveReq = resolveReq.WithExpectedPeer(peercred.Expected(peer))
+	resolved, err := client.ResolveSession(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), resolveReq)
+	if err != nil {
+		t.Fatalf("ResolveSession returned error: %v", err)
+	}
+	if resolved.Env["TOKEN"] != "value" {
+		t.Fatalf("resolved env = %+v", resolved.Env)
+	}
+	if err := client.ReportStarted(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), 4321); err != nil {
+		t.Fatalf("ReportStarted returned error: %v", err)
+	}
+	if err := client.ReportCompleted(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), 0, ""); err != nil {
+		t.Fatalf("ReportCompleted returned error: %v", err)
+	}
+
+	got := auditEventTypes(aud.Events())
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventSessionCreated,
+		audit.EventSessionResolved,
+		audit.EventCommandStarting,
+		audit.EventCommandStarted,
+		audit.EventCommandCompleted,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+}
+
+func TestServerSessionListAndDestroyProtocol(t *testing.T) {
+	t.Parallel()
+
+	ref := "op://Example/Item/token"
+	aud := &memoryAudit{}
+	client, cleanup := startSocketPairTestServer(t, daemonbroker.Options{
+		Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+		Audit:    aud,
+	})
+	defer cleanup()
+
+	cwd, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("absolute cwd: %v", err)
+	}
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		t.Fatalf("resolve cwd: %v", err)
+	}
+	exe, err := filepath.EvalSymlinks(currentExecutable(t))
+	if err != nil {
+		t.Fatalf("resolve executable: %v", err)
+	}
+	identity, err := fileidentity.Capture(exe)
+	if err != nil {
+		t.Fatalf("capture executable identity: %v", err)
+	}
+	createReq, err := request.NewSessionCreate(request.SessionCreateOptions{
+		Reason:             "Run deploy workflow",
+		Command:            []string{"agent-secret", "session", "create"},
+		ResolvedExecutable: exe,
+		ExecutableIdentity: identity,
+		CWD:                cwd,
+		Secrets:            []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}},
+		TTL:                time.Minute,
+		MaxReads:           2,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionCreate returned error: %v", err)
+	}
+	created, err := client.CreateSession(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	listed, err := client.ListSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ListSessions returned error: %v", err)
+	}
+	if len(listed.Sessions) != 1 || listed.Sessions[0].SessionID != created.SessionID {
+		t.Fatalf("listed sessions = %+v, want %s", listed.Sessions, created.SessionID)
+	}
+	if listed.Sessions[0].RemainingReads != 2 || listed.Sessions[0].CWD != cwd {
+		t.Fatalf("listed session metadata = %+v", listed.Sessions[0])
+	}
+
+	destroyed, err := client.DestroySession(context.Background(), request.SessionDestroyRequest{SessionID: created.SessionID})
+	if err != nil {
+		t.Fatalf("DestroySession returned error: %v", err)
+	}
+	if destroyed.SessionID != created.SessionID || !destroyed.Destroyed {
+		t.Fatalf("destroyed payload = %+v", destroyed)
+	}
+	listed, err = client.ListSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ListSessions after destroy returned error: %v", err)
+	}
+	if len(listed.Sessions) != 0 {
+		t.Fatalf("listed sessions after destroy = %+v, want empty", listed.Sessions)
+	}
+	_, err = client.DestroySession(context.Background(), request.SessionDestroyRequest{SessionID: created.SessionID})
+	if !control.IsProtocolError(err, protocol.ErrorCodeSessionNotFound) {
+		t.Fatalf("second DestroySession error = %v, want session_not_found protocol error", err)
+	}
+
+	got := auditEventTypes(aud.Events())
+	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventSessionCreated,
+		audit.EventSessionDestroyed,
+		audit.EventSessionDestroyed,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("audit events = %v, want %v", got, want)
+	}
+}
+
+func TestSessionProtocolErrorsMapToCodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		err  error
+		want protocol.ErrorCode
+	}{
+		{err: daemonbroker.ErrSessionNotFound, want: protocol.ErrorCodeSessionNotFound},
+		{err: daemonbroker.ErrSessionPeerMismatch, want: protocol.ErrorCodeSessionPeerMismatch},
+		{err: daemonbroker.ErrSessionReadExhausted, want: protocol.ErrorCodeSessionReadExhausted},
+	}
+	for _, tt := range tests {
+		if got := codeForError(tt.err); got != tt.want {
+			t.Fatalf("codeForError(%v) = %s, want %s", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestSessionMessagesTriggerExecutableIdentityCheck(t *testing.T) {
+	t.Parallel()
+
+	for _, messageType := range []protocol.MessageType{
+		protocol.TypeSessionCreate,
+		protocol.TypeSessionResolve,
+		protocol.TypeSessionDestroy,
+		protocol.TypeSessionList,
+	} {
+		if !checksExecutableIdentity(messageType) {
+			t.Fatalf("checksExecutableIdentity(%s) = false, want true", messageType)
+		}
+	}
+	if checksExecutableIdentity(protocol.TypeApprovalPending) {
+		t.Fatal("approval.pending should not trigger executable identity check")
 	}
 }
 

--- a/internal/daemon/test_helpers_test.go
+++ b/internal/daemon/test_helpers_test.go
@@ -394,11 +394,16 @@ func currentExecutableClientPaths(t *testing.T) []string {
 
 func peerInfoForTest(t *testing.T, pid int, exe string) peercred.Info {
 	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd returned error: %v", err)
+	}
 	return peercred.Info{
 		UID:            os.Getuid(),
 		GID:            os.Getgid(),
 		PID:            pid,
 		ExecutablePath: exe,
+		CWD:            cwd,
 	}
 }
 

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -167,7 +167,7 @@ func (r ExecRequest) ValidateForDaemon() error {
 	}); err != nil {
 		return err
 	}
-	if _, err := validateDaemonSecrets(r.Secrets); err != nil {
+	if err := validateDaemonSecrets(r.Secrets); err != nil {
 		return err
 	}
 	if err := validateOverriddenAliases(r.Secrets, r.OverriddenAliases, r.OverrideEnv); err != nil {
@@ -449,21 +449,21 @@ func ParseSecrets(specs []SecretSpec) ([]Secret, error) {
 	return secrets, nil
 }
 
-func validateDaemonSecrets(secrets []Secret) ([]Secret, error) {
+func validateDaemonSecrets(secrets []Secret) error {
 	specs := make([]SecretSpec, 0, len(secrets))
 	for _, secret := range secrets {
 		if strings.TrimSpace(secret.Account) != secret.Account {
-			return nil, fmt.Errorf("%w: secret %q account must be trimmed", ErrInvalidReference, secret.Alias)
+			return fmt.Errorf("%w: secret %q account must be trimmed", ErrInvalidReference, secret.Alias)
 		}
 		if strings.TrimSpace(secret.Source) != secret.Source {
-			return nil, fmt.Errorf("%w: secret %q source must be trimmed", ErrInvalidReference, secret.Alias)
+			return fmt.Errorf("%w: secret %q source must be trimmed", ErrInvalidReference, secret.Alias)
 		}
 		parsed, err := ParseSecretRef(secret.Ref.Raw)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if parsed != secret.Ref {
-			return nil, fmt.Errorf("%w: parsed reference metadata does not match raw ref", ErrInvalidReference)
+			return fmt.Errorf("%w: parsed reference metadata does not match raw ref", ErrInvalidReference)
 		}
 		specs = append(specs, SecretSpec{
 			Alias:     secret.Alias,
@@ -475,17 +475,17 @@ func validateDaemonSecrets(secrets []Secret) ([]Secret, error) {
 	}
 	parsed, err := ParseSecrets(specs)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(parsed) != len(secrets) {
-		return nil, fmt.Errorf("%w: secret count mismatch", ErrInvalidReference)
+		return fmt.Errorf("%w: secret count mismatch", ErrInvalidReference)
 	}
 	for i := range parsed {
 		if parsed[i] != secrets[i] {
-			return nil, fmt.Errorf("%w: secret metadata must be pre-normalized", ErrInvalidReference)
+			return fmt.Errorf("%w: secret metadata must be pre-normalized", ErrInvalidReference)
 		}
 	}
-	return parsed, nil
+	return nil
 }
 
 func normalizeBitwardenSecretSource(ref SecretRef, source string, metadata BitwardenSource) (BitwardenSource, error) {

--- a/internal/request/session.go
+++ b/internal/request/session.go
@@ -1,0 +1,264 @@
+package request
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
+	"github.com/kovyrin/agent-secret/internal/peercred"
+)
+
+const (
+	DefaultSessionTTL      = 2 * time.Minute
+	DefaultSessionMaxReads = 1
+	MaxSessionReads        = 20
+)
+
+var (
+	ErrInvalidSessionID   = fmt.Errorf("%w: invalid session id", ErrInvalidRequest)
+	ErrInvalidSessionRead = fmt.Errorf("%w: invalid session read count", ErrInvalidRequest)
+)
+
+var sessionIDPattern = regexp.MustCompile(`^asess_[A-Za-z0-9_-]+$`)
+
+type SessionCreateOptions struct {
+	Reason             string
+	Command            []string
+	ResolvedExecutable string
+	ExecutableIdentity fileidentity.Identity
+	CWD                string
+	Secrets            []SecretSpec
+	TTL                time.Duration
+	ReceivedAt         time.Time
+	MaxReads           int
+	OverrideEnv        bool
+}
+
+type SessionCreateRequest struct {
+	Reason             string                `json:"reason"`
+	Command            []string              `json:"command"`
+	ResolvedExecutable string                `json:"resolved_executable"`
+	ExecutableIdentity fileidentity.Identity `json:"executable_identity"`
+	CWD                string                `json:"cwd"`
+	Secrets            []Secret              `json:"secrets"`
+	TTL                time.Duration         `json:"ttl"`
+	ReceivedAt         time.Time             `json:"received_at"`
+	ExpiresAt          time.Time             `json:"expires_at"`
+	MaxReads           int                   `json:"max_reads"`
+	OverrideEnv        bool                  `json:"override_env"`
+}
+
+type SessionResolveRequest struct {
+	SessionID              string                `json:"session_id"`
+	Command                []string              `json:"command"`
+	ResolvedExecutable     string                `json:"resolved_executable"`
+	ExecutableIdentity     fileidentity.Identity `json:"executable_identity"`
+	CWD                    string                `json:"cwd"`
+	EnvironmentFingerprint string                `json:"environment_fingerprint"`
+	ExpectedPeer           peercred.Expected     `json:"expected_peer"`
+}
+
+type SessionDestroyRequest struct {
+	SessionID string `json:"session_id"`
+}
+
+type SessionSummary struct {
+	SessionID      string    `json:"session_id"`
+	Reason         string    `json:"reason"`
+	CWD            string    `json:"cwd"`
+	SecretAliases  []string  `json:"secret_aliases"`
+	ExpiresAt      time.Time `json:"expires_at"`
+	MaxReads       int       `json:"max_reads"`
+	RemainingReads int       `json:"remaining_reads"`
+	OverrideEnv    bool      `json:"override_env"`
+}
+
+func NewSessionCreate(opts SessionCreateOptions) (SessionCreateRequest, error) {
+	reason, err := validateReason(opts.Reason)
+	if err != nil {
+		return SessionCreateRequest{}, err
+	}
+	ttl := opts.TTL
+	if ttl == 0 {
+		ttl = DefaultSessionTTL
+	}
+	if ttl < MinRequestTTL || ttl > MaxRequestTTL {
+		return SessionCreateRequest{}, fmt.Errorf("%w: must be between %s and %s", ErrInvalidTTL, MinRequestTTL, MaxRequestTTL)
+	}
+	maxReads := opts.MaxReads
+	if maxReads == 0 {
+		maxReads = DefaultSessionMaxReads
+	}
+	if maxReads < 1 || maxReads > MaxSessionReads {
+		return SessionCreateRequest{}, fmt.Errorf("%w: must be between 1 and %d", ErrInvalidSessionRead, MaxSessionReads)
+	}
+	if err := validatePreparedPath("cwd", opts.CWD, false); err != nil {
+		return SessionCreateRequest{}, err
+	}
+	if err := validatePreparedPath("resolved executable", opts.ResolvedExecutable, true); err != nil {
+		return SessionCreateRequest{}, err
+	}
+	if opts.ExecutableIdentity.IsZero() {
+		return SessionCreateRequest{}, fmt.Errorf("%w: executable identity is required", ErrInvalidRequest)
+	}
+	command := slices.Clone(opts.Command)
+	if len(command) == 0 || command[0] == "" {
+		return SessionCreateRequest{}, fmt.Errorf("%w: argv is required", ErrInvalidCommand)
+	}
+	secrets, err := ParseSecrets(opts.Secrets)
+	if err != nil {
+		return SessionCreateRequest{}, err
+	}
+	receivedAt := opts.ReceivedAt
+	expiresAt := time.Time{}
+	if !receivedAt.IsZero() {
+		expiresAt = receivedAt.Add(ttl)
+	}
+	return SessionCreateRequest{
+		Reason:             reason,
+		Command:            command,
+		ResolvedExecutable: opts.ResolvedExecutable,
+		ExecutableIdentity: opts.ExecutableIdentity,
+		CWD:                opts.CWD,
+		Secrets:            secrets,
+		TTL:                ttl,
+		ReceivedAt:         receivedAt,
+		ExpiresAt:          expiresAt,
+		MaxReads:           maxReads,
+		OverrideEnv:        opts.OverrideEnv,
+	}, nil
+}
+
+func (r SessionCreateRequest) WithReceiptTime(receivedAt time.Time) SessionCreateRequest {
+	r.ReceivedAt = receivedAt
+	r.ExpiresAt = receivedAt.Add(r.TTL)
+	return r
+}
+
+func (r SessionCreateRequest) Expired(at time.Time) bool {
+	return !at.Before(r.ExpiresAt)
+}
+
+func (r SessionCreateRequest) ValidateForDaemon() error {
+	if err := validateDaemonLifecycle(daemonLifecycle{
+		Reason:             r.Reason,
+		Command:            r.Command,
+		CWD:                r.CWD,
+		ResolvedExecutable: r.ResolvedExecutable,
+		TTL:                r.TTL,
+		ReceivedAt:         r.ReceivedAt,
+		ExpiresAt:          r.ExpiresAt,
+	}); err != nil {
+		return err
+	}
+	if r.MaxReads < 1 || r.MaxReads > MaxSessionReads {
+		return fmt.Errorf("%w: must be between 1 and %d", ErrInvalidSessionRead, MaxSessionReads)
+	}
+	if r.ExecutableIdentity.IsZero() {
+		return fmt.Errorf("%w: executable identity is required", ErrInvalidRequest)
+	}
+	if err := validateDaemonPreparedPath("cwd", r.CWD, false); err != nil {
+		return err
+	}
+	if err := validateDaemonPreparedPath("resolved executable", r.ResolvedExecutable, true); err != nil {
+		return err
+	}
+	if err := fileidentity.Verify(r.ResolvedExecutable, r.ExecutableIdentity); err != nil {
+		return fmt.Errorf("%w: executable identity changed: %w", ErrInvalidRequest, err)
+	}
+	if err := validateDaemonSecrets(r.Secrets); err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewSessionResolve(
+	sessionID string,
+	command []string,
+	resolvedExecutable string,
+	executableIdentity fileidentity.Identity,
+	cwd string,
+	environmentFingerprint string,
+) (SessionResolveRequest, error) {
+	if err := ValidateSessionID(sessionID); err != nil {
+		return SessionResolveRequest{}, err
+	}
+	if len(command) == 0 || command[0] == "" {
+		return SessionResolveRequest{}, fmt.Errorf("%w: argv is required", ErrInvalidCommand)
+	}
+	if err := validatePreparedPath("cwd", cwd, false); err != nil {
+		return SessionResolveRequest{}, err
+	}
+	if err := validatePreparedPath("resolved executable", resolvedExecutable, true); err != nil {
+		return SessionResolveRequest{}, err
+	}
+	if executableIdentity.IsZero() {
+		return SessionResolveRequest{}, fmt.Errorf("%w: executable identity is required", ErrInvalidRequest)
+	}
+	if err := validateEnvironmentFingerprint(environmentFingerprint); err != nil {
+		return SessionResolveRequest{}, err
+	}
+	return SessionResolveRequest{
+		SessionID:              sessionID,
+		Command:                slices.Clone(command),
+		ResolvedExecutable:     resolvedExecutable,
+		ExecutableIdentity:     executableIdentity,
+		CWD:                    cwd,
+		EnvironmentFingerprint: environmentFingerprint,
+	}, nil
+}
+
+func (r SessionResolveRequest) WithExpectedPeer(expected peercred.Expected) SessionResolveRequest {
+	r.ExpectedPeer = expected
+	return r
+}
+
+func (r SessionResolveRequest) ValidateForDaemon() error {
+	if err := ValidateSessionID(r.SessionID); err != nil {
+		return err
+	}
+	if len(r.Command) == 0 || r.Command[0] == "" {
+		return fmt.Errorf("%w: argv is required", ErrInvalidCommand)
+	}
+	if err := validateEnvironmentFingerprint(r.EnvironmentFingerprint); err != nil {
+		return err
+	}
+	if err := validateDaemonPreparedPath("cwd", r.CWD, false); err != nil {
+		return err
+	}
+	if err := validateDaemonPreparedPath("resolved executable", r.ResolvedExecutable, true); err != nil {
+		return err
+	}
+	if r.ExecutableIdentity.IsZero() {
+		return fmt.Errorf("%w: executable identity is required", ErrInvalidRequest)
+	}
+	if err := fileidentity.Verify(r.ResolvedExecutable, r.ExecutableIdentity); err != nil {
+		return fmt.Errorf("%w: executable identity changed: %w", ErrInvalidRequest, err)
+	}
+	if r.ExpectedPeer.UID < 0 || r.ExpectedPeer.GID < 0 || r.ExpectedPeer.PID <= 0 ||
+		r.ExpectedPeer.ExecutablePath == "" || r.ExpectedPeer.CWD == "" {
+		return fmt.Errorf("%w: expected peer metadata is required", ErrInvalidRequest)
+	}
+	return nil
+}
+
+func NewSessionDestroy(sessionID string) (SessionDestroyRequest, error) {
+	req := SessionDestroyRequest{SessionID: sessionID}
+	if err := req.ValidateForDaemon(); err != nil {
+		return SessionDestroyRequest{}, err
+	}
+	return req, nil
+}
+
+func (r SessionDestroyRequest) ValidateForDaemon() error {
+	return ValidateSessionID(r.SessionID)
+}
+
+func ValidateSessionID(sessionID string) error {
+	if !sessionIDPattern.MatchString(sessionID) {
+		return fmt.Errorf("%w: %q", ErrInvalidSessionID, sessionID)
+	}
+	return nil
+}

--- a/internal/request/session.go
+++ b/internal/request/session.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/kovyrin/agent-secret/internal/fileidentity"
@@ -57,6 +58,7 @@ type SessionResolveRequest struct {
 	ExecutableIdentity     fileidentity.Identity `json:"executable_identity"`
 	CWD                    string                `json:"cwd"`
 	EnvironmentFingerprint string                `json:"environment_fingerprint"`
+	RequestedAliases       []string              `json:"requested_aliases,omitempty"`
 	ExpectedPeer           peercred.Expected     `json:"expected_peer"`
 }
 
@@ -215,6 +217,15 @@ func (r SessionResolveRequest) WithExpectedPeer(expected peercred.Expected) Sess
 	return r
 }
 
+func (r SessionResolveRequest) WithRequestedAliases(aliases []string) (SessionResolveRequest, error) {
+	normalized, err := NormalizeAliases(aliases)
+	if err != nil {
+		return SessionResolveRequest{}, err
+	}
+	r.RequestedAliases = normalized
+	return r, nil
+}
+
 func (r SessionResolveRequest) ValidateForDaemon() error {
 	if err := ValidateSessionID(r.SessionID); err != nil {
 		return err
@@ -223,6 +234,9 @@ func (r SessionResolveRequest) ValidateForDaemon() error {
 		return fmt.Errorf("%w: argv is required", ErrInvalidCommand)
 	}
 	if err := validateEnvironmentFingerprint(r.EnvironmentFingerprint); err != nil {
+		return err
+	}
+	if err := validateNormalizedAliases(r.RequestedAliases); err != nil {
 		return err
 	}
 	if err := validateDaemonPreparedPath("cwd", r.CWD, false); err != nil {
@@ -259,6 +273,38 @@ func (r SessionDestroyRequest) ValidateForDaemon() error {
 func ValidateSessionID(sessionID string) error {
 	if !sessionIDPattern.MatchString(sessionID) {
 		return fmt.Errorf("%w: %q", ErrInvalidSessionID, sessionID)
+	}
+	return nil
+}
+
+func NormalizeAliases(aliases []string) ([]string, error) {
+	if len(aliases) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(aliases))
+	normalized := make([]string, 0, len(aliases))
+	for _, raw := range aliases {
+		alias := strings.TrimSpace(raw)
+		if !aliasPattern.MatchString(alias) {
+			return nil, fmt.Errorf("%w: alias must match [A-Z_][A-Z0-9_]*, for example API_TOKEN (got: %q)", ErrInvalidAlias, raw)
+		}
+		if _, ok := seen[alias]; ok {
+			return nil, fmt.Errorf("%w: duplicate alias %q", ErrInvalidAlias, alias)
+		}
+		seen[alias] = struct{}{}
+		normalized = append(normalized, alias)
+	}
+	slices.Sort(normalized)
+	return normalized, nil
+}
+
+func validateNormalizedAliases(aliases []string) error {
+	normalized, err := NormalizeAliases(aliases)
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(aliases, normalized) {
+		return fmt.Errorf("%w: aliases must be sorted and trimmed", ErrInvalidAlias)
 	}
 	return nil
 }

--- a/internal/request/session_test.go
+++ b/internal/request/session_test.go
@@ -1,0 +1,226 @@
+package request
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/fileidentity"
+	"github.com/kovyrin/agent-secret/internal/peercred"
+)
+
+func TestNewSessionCreateDefaultsAndDaemonValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := testResolvedDir(t)
+	bin, identity := testExecutable(t, dir, "agent-secret")
+	receivedAt := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+
+	req, err := NewSessionCreate(SessionCreateOptions{
+		Reason:             "  Run deployment workflow  ",
+		Command:            []string{"agent-secret", "session", "create"},
+		ResolvedExecutable: bin,
+		ExecutableIdentity: identity,
+		CWD:                dir,
+		ReceivedAt:         receivedAt,
+		Secrets: []SecretSpec{
+			{Alias: "TOKEN", Ref: "op://Example Vault/Deploy/token", Account: " Work "},
+		},
+		OverrideEnv: true,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionCreate returned error: %v", err)
+	}
+
+	if req.Reason != "Run deployment workflow" {
+		t.Fatalf("reason = %q", req.Reason)
+	}
+	if req.TTL != DefaultSessionTTL {
+		t.Fatalf("ttl = %s, want %s", req.TTL, DefaultSessionTTL)
+	}
+	if req.MaxReads != DefaultSessionMaxReads {
+		t.Fatalf("max reads = %d, want %d", req.MaxReads, DefaultSessionMaxReads)
+	}
+	if !req.ExpiresAt.Equal(receivedAt.Add(DefaultSessionTTL)) {
+		t.Fatalf("expires_at = %s, want %s", req.ExpiresAt, receivedAt.Add(DefaultSessionTTL))
+	}
+	if !req.OverrideEnv {
+		t.Fatal("override env was not preserved")
+	}
+	if len(req.Secrets) != 1 || req.Secrets[0].Account != "Work" {
+		t.Fatalf("secrets not parsed and normalized: %+v", req.Secrets)
+	}
+
+	received := req.WithReceiptTime(receivedAt.Add(time.Minute))
+	if !received.ExpiresAt.Equal(received.ReceivedAt.Add(DefaultSessionTTL)) {
+		t.Fatalf("WithReceiptTime expires_at = %s received_at = %s", received.ExpiresAt, received.ReceivedAt)
+	}
+	if received.Expired(received.ExpiresAt.Add(-time.Nanosecond)) || !received.Expired(received.ExpiresAt) {
+		t.Fatalf("Expired boundary mismatch for expires_at %s", received.ExpiresAt)
+	}
+	if err := received.ValidateForDaemon(); err != nil {
+		t.Fatalf("ValidateForDaemon returned error: %v", err)
+	}
+}
+
+func TestNewSessionCreateRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	dir := testResolvedDir(t)
+	bin, identity := testExecutable(t, dir, "agent-secret")
+	base := SessionCreateOptions{
+		Reason:             "Deploy",
+		Command:            []string{"agent-secret", "session", "create"},
+		ResolvedExecutable: bin,
+		ExecutableIdentity: identity,
+		CWD:                dir,
+		Secrets: []SecretSpec{
+			{Alias: "TOKEN", Ref: "op://Example Vault/Deploy/token", Account: "Work"},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*SessionCreateOptions)
+		want   error
+	}{
+		{name: "missing reason", mutate: func(o *SessionCreateOptions) { o.Reason = "" }, want: ErrInvalidReason},
+		{name: "short ttl", mutate: func(o *SessionCreateOptions) { o.TTL = time.Second }, want: ErrInvalidTTL},
+		{name: "too many reads", mutate: func(o *SessionCreateOptions) { o.MaxReads = MaxSessionReads + 1 }, want: ErrInvalidSessionRead},
+		{name: "missing cwd", mutate: func(o *SessionCreateOptions) { o.CWD = "" }, want: ErrInvalidRequest},
+		{name: "missing executable", mutate: func(o *SessionCreateOptions) { o.ResolvedExecutable = "" }, want: ErrInvalidRequest},
+		{name: "missing executable identity", mutate: func(o *SessionCreateOptions) { o.ExecutableIdentity = fileidentity.Identity{} }, want: ErrInvalidRequest},
+		{name: "missing command", mutate: func(o *SessionCreateOptions) { o.Command = nil }, want: ErrInvalidCommand},
+		{name: "bad secret", mutate: func(o *SessionCreateOptions) { o.Secrets[0].Alias = "token" }, want: ErrInvalidAlias},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := base
+			opts.Command = append([]string(nil), base.Command...)
+			opts.Secrets = append([]SecretSpec(nil), base.Secrets...)
+			tt.mutate(&opts)
+			_, err := NewSessionCreate(opts)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("NewSessionCreate error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionResolveValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := testResolvedDir(t)
+	bin, identity := testExecutable(t, dir, "terraform")
+	env := []string{"PATH=" + filepath.Dir(bin), "TOKEN=existing"}
+
+	req, err := NewSessionResolve(
+		"asess_abc123",
+		[]string{bin, "plan"},
+		bin,
+		identity,
+		dir,
+		EnvironmentFingerprint(env),
+	)
+	if err != nil {
+		t.Fatalf("NewSessionResolve returned error: %v", err)
+	}
+	expected := peercred.Expected{
+		UID:            501,
+		GID:            20,
+		PID:            12345,
+		ExecutablePath: bin,
+		CWD:            dir,
+	}
+	req = req.WithExpectedPeer(expected)
+	if req.ExpectedPeer != expected {
+		t.Fatalf("expected peer not applied: %+v", req.ExpectedPeer)
+	}
+	if err := req.ValidateForDaemon(); err != nil {
+		t.Fatalf("ValidateForDaemon returned error: %v", err)
+	}
+}
+
+func TestSessionResolveRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	dir := testResolvedDir(t)
+	bin, identity := testExecutable(t, dir, "terraform")
+	fingerprint := EnvironmentFingerprint([]string{"PATH=" + filepath.Dir(bin)})
+
+	tests := []struct {
+		name      string
+		sessionID string
+		command   []string
+		exe       string
+		identity  fileidentity.Identity
+		cwd       string
+		env       string
+		want      error
+	}{
+		{name: "bad session id", sessionID: "session_abc", command: []string{bin}, exe: bin, identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidSessionID},
+		{name: "missing command", sessionID: "asess_abc", command: nil, exe: bin, identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidCommand},
+		{name: "relative cwd", sessionID: "asess_abc", command: []string{bin}, exe: bin, identity: identity, cwd: "deploy", env: fingerprint, want: ErrInvalidRequest},
+		{name: "relative executable", sessionID: "asess_abc", command: []string{bin}, exe: "terraform", identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidRequest},
+		{name: "missing identity", sessionID: "asess_abc", command: []string{bin}, exe: bin, identity: fileidentity.Identity{}, cwd: dir, env: fingerprint, want: ErrInvalidRequest},
+		{name: "bad env fingerprint", sessionID: "asess_abc", command: []string{bin}, exe: bin, identity: identity, cwd: dir, env: "sha256:bad", want: ErrInvalidRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewSessionResolve(tt.sessionID, tt.command, tt.exe, tt.identity, tt.cwd, tt.env)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("NewSessionResolve error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionResolveDaemonValidationRejectsMissingPeerMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := testResolvedDir(t)
+	bin, identity := testExecutable(t, dir, "terraform")
+	req, err := NewSessionResolve(
+		"asess_abc",
+		[]string{bin},
+		bin,
+		identity,
+		dir,
+		EnvironmentFingerprint([]string{"PATH=" + filepath.Dir(bin)}),
+	)
+	if err != nil {
+		t.Fatalf("NewSessionResolve returned error: %v", err)
+	}
+	err = req.ValidateForDaemon()
+	if !errors.Is(err, ErrInvalidRequest) || !strings.Contains(err.Error(), "expected peer metadata") {
+		t.Fatalf("ValidateForDaemon error = %v, want missing peer metadata", err)
+	}
+}
+
+func TestSessionDestroyValidation(t *testing.T) {
+	t.Parallel()
+
+	req, err := NewSessionDestroy("asess_abc123")
+	if err != nil {
+		t.Fatalf("NewSessionDestroy returned error: %v", err)
+	}
+	if req.SessionID != "asess_abc123" {
+		t.Fatalf("session id = %q", req.SessionID)
+	}
+	if err := req.ValidateForDaemon(); err != nil {
+		t.Fatalf("ValidateForDaemon returned error: %v", err)
+	}
+	if err := ValidateSessionID("asess_abc-DEF_123"); err != nil {
+		t.Fatalf("ValidateSessionID returned error: %v", err)
+	}
+	_, err = NewSessionDestroy("bad")
+	if !errors.Is(err, ErrInvalidSessionID) {
+		t.Fatalf("NewSessionDestroy error = %v, want ErrInvalidSessionID", err)
+	}
+}

--- a/internal/request/session_test.go
+++ b/internal/request/session_test.go
@@ -3,6 +3,7 @@ package request
 import (
 	"errors"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -137,11 +138,52 @@ func TestSessionResolveValidation(t *testing.T) {
 		CWD:            dir,
 	}
 	req = req.WithExpectedPeer(expected)
+	req, err = req.WithRequestedAliases([]string{" B_TOKEN ", "A_TOKEN"})
+	if err != nil {
+		t.Fatalf("WithRequestedAliases returned error: %v", err)
+	}
 	if req.ExpectedPeer != expected {
 		t.Fatalf("expected peer not applied: %+v", req.ExpectedPeer)
 	}
+	if !slices.Equal(req.RequestedAliases, []string{"A_TOKEN", "B_TOKEN"}) {
+		t.Fatalf("requested aliases = %v, want sorted subset", req.RequestedAliases)
+	}
 	if err := req.ValidateForDaemon(); err != nil {
 		t.Fatalf("ValidateForDaemon returned error: %v", err)
+	}
+}
+
+func TestSessionResolveRejectsInvalidRequestedAliases(t *testing.T) {
+	t.Parallel()
+
+	dir := testResolvedDir(t)
+	bin, identity := testExecutable(t, dir, "terraform")
+	req, err := NewSessionResolve(
+		"asess_abc123",
+		[]string{bin, "plan"},
+		bin,
+		identity,
+		dir,
+		EnvironmentFingerprint([]string{"PATH=" + filepath.Dir(bin)}),
+	)
+	if err != nil {
+		t.Fatalf("NewSessionResolve returned error: %v", err)
+	}
+	if _, err := req.WithRequestedAliases([]string{"TOKEN", "TOKEN"}); !errors.Is(err, ErrInvalidAlias) {
+		t.Fatalf("WithRequestedAliases duplicate error = %v, want ErrInvalidAlias", err)
+	}
+
+	expected := peercred.Expected{
+		UID:            501,
+		GID:            20,
+		PID:            12345,
+		ExecutablePath: bin,
+		CWD:            dir,
+	}
+	req = req.WithExpectedPeer(expected)
+	req.RequestedAliases = []string{"B_TOKEN", "A_TOKEN"}
+	if err := req.ValidateForDaemon(); !errors.Is(err, ErrInvalidAlias) {
+		t.Fatalf("ValidateForDaemon unsorted aliases error = %v, want ErrInvalidAlias", err)
 	}
 }
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -6,12 +6,12 @@
     <title>Docs · Agent Secret</title>
     <meta
       name="description"
-      content="Practical setup docs for Agent Secret with 1Password, Bitwarden Secrets Manager, project profiles, validation, troubleshooting, and FAQ."
+      content="Practical setup docs for Agent Secret with 1Password, Bitwarden Secrets Manager, project profiles, bounded sessions, validation, troubleshooting, and FAQ."
     >
     <meta property="og:title" content="Docs · Agent Secret">
     <meta
       property="og:description"
-      content="Install Agent Secret, connect 1Password or Bitwarden Secrets Manager, configure project profiles, and run safe secret-injection checks."
+      content="Install Agent Secret, connect 1Password or Bitwarden Secrets Manager, configure project profiles and sessions, and run safe secret-injection checks."
     >
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://agent-secret.sh/docs">
@@ -21,7 +21,7 @@
     <link rel="canonical" href="https://agent-secret.sh/docs">
     <link rel="icon" href="assets/app-icon-180.png">
     <link rel="apple-touch-icon" href="assets/app-icon-180.png">
-    <link rel="stylesheet" href="styles.css?v=20260607-1">
+    <link rel="stylesheet" href="styles.css?v=20260608-1">
   </head>
   <body class="legal-page docs-page">
     <header class="site-header" aria-label="Primary">
@@ -48,7 +48,7 @@
           Secrets Manager, keep references in project profiles, and validate
           requests without printing secret values.
         </p>
-        <p class="legal-date">Last updated: June 7, 2026</p>
+        <p class="legal-date">Last updated: June 8, 2026</p>
       </section>
 
       <div class="docs-layout">
@@ -58,6 +58,7 @@
             <a href="#onepassword">1Password</a>
             <a href="#bitwarden">Bitwarden</a>
             <a href="#profiles">Profiles</a>
+            <a href="#sessions">Sessions</a>
             <a href="#validate">Validate</a>
             <a href="#troubleshooting">Troubleshooting</a>
             <a href="#faq">FAQ</a>
@@ -200,6 +201,37 @@ profiles:
               <code>agent-secret exec -- terraform plan</code> from the project
               directory uses that profile. Use <code>--profile NAME</code> when
               a repo has multiple workflows.
+            </p>
+          </section>
+
+          <section id="sessions" class="docs-section">
+            <div class="section-kicker">Sessions</div>
+            <h2>Approve a bag once, then run bounded commands.</h2>
+            <p>
+              Sessions are for short workflows where an agent needs the same
+              approved set of references in different combinations. The daemon
+              stores values in memory and returns only an opaque session ID.
+            </p>
+            <div class="code-panel">
+              <pre><code>agent-secret session create --profile terraform-cloudflare --max-reads 3
+agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN -- terraform plan
+agent-secret with-session asess_123 \
+  --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
+  -- terraform apply
+agent-secret session destroy asess_123</code></pre>
+            </div>
+            <p>
+              <code>session create</code> can combine a project profile, env
+              files, and one-off <code>--secret ALIAS=REF</code> flags.
+              <code>with-session</code> injects every approved alias by default,
+              or a per-command subset with <code>--only</code>. Unknown aliases
+              fail before the child command starts.
+            </p>
+            <p>
+              Sessions end when TTL passes, the read count is exhausted,
+              <code>session destroy</code> succeeds, or the daemon stops. V1
+              sessions do not expose raw socket reads or long-lived interactive
+              shells.
             </p>
           </section>
 

--- a/site/index.html
+++ b/site/index.html
@@ -6,12 +6,12 @@
     <title>Agent Secret — approve exactly what your agents unlock</title>
     <meta
       name="description"
-      content="Agent Secret is a local macOS approval broker for coding-agent secrets, backed by 1Password or Bitwarden Secrets Manager. Agents request exact secret references with a reason and command; you approve before any value is handed over."
+      content="Agent Secret is a local macOS approval broker for coding-agent secrets, backed by 1Password or Bitwarden Secrets Manager. Agents request exact secret references with a reason and command; you approve before values are handed to one command or a bounded session."
     >
     <meta property="og:title" content="Agent Secret">
     <meta
       property="og:description"
-      content="Your agents ask for secrets. You approve exactly what they get. A local macOS approval broker for coding-agent secrets, backed by 1Password or Bitwarden Secrets Manager."
+      content="Your agents ask for secrets. You approve exactly what they get. A local macOS approval broker for one-command and bounded-session secret access."
     >
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://agent-secret.sh/">
@@ -25,7 +25,7 @@
     <link rel="canonical" href="https://agent-secret.sh/">
     <link rel="icon" href="assets/app-icon-180.png">
     <link rel="apple-touch-icon" href="assets/app-icon-180.png">
-    <link rel="stylesheet" href="styles.css?v=20260603-3">
+    <link rel="stylesheet" href="styles.css?v=20260608-1">
     <script src="scripts.js?v=20260527-4" defer></script>
   </head>
   <body>
@@ -107,8 +107,9 @@
             Agent Secret turns secret access into a native approval moment. The
             prompt shows the reason, the exact command, the working directory,
             and the precise references being asked for. Approve it and the values
-            are injected into that one child process. Deny it and nothing leaks —
-            and the prompt quietly tells you where a background agent is heading.
+            are injected into one child process or held for a bounded session.
+            Deny it and nothing leaks — and the prompt quietly tells you where a
+            background agent is heading.
           </p>
         </div>
         <div class="capability-grid">
@@ -127,6 +128,11 @@
             <h3>Delivered to the command, not the disk</h3>
             <p>Approved values go straight into the process you saw — never printed to logs, never written into the repo.</p>
           </article>
+          <article>
+            <span>04</span>
+            <h3>Session subsets for short workflows</h3>
+            <p>Approve a bag once, then use <code>with-session --only</code> so each command receives only the aliases it needs.</p>
+          </article>
         </div>
       </section>
 
@@ -141,7 +147,8 @@
               Put references in config, ask for the exact profile you need, and
               Agent Secret shows the command, reason, working directory, account,
               and requested references before anything resolves. The approved
-              value is delivered only to that child process.
+              value is delivered only to that child process, or to later
+              <code>with-session</code> commands inside a bounded session.
             </p>
             <a class="text-link" href="https://github.com/kovyrin/agent-secret#quick-start">
               Read the Quick Start →
@@ -164,6 +171,16 @@
                 <code data-copy-text>agent-secret exec --profile terraform-cloudflare -- terraform plan</code>
               </div>
               <button class="copy-button" type="button" data-copy-button aria-label="Copy approval command">
+                <svg class="copy-icon" aria-hidden="true" viewBox="0 0 24 24"><rect x="8" y="8" width="10" height="10" rx="2"></rect><path d="M6 16H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                <svg class="check-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="m5 12 4 4L19 6"></path></svg>
+              </button>
+            </div>
+            <div class="command-row copyable">
+              <div class="command-line">
+                <span class="prompt" aria-hidden="true">$</span>
+                <code data-copy-text>agent-secret session create --profile terraform-cloudflare --max-reads 3</code>
+              </div>
+              <button class="copy-button" type="button" data-copy-button aria-label="Copy session command">
                 <svg class="copy-icon" aria-hidden="true" viewBox="0 0 24 24"><rect x="8" y="8" width="10" height="10" rx="2"></rect><path d="M6 16H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                 <svg class="check-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="m5 12 4 4L19 6"></path></svg>
               </button>
@@ -345,12 +362,14 @@ profiles:
               <li>The daemon fetches only the secrets you approved for the request.</li>
               <li>Audit logs record metadata, never raw secrets.</li>
               <li>Reusable approvals stay bounded by command, cwd, references, account, TTL, and use count.</li>
+              <li>Sessions stay bounded by cwd, aliases, TTL, read count, and the <code>with-session</code> wrapper.</li>
             </ul>
           </div>
           <div>
             <h3 id="limitations">Known limitations</h3>
             <ul>
               <li>It won't sandbox a malicious approved child process.</li>
+              <li>No raw session socket reads or open-ended session shells.</li>
               <li>No Linux or Windows support yet.</li>
               <li>No writing or updating secrets yet.</li>
               <li>No GCP Secret Manager support yet.</li>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agent-secret.sh/</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-08</lastmod>
   </url>
   <url>
     <loc>https://agent-secret.sh/docs</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-08</lastmod>
   </url>
   <url>
     <loc>https://agent-secret.sh/privacy</loc>

--- a/site/styles.css
+++ b/site/styles.css
@@ -388,7 +388,7 @@ h3 {
 
 .capability-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1px;
   overflow: hidden;
   border: 1px solid var(--line);


### PR DESCRIPTION
## Summary

- add bounded in-memory session creation, resolution, listing, and destruction in the daemon
- add `agent-secret session create|list|destroy` and `agent-secret with-session` for wrapped child processes
- add `agent-secret with-session --only` so each command can inject a subset of the approved session bag
- document a re-runnable live session E2E validation runbook
- update the configuration reference, README link, bundled coding-agent skill, changelog, and public website for session workflows
- wire session approval, audit metadata, Swift approval UI text, docs, PRD, and changelog updates

## Validation

- `mise run lint`
- `mise run build`
- `scripts/deploy-site.sh --check-only`
- `mise exec -- npx --yes markdownlint-cli README.md CHANGELOG.md docs/configuration.md docs/session-e2e-validation.md .agents/skills/agent-secret/SKILL.md`
- `mise exec -- npx --yes markdownlint-cli README.md docs/prd.md CHANGELOG.md`
- `mise exec -- npx --yes markdownlint-cli docs/session-e2e-validation.md`
- `git diff --check`
- Headless Chrome local preview for `site/index.html` and `site/docs.html` at 1440px and 390px: session content present, no console errors, no horizontal overflow
- Live session E2E with `op://Agent Secret Integration/Test Secret/password` and `op://Agent Secret Integration/Another Test Secret/password`: config+CLI session create, full injection, `--only` subsets, missing alias rejection before child spawn, destroy rejection, read exhaustion, and audit metadata