### PR TITLE
Hide stale helpers behind background helper repair

### DIFF
--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -118,10 +118,11 @@ agent-secret session destroy asess_123
 Use sessions when the user approves a bag of secrets once and later commands
 need different subsets. `session create` accepts the same config, profile,
 env-file, and `--secret` inputs as `exec`, then returns only an opaque session
-ID. The daemon keeps resolved values in memory until TTL, read count, explicit
-destroy, or daemon stop clears them. `with-session` injects every approved alias
-by default; add `--only ALIAS[,ALIAS...]` to deliver only the aliases needed by
-that child command. Unknown aliases fail before the child process starts.
+ID. Agent Secret keeps resolved values in background helper memory until TTL,
+read count, explicit destroy, or helper stop clears them. `with-session`
+injects every approved alias by default; add `--only ALIAS[,ALIAS...]` to
+deliver only the aliases needed by that child command. Unknown aliases fail
+before the child process starts.
 
 Use a shell only when the shell is the command you actually want approved:
 
@@ -472,9 +473,11 @@ print(f"len={len(v)} sha256={digest}")
 ## Troubleshooting
 
 - `agent-secret doctor` shows non-secret local diagnostics.
-- `agent-secret daemon status` confirms whether the daemon is running.
-- `agent-secret daemon stop` clears daemon-owned in-memory approvals and cached
-  values.
+- `agent-secret repair` inspects and repairs Agent Secret background helper
+  state.
+- `agent-secret install-cli` repairs the command symlink and then tries to
+  refresh the local background helper.
+- `agent-secret daemon status|start|stop` is for low-level daemon diagnostics.
 - `agent-secret bitwarden secrets-manager token status --alias ALIAS` checks
   whether a Bitwarden token alias exists without printing the token.
 - `agent-secret bitwarden secrets-manager token install --alias ALIAS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,36 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
+## [0.0.19] - Pending
+
+### Added
+
+- Added `agent-secret repair` as the user-facing recovery command for Agent
+  Secret background helper and socket state.
+- Added a non-secret background helper hello handshake so the CLI can identify
+  the helper protocol, version, build, process, executable, team, and bundle
+  before sending secret-bearing requests.
+
+### Changed
+
+- Normal commands now refresh trusted old or mismatched background helpers and
+  retry the request path once instead of asking users to stop an old helper.
+- `agent-secret doctor`, help output, docs, the website, and the bundled
+  coding-agent skill now describe normal helper state as Agent Secret's
+  background helper.
+
+### Security
+
+- Unexpected or untrusted background helper socket owners fail closed before any
+  secret-bearing request is sent.
+
 ## [0.0.18] - 2026-06-09
 
 ### Added
 
 - Added bounded session support with `agent-secret session create|list|destroy`
   and `agent-secret with-session` for multi-command workflows that keep values
-  in daemon memory and inject them only into wrapped child processes.
+  in background helper memory and inject them only into wrapped child processes.
 - Added `agent-secret with-session --only` to inject a per-command subset of an
   approved session's aliases.
 - Added metadata-only session audit events for create, resolve, and destroy.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ precedence, env-file migration, and the full schema.
 ## Commands
 
 - `agent-secret exec -- COMMAND [ARG...]`: run a command with approved secrets.
-- `agent-secret session create|list|destroy`: manage bounded daemon-held
+- `agent-secret session create|list|destroy`: manage bounded background-helper
   sessions.
 - `agent-secret with-session SESSION_ID -- COMMAND [ARG...]`: run one command
   with secrets from an approved session. Add `--only ALIAS[,ALIAS...]` to inject
@@ -207,9 +207,11 @@ precedence, env-file migration, and the full schema.
 - `agent-secret profile list|show`: inspect project profiles without resolving
   values.
 - `agent-secret doctor`: print non-secret setup diagnostics.
-- `agent-secret daemon status|start|stop`: inspect or control the per-user
-  daemon.
-- `agent-secret install-cli`: repair the command symlink for the current user.
+- `agent-secret repair`: inspect and repair Agent Secret background helper
+  state.
+- `agent-secret daemon status|start|stop`: run low-level daemon diagnostics.
+- `agent-secret install-cli`: repair the command symlink for the current user
+  and try to refresh the local background helper.
 - `agent-secret skill-install`: repair the bundled coding-agent skill symlink.
 
 Run `agent-secret --help` or `agent-secret exec --help` for the full command
@@ -225,12 +227,13 @@ What Agent Secret does protect:
 
 - Project configs and command flags carry `op://` or `bws://` references, not
   resolved values.
-- The daemon fetches only secrets approved for the current request.
+- The background helper fetches only secrets approved for the current request.
 - Audit logs contain metadata only, not raw secret values.
 - Reusable approvals are bounded by command, cwd, secret references, account or
   token alias, TTL, and use count.
-- Reusable cached values are kept in daemon memory and cleared when their scope
-  is replaced, refreshed, expired, or when the daemon stops.
+- Reusable cached values are kept in Agent Secret's background helper memory and
+  cleared when their scope is replaced, refreshed, expired, or when the helper
+  stops.
 
 Out of scope:
 
@@ -252,7 +255,7 @@ The launch build is intentionally narrow:
 
 - macOS on Apple Silicon only.
 - 1Password Desktop and Bitwarden Secrets Manager only; no other providers yet.
-- Sessions are bounded, daemon-memory only, and usable only through
+- Sessions are bounded, background-helper-memory only, and usable only through
   `agent-secret with-session`; no long-lived interactive shells.
 - No writing, updating, or rotating secrets yet.
 - No GCP Secret Manager or GCP token minting support yet.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,7 +257,8 @@ Current flags:
 - `--force-refresh`: when a reusable approval matches, refetch approved secrets
   before delivering them to the child.
 - `--dry-run`: validate the request and print preflight output without starting
-  the daemon, prompting for approval, resolving values, or spawning the child.
+  the background helper, prompting for approval, resolving values, or spawning
+  the child.
 - `--reuse-only`: use an existing matching reusable approval or fail without
   opening a new approval prompt.
 - `--allow-mutable-executable`: allow a user-owned or writable executable path
@@ -305,8 +306,9 @@ value and env-var delivery does not support binary attachments with NUL bytes.
 ## Session Commands
 
 Sessions approve one bag of secret references, keep the resolved values in
-daemon memory, and let later child commands consume that bag only through
-`agent-secret with-session`. Use them for bounded workflows where a user
+Agent Secret's background helper memory, and let later child commands consume
+that bag only through `agent-secret with-session`. Use them for bounded
+workflows where a user
 approves several secrets once and subsequent commands need those secrets in
 different combinations.
 
@@ -364,10 +366,10 @@ session, Agent Secret fails before spawning the child command.
 `--allow-mutable-executable`. The `--cwd` value defaults to the caller's current
 directory and must match the session working directory.
 
-Sessions are daemon-memory only. They expire when TTL passes, the read count is
-exhausted, `agent-secret session destroy SESSION_ID` succeeds, or the daemon
-stops. V1 sessions intentionally do not expose raw socket value reads,
-credential-helper protocols, or long-lived interactive shells.
+Sessions are background-helper-memory only. They expire when TTL passes, the
+read count is exhausted, `agent-secret session destroy SESSION_ID` succeeds, or
+the helper stops. V1 sessions intentionally do not expose raw socket value
+reads, credential-helper protocols, or long-lived interactive shells.
 
 ## Agent-Friendly Introspection
 
@@ -438,7 +440,13 @@ environment account overrides, then default desktop account detection.
 
 ## Other Commands
 
-Daemon management:
+Background helper repair:
+
+```bash
+agent-secret repair [--json]
+```
+
+Low-level daemon diagnostics:
 
 ```bash
 agent-secret daemon status [--json]
@@ -465,6 +473,9 @@ agent-secret install-cli --force
 ```
 
 `install-cli` creates or repairs the user-level `agent-secret` command symlink.
+After a successful install, it also tries to refresh the local background
+helper. Helper repair failures are warnings; rerun `agent-secret repair` if the
+helper needs manual attention.
 It leaves an existing target symlink in place, refuses directories, and replaces
 an existing regular file or different symlink only when `--force` is passed.
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -9,8 +9,8 @@ Agent Secret Broker is a local, macOS-first system for letting coding agents use
 agent requests exact secret references with a reason and a bounded policy. A
 local broker presents a native approval prompt, fetches approved secrets through
 the official 1Password SDK, and delivers them through CLI-supervised execution
-or bounded session wrappers. Session values stay in daemon memory and are
-injected only into approved child processes.
+or bounded session wrappers. Session values stay in Agent Secret's background
+helper memory and are injected only into approved child processes.
 
 The first user is a local developer running coding agents such as Codex, Claude
 Code, Cursor agent, or similar tools. The first practical workflow is running
@@ -131,9 +131,10 @@ ansible-playbook site.yml --check
 ```
 
 The user approves once for a TTL and max-read count. The broker returns an
-opaque session ID, keeps values in daemon memory, and subsequent commands must
-run through `agent-secret with-session`. The wrapper resolves values over the
-daemon command channel and injects them only into the approved child process.
+opaque session ID, keeps values in Agent Secret's background helper memory, and
+subsequent commands must run through `agent-secret with-session`. The wrapper
+resolves values over the daemon command channel and injects them only into the
+approved child process.
 V1 sessions do not add generic socket reads or credential-helper protocols.
 
 ### Use Case 3: Config-Driven Secret Sync
@@ -230,14 +231,14 @@ agent / Codex
 
 - Collect structured requests from agents and users.
 - Talk to `agent-secretd` over a local Unix domain socket.
-- Provide `exec`, `session`, `with-session`, daemon management, and `doctor`
-  commands.
+- Provide `exec`, `session`, `with-session`, `repair`, low-level daemon
+  diagnostics, and `doctor` commands.
 - Never print raw secret values.
 - In `exec` mode, resolve the executable path and cwd, request an approved
   environment payload from the daemon, spawn the child process, wait for it, and
   report child lifecycle metadata back to the daemon.
-- In session mode, create/list/destroy daemon-held sessions and run each command
-  through `with-session`.
+- In session mode, create/list/destroy background-helper sessions and run each
+  command through `with-session`.
 - Preserve the target command's exit code or signal-based exit status in `exec`
   and `with-session` modes.
 - Hold approved secret values only transiently in memory while preparing the
@@ -258,10 +259,11 @@ agent / Codex
 - Request decisions from the macOS approver app.
 
 The daemon should run as a per-user local daemon, not a privileged system daemon.
-V1 should use it from day one so reusable approvals have shared state. The user
-should not have to think about daemon lifecycle: `agent-secret` starts the daemon
-on demand, connects to it, and reports clear errors if startup fails. A later
-version can install it as a `launchd` LaunchAgent.
+V1 should use it from day one so reusable approvals have shared state. The
+user-facing abstraction is the Agent Secret background helper: `agent-secret`
+starts, refreshes, or repairs the helper on demand and reports clear
+background-helper errors if recovery fails. A later version can install it as a
+`launchd` LaunchAgent.
 
 For v1, `agent-secret` should start a separate `agent-secretd` process when no
 healthy daemon is available. The daemon must detach from the invoking CLI,
@@ -277,12 +279,14 @@ request and approval path.
 
 The v1 daemon should stay alive until manually stopped or until the user logs
 out. Approvals and secret values still expire internally. Users do not need to
-manage the daemon for normal use, but the CLI should provide explicit daemon
-management commands for troubleshooting: `agent-secret daemon status`,
-`agent-secret daemon start`, and `agent-secret daemon stop`.
+manage the daemon for normal use. The CLI should provide `agent-secret repair`
+as the documented recovery path for helper/socket state, plus explicit
+low-level daemon management commands for developer diagnostics:
+`agent-secret daemon status`, `agent-secret daemon start`, and
+`agent-secret daemon stop`.
 
 `agent-secret daemon stop` is immediate in v1. It stops the daemon, cancels
-active approvals, clears daemon memory, stops accepting new work, and exits. It
+active approvals, clears helper memory, stops accepting new work, and exits. It
 does not track, signal, or manage already-spawned child processes;
 those processes continue under normal OS process semantics. Before stopping, the
 daemon should attempt one best-effort `daemon_stop` audit event. Failure to
@@ -534,7 +538,8 @@ should meet the same macOS peer-validation bar.
 
 ## Secret Storage Rules
 
-- Store reusable approval secret values only in daemon memory by default.
+- Store reusable approval secret values only in background helper memory by
+  default.
 - Let `agent-secret exec` hold approved values transiently in memory only while
   preparing and supervising the child process.
 - Keep policy objects value-free; only `SecretCache` and transient
@@ -612,7 +617,7 @@ stderr, then returns the child exit code.
 
 If the daemon sends an approved environment payload and the CLI disconnects
 before reporting `command_started`, the daemon records
-`exec_client_disconnected_after_payload`, clears one-shot daemon-held values, and
+`exec_client_disconnected_after_payload`, clears one-shot helper-held values, and
 does not try to kill or infer any child process. The reusable use was already
 consumed at payload delivery. Reusable cached values remain available until TTL,
 3-use exhaustion, or daemon stop; the disconnect does not clear that reusable
@@ -626,7 +631,7 @@ process-supervision role.
 The validation sequence is:
 
 1. env-only `agent-secret exec`;
-2. bounded daemon-held sessions resolved only by `agent-secret with-session`;
+2. bounded background-helper sessions resolved only by `agent-secret with-session`;
 3. future credential helpers, raw socket reads, file descriptors, and
    config-driven mapping after the wrapper paths are solid.
 
@@ -639,9 +644,10 @@ The daemon approves and fetches secrets. `agent-secret exec` receives the
 approved environment payload over the single per-user daemon socket, spawns the
 target command, injects values into that child process, and waits for exit. The
 daemon never spawns the child. For one-shot exec, TTL bounds the pre-spawn
-approval/fetch/delivery window and values clear from daemon and CLI wrapper
-memory after the command exits. Reusable approvals keep values in daemon memory
-until their TTL or use limit is exhausted. This is the default v1 mode.
+approval/fetch/delivery window and values clear from helper and CLI wrapper
+memory after the command exits. Reusable approvals keep values in background
+helper memory until their TTL or use limit is exhausted. This is the default v1
+mode.
 
 For env-mode `exec`, TTL is not a process lifetime limit. If a child process is
 already running when a one-shot or reusable approval expires, neither the daemon
@@ -670,12 +676,12 @@ Limitations:
 - Environment variables can still be exposed by child process behavior, crash
   reporters, debuggers, or subprocesses.
 
-### Mode 2: Daemon-Held Session IDs
+### Mode 2: Background-Helper Session IDs
 
 The broker creates a short-lived session and returns an opaque session ID
-instead of values. Values stay in daemon memory and are useful only through
-`agent-secret with-session`, matching peer credentials, cwd, remaining read
-count, and unexpired policy.
+instead of values. Values stay in Agent Secret's background helper memory and
+are useful only through `agent-secret with-session`, matching peer credentials,
+cwd, remaining read count, and unexpired policy.
 
 Unlike same-command reuse, sessions approve a bounded set of references for a
 workflow lifetime and allow those approved references to be injected into
@@ -790,7 +796,8 @@ Secret rows should show both alias and full reference, for example
 `CLOUDFLARE_API_TOKEN -> op://Example/Cloudflare API Token/password`.
 The `Approve once` action should be the default highlighted approval action.
 The reusable action should show its 3-use limit and clearly state that approved
-values stay in daemon memory for up to the requested TTL or 3 matching uses.
+values stay in background helper memory for up to the requested TTL or 3
+matching uses.
 In operator-facing UI, say "uses" rather than "runs." A use means approved
 values were delivered to `agent-secret exec`; a failed spawn after delivery still
 spends one use.
@@ -851,6 +858,7 @@ agent-secret session create [options]
 agent-secret with-session asess_123 [--only ALIAS[,ALIAS...]] -- command [args...]
 agent-secret session list
 agent-secret session destroy asess_123
+agent-secret repair
 agent-secret daemon status
 agent-secret daemon start
 agent-secret daemon stop
@@ -862,8 +870,10 @@ file directly at `~/Library/Logs/agent-secret/audit.jsonl`.
 
 There are no reusable approval management commands in v1. In particular,
 `agent-secret approvals list` and `agent-secret approvals destroy <id>` are out
-of scope. If the operator wants to clear reusable approvals before TTL or 3-use
-exhaustion, they use `agent-secret daemon stop`, which clears daemon memory.
+of scope. If the operator needs helper/socket recovery, they use
+`agent-secret repair`. If they need to clear reusable approvals before TTL or
+3-use exhaustion, the low-level `agent-secret daemon stop` diagnostic command
+clears helper memory.
 
 `agent-secret --help` must be detailed enough for an agent to run it and know
 what to do without reading the PRD. Model it after dense agent-oriented CLIs such
@@ -889,14 +899,15 @@ and project-local `--profile NAME` or `default_profile` mappings from
 per-secret account overrides. A broader `--secret-config` mapping mode remains
 deferred.
 
-`doctor` should use the same on-demand daemon startup path as normal commands,
-then report the resulting daemon status. It should launch/probe the native
-approver using a non-secret health check, not a real approval request. It should
-also verify 1Password SDK/client availability, desktop-app auth state,
-desktop-app integration availability, socket directory permissions, and audit log
-writability. It may trigger the 1Password desktop authentication flow so it can
-verify readiness, but it must stop before item/reference access. It must not
-resolve any `op://` reference, fetch arbitrary secrets, or print secret values.
+`doctor` should use the same on-demand background-helper repair path as normal
+commands, then report helper status as `ok`, `refreshed`, or `repair required`.
+It should launch/probe the native approver using a non-secret health check, not
+a real approval request. It should also verify 1Password SDK/client
+availability, desktop-app auth state, desktop-app integration availability,
+socket directory permissions, and audit log writability. It may trigger the
+1Password desktop authentication flow so it can verify readiness, but it must
+stop before item/reference access. It must not resolve any `op://` reference,
+fetch arbitrary secrets, or print secret values.
 
 ## Socket API V1
 
@@ -993,7 +1004,7 @@ MVP must include:
 - Swift macOS approval app with foreground prompt
 - official 1Password Go SDK integration
 - `exec` mode with environment injection
-- bounded daemon-held sessions with `session create`, `session list`,
+- bounded background-helper sessions with `session create`, `session list`,
   `session destroy`, and `with-session`
 - required `--reason`
 - secret references displayed before fetch
@@ -1050,7 +1061,7 @@ Exit criteria:
 Deliverables:
 
 - `agent-secret exec`
-- hidden daemon startup
+- hidden background helper startup
 - native approval UI
 - 1Password fetch after approval
 - child process env injection
@@ -1076,7 +1087,7 @@ Deliverables:
 - session create, list, and destroy
 - opaque session IDs
 - `with-session` wrapper
-- daemon-memory value storage and wrapper-only resolution
+- background-helper-memory value storage and wrapper-only resolution
 - TTL and max-read enforcement
 - strict macOS peer validation for UID, PID, executable path, and cwd
 
@@ -1209,7 +1220,7 @@ Exit criteria:
   returns the child exit code.
 - If `agent-secret exec` disconnects after payload delivery but before
   `command_started`, the daemon records `exec_client_disconnected_after_payload`,
-  clears one-shot daemon-held values, and does not try to kill or infer a child
+  clears one-shot helper-held values, and does not try to kill or infer a child
   process. Reusable cached values are not cleared by this event alone.
 - If `agent-secret exec` disconnects after `command_started` but before
   `command_completed`, the daemon records

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -1,8 +1,8 @@
 # Session E2E Validation
 
 Use this runbook to manually re-test bounded sessions against the real
-CLI, daemon, native approver, provider resolver, audit log, and child-process
-environment injection path.
+CLI, background helper, native approver, provider resolver, audit log, and
+child-process environment injection path.
 
 The test uses two test-only secret references. It never prints resolved values.
 The child commands only assert whether expected environment variables are
@@ -19,7 +19,7 @@ present.
 
 2. Make sure `agent-secret doctor` reports:
 
-   - `daemon startup: ok`
+   - `Background helper: ok`
    - `native approver: ok`
    - `1password desktop integration: ok`
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -35,6 +35,7 @@ type daemonManagerFactory func() (daemonManager, error)
 
 type daemonManager interface {
 	EnsureRunning(ctx context.Context) error
+	Repair(ctx context.Context) (control.RepairResult, error)
 	Connect(ctx context.Context) (daemonClient, error)
 	Status(ctx context.Context) (protocol.StatusPayload, error)
 	Start(ctx context.Context) error
@@ -169,8 +170,10 @@ func (a App) Run(ctx context.Context, args []string) int {
 		return a.runDaemonStop(ctx, command)
 	case KindDoctor:
 		return a.runDoctor(ctx, command)
+	case KindRepair:
+		return a.runRepair(ctx, command)
 	case KindInstallCLI:
-		return a.runInstallCLI(command)
+		return a.runInstallCLI(ctx, command)
 	case KindSkillInstall:
 		return a.runSkillInstall(command)
 	default:

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -111,8 +111,8 @@ func (a App) runAgentContext(command Command) int {
 			MutationBoundary: []string{
 				"exec --dry-run validates without prompting or spawning",
 				"exec --reuse-only fails instead of opening a new approval prompt",
-				"daemon stop clears daemon-owned reusable approvals and cached values",
-				"session destroy or daemon stop clears daemon-held session values",
+				"agent-secret repair safely refreshes trusted background helper mismatches",
+				"session destroy or helper stop clears background-helper session values",
 			},
 		},
 	}
@@ -153,15 +153,20 @@ func agentContextCommands() map[string]commandContext {
 			Outputs: []string{"json"},
 		},
 		"daemon": {
-			Summary: "Troubleshoot the hidden per-user daemon.",
+			Summary: "Run low-level diagnostics for the per-user daemon.",
 			Subcommands: map[string]commandContext{
 				"status": {Summary: "Report whether the daemon is running.", Flags: jsonFlag(), Outputs: []string{"text", "json"}},
 				"start":  {Summary: "Start the daemon and report its status.", Flags: jsonFlag(), Outputs: []string{"text", "json"}},
-				"stop":   {Summary: "Stop the daemon and clear daemon-owned reusable approvals.", Flags: jsonFlag(), Outputs: []string{"text", "json"}},
+				"stop":   {Summary: "Stop the daemon and clear helper-owned reusable approvals.", Flags: jsonFlag(), Outputs: []string{"text", "json"}},
 			},
 		},
 		"doctor": {
-			Summary: "Print non-secret local setup diagnostics.",
+			Summary: "Print non-secret local setup diagnostics, including background helper health.",
+			Flags:   jsonFlag(),
+			Outputs: []string{"text", "json"},
+		},
+		"repair": {
+			Summary: "Inspect and repair Agent Secret background helper state.",
 			Flags:   jsonFlag(),
 			Outputs: []string{"text", "json"},
 		},
@@ -196,7 +201,7 @@ func agentContextCommands() map[string]commandContext {
 			Outputs: []string{"text", "json"},
 		},
 		"session": {
-			Summary: "Create, list, and destroy bounded daemon-held secret sessions.",
+			Summary: "Create, list, and destroy bounded background-helper secret sessions.",
 			Subcommands: map[string]commandContext{
 				"create": {
 					Summary: "Ask for approval, resolve refs, and return an opaque session id.",
@@ -215,7 +220,7 @@ func agentContextCommands() map[string]commandContext {
 						{Name: "--json", Type: "bool", Description: "Print session metadata as JSON."},
 					},
 					Outputs: []string{"text", "json"},
-					Notes:   []string{"returns a session id only", "secret values stay in daemon memory until TTL, max reads, destroy, or daemon stop"},
+					Notes:   []string{"returns a session id only", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
 				},
 				"list": {
 					Summary: "List active session ids and non-secret metadata.",

--- a/internal/cli/app_daemon.go
+++ b/internal/cli/app_daemon.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/kovyrin/agent-secret/internal/audit"
+	"github.com/kovyrin/agent-secret/internal/daemon/control"
 	"github.com/kovyrin/agent-secret/internal/daemon/socket"
 	"github.com/kovyrin/agent-secret/internal/opaccount"
 	"github.com/kovyrin/agent-secret/internal/profileconfig"
@@ -24,6 +25,13 @@ type daemonStatusOutput struct {
 type daemonStopOutput struct {
 	SchemaVersion string `json:"schema_version"`
 	Stopped       bool   `json:"stopped"`
+	Error         string `json:"error,omitempty"`
+}
+
+type repairOutput struct {
+	SchemaVersion string `json:"schema_version"`
+	Status        string `json:"status"`
+	PID           int    `json:"pid,omitempty"`
 	Error         string `json:"error,omitempty"`
 }
 
@@ -122,13 +130,59 @@ func (a App) runDaemonStop(ctx context.Context, command Command) int {
 	return 0
 }
 
+func (a App) runRepair(ctx context.Context, command Command) int {
+	manager, err := a.daemonManager()
+	if err != nil {
+		if command.OutputJSON {
+			return a.writeRepairJSON(repairOutput{
+				SchemaVersion: "1",
+				Status:        string(control.RepairStatusRepairRequired),
+				Error:         err.Error(),
+			}, 1)
+		}
+		a.stderrf("agent-secret: initialize background helper manager: %v\n", err)
+		return 1
+	}
+	result, err := manager.Repair(ctx)
+	if err != nil {
+		if command.OutputJSON {
+			return a.writeRepairJSON(repairOutput{
+				SchemaVersion: "1",
+				Status:        string(control.RepairStatusRepairRequired),
+				Error:         err.Error(),
+			}, 1)
+		}
+		a.stdoutln("Background helper: repair required")
+		a.stdoutln("Run `agent-secret repair` after closing any unexpected Agent Secret helper processes.")
+		return 1
+	}
+	if command.OutputJSON {
+		return a.writeRepairJSON(repairOutput{
+			SchemaVersion: "1",
+			Status:        string(result.Status),
+			PID:           result.PID,
+		}, 0)
+	}
+	switch result.Status {
+	case control.RepairStatusRefreshed:
+		a.stdoutln("Background helper: refreshed")
+	case control.RepairStatusOK:
+		a.stdoutln("Background helper: ok")
+	case control.RepairStatusRepairRequired:
+		a.stdoutln("Background helper: repair required")
+	default:
+		a.stdoutf("Background helper: %s\n", result.Status)
+	}
+	return 0
+}
+
 func (a App) runDoctor(ctx context.Context, command Command) int {
 	manager, err := a.daemonManager()
 	if err != nil {
 		if command.OutputJSON {
-			return a.writeJSONError("initialize daemon manager", err)
+			return a.writeJSONError("initialize background helper manager", err)
 		}
-		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		a.stderrf("agent-secret: initialize background helper manager: %v\n", err)
 		return 1
 	}
 	healthy := true
@@ -138,16 +192,14 @@ func (a App) runDoctor(ctx context.Context, command Command) int {
 	if !jsonOutput {
 		a.stdoutln("agent-secret doctor")
 		a.stdoutf("platform: %s\n", platform)
-		a.stdoutf("daemon socket: %s\n", manager.SocketPath())
+		a.stdoutf("background helper socket: %s\n", manager.SocketPath())
 	}
 
 	var check doctorCheck
 	var checkOK bool
 	check, checkOK = a.auditLogDoctorCheck(ctx, jsonOutput)
 	checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
-	check, checkOK = a.daemonStartupDoctorCheck(ctx, manager, jsonOutput)
-	checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
-	check, checkOK = a.daemonStatusDoctorCheck(ctx, manager, jsonOutput)
+	check, checkOK = a.backgroundHelperDoctorCheck(ctx, manager, jsonOutput)
 	checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
 	check, checkOK = a.socketDirectoryDoctorCheck(manager, jsonOutput)
 	checks, healthy = appendDoctorCheck(checks, healthy, check, checkOK)
@@ -219,31 +271,28 @@ func (a App) auditLogDoctorCheck(ctx context.Context, jsonOutput bool) (doctorCh
 	return doctorCheck{Name: "audit_log", Status: "ok", Path: auditPath}, true
 }
 
-func (a App) daemonStartupDoctorCheck(ctx context.Context, manager daemonManager, jsonOutput bool) (doctorCheck, bool) {
-	if err := manager.EnsureRunning(ctx); err != nil {
-		if !jsonOutput {
-			a.stdoutf("daemon startup: failed (%v)\n", err)
-		}
-		return doctorCheck{Name: "daemon_startup", Status: "failed", Error: err.Error()}, false
-	}
-	if !jsonOutput {
-		a.stdoutln("daemon startup: ok")
-	}
-	return doctorCheck{Name: "daemon_startup", Status: "ok"}, true
-}
-
-func (a App) daemonStatusDoctorCheck(ctx context.Context, manager daemonManager, jsonOutput bool) (doctorCheck, bool) {
-	status, err := manager.Status(ctx)
+func (a App) backgroundHelperDoctorCheck(ctx context.Context, manager daemonManager, jsonOutput bool) (doctorCheck, bool) {
+	result, err := manager.Repair(ctx)
 	if err != nil {
 		if !jsonOutput {
-			a.stdoutf("daemon: failed (%v)\n", err)
+			a.stdoutf("Background helper: repair required (%v)\n", err)
+			a.stdoutln("Run `agent-secret repair` to inspect and repair the local helper state.")
 		}
-		return doctorCheck{Name: "daemon_status", Status: "failed", Error: err.Error()}, false
+		return doctorCheck{Name: "background_helper", Status: string(control.RepairStatusRepairRequired), Error: err.Error()}, false
 	}
 	if !jsonOutput {
-		a.stdoutf("daemon: running pid=%d\n", status.PID)
+		switch result.Status {
+		case control.RepairStatusRefreshed:
+			a.stdoutf("Background helper: refreshed pid=%d\n", result.PID)
+		case control.RepairStatusOK:
+			a.stdoutf("Background helper: ok pid=%d\n", result.PID)
+		case control.RepairStatusRepairRequired:
+			a.stdoutln("Background helper: repair required")
+		default:
+			a.stdoutf("Background helper: %s pid=%d\n", result.Status, result.PID)
+		}
 	}
-	return doctorCheck{Name: "daemon_status", Status: "ok", PID: status.PID}, true
+	return doctorCheck{Name: "background_helper", Status: string(result.Status), PID: result.PID}, true
 }
 
 func (a App) socketDirectoryDoctorCheck(manager daemonManager, jsonOutput bool) (doctorCheck, bool) {
@@ -311,6 +360,14 @@ func (a App) writeDaemonStatusJSON(output daemonStatusOutput, code int) int {
 func (a App) writeDaemonStopJSON(output daemonStopOutput, code int) int {
 	if err := a.writeJSON(output); err != nil {
 		a.stderrf("agent-secret: write daemon stop json: %v\n", err)
+		return 1
+	}
+	return code
+}
+
+func (a App) writeRepairJSON(output repairOutput, code int) int {
+	if err := a.writeJSON(output); err != nil {
+		a.stderrf("agent-secret: write repair json: %v\n", err)
 		return 1
 	}
 	return code

--- a/internal/cli/app_exec.go
+++ b/internal/cli/app_exec.go
@@ -46,11 +46,11 @@ func (a App) runExec(ctx context.Context, command Command) int {
 	}
 	manager, err := a.daemonManager()
 	if err != nil {
-		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		a.stderrf("agent-secret: initialize background helper manager: %v\n", err)
 		return 1
 	}
-	if err := manager.EnsureRunning(ctx); err != nil {
-		a.stderrf("agent-secret: start daemon: %v\n", err)
+	if err := a.ensureBackgroundHelper(ctx, manager); err != nil {
+		a.stderrf("agent-secret: %s\n", backgroundHelperError(err))
 		return 1
 	}
 	requestID, err := a.randomID("req")

--- a/internal/cli/app_install.go
+++ b/internal/cli/app_install.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,7 +24,7 @@ type pathWarning struct {
 	ShadowedBy string `json:"shadowed_by,omitempty"`
 }
 
-func (a App) runInstallCLI(command Command) int {
+func (a App) runInstallCLI(ctx context.Context, command Command) int {
 	installCLI := a.InstallCLI
 	if installCLI == nil {
 		installCLI = install.InstallCLI
@@ -36,6 +37,7 @@ func (a App) runInstallCLI(command Command) int {
 		a.stderrf("agent-secret: install-cli: %v\n", err)
 		return 1
 	}
+	a.tryRepairBackgroundHelperAfterInstall(ctx)
 	if command.OutputJSON {
 		output := installOutput{
 			SchemaVersion: "1",
@@ -55,6 +57,17 @@ func (a App) runInstallCLI(command Command) int {
 	a.stdoutf("agent-secret command installed: %s -> %s\n", result.LinkPath, result.TargetPath)
 	a.warnIfCommandDirMissingFromPath(filepath.Dir(result.LinkPath))
 	return 0
+}
+
+func (a App) tryRepairBackgroundHelperAfterInstall(ctx context.Context) {
+	manager, err := a.daemonManager()
+	if err != nil {
+		a.stderrf("agent-secret: background helper repair skipped: %v\n", err)
+		return
+	}
+	if err := a.ensureBackgroundHelper(ctx, manager); err != nil {
+		a.stderrf("agent-secret: %s\n", backgroundHelperError(err))
+	}
 }
 
 func (a App) runSkillInstall(command Command) int {

--- a/internal/cli/app_item.go
+++ b/internal/cli/app_item.go
@@ -14,11 +14,11 @@ import (
 func (a App) runItemDescribe(ctx context.Context, command Command) int {
 	manager, err := a.daemonManager()
 	if err != nil {
-		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		a.stderrf("agent-secret: initialize background helper manager: %v\n", err)
 		return 1
 	}
-	if err := manager.EnsureRunning(ctx); err != nil {
-		a.stderrf("agent-secret: start daemon: %v\n", err)
+	if err := a.ensureBackgroundHelper(ctx, manager); err != nil {
+		a.stderrf("agent-secret: %s\n", backgroundHelperError(err))
 		return 1
 	}
 	requestID, err := a.randomID("req")

--- a/internal/cli/app_requests.go
+++ b/internal/cli/app_requests.go
@@ -2,11 +2,31 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/kovyrin/agent-secret/internal/daemon/control"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 )
+
+func (a App) ensureBackgroundHelper(ctx context.Context, manager daemonManager) error {
+	result, err := manager.Repair(ctx)
+	if err != nil {
+		return err
+	}
+	if result.Status == control.RepairStatusRefreshed {
+		a.stderrf("agent-secret: Refreshing Agent Secret background helper...\n")
+	}
+	return nil
+}
+
+func backgroundHelperError(err error) string {
+	if errors.Is(err, control.ErrUnexpectedHelper) {
+		return "Agent Secret found an unexpected background helper and refused to send secrets to it.\n" +
+			"Run `agent-secret repair` to inspect and repair the local helper state."
+	}
+	return fmt.Sprintf("prepare background helper: %v", err)
+}
 
 func requestDaemonPayload[T any](
 	ctx context.Context,
@@ -16,7 +36,7 @@ func requestDaemonPayload[T any](
 	var zero T
 	client, err := manager.Connect(ctx)
 	if err != nil {
-		return nil, zero, fmt.Errorf("connect daemon: %w", err)
+		return nil, zero, fmt.Errorf("connect background helper: %w", err)
 	}
 	payload, err := send(client)
 	if err == nil {
@@ -29,11 +49,11 @@ func requestDaemonPayload[T any](
 	_ = client.Close()
 
 	if err := manager.EnsureRunning(ctx); err != nil {
-		return nil, zero, fmt.Errorf("start daemon after upgrade: %w", err)
+		return nil, zero, fmt.Errorf("refresh background helper after upgrade: %w", err)
 	}
 	client, err = manager.Connect(ctx)
 	if err != nil {
-		return nil, zero, fmt.Errorf("connect daemon after upgrade: %w", err)
+		return nil, zero, fmt.Errorf("connect background helper after upgrade: %w", err)
 	}
 	payload, err = send(client)
 	if err != nil {

--- a/internal/cli/app_session.go
+++ b/internal/cli/app_session.go
@@ -31,11 +31,11 @@ type sessionListOutput struct {
 func (a App) runSessionCreate(ctx context.Context, command Command) int {
 	manager, err := a.daemonManager()
 	if err != nil {
-		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		a.stderrf("agent-secret: initialize background helper manager: %v\n", err)
 		return 1
 	}
-	if err := manager.EnsureRunning(ctx); err != nil {
-		a.stderrf("agent-secret: start daemon: %v\n", err)
+	if err := a.ensureBackgroundHelper(ctx, manager); err != nil {
+		a.stderrf("agent-secret: %s\n", backgroundHelperError(err))
 		return 1
 	}
 	correlation, err := a.newCorrelation()
@@ -74,11 +74,11 @@ func (a App) runSessionCreate(ctx context.Context, command Command) int {
 func (a App) runSessionList(ctx context.Context, command Command) int {
 	manager, err := a.daemonManager()
 	if err != nil {
-		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		a.stderrf("agent-secret: initialize background helper manager: %v\n", err)
 		return 1
 	}
-	if err := manager.EnsureRunning(ctx); err != nil {
-		a.stderrf("agent-secret: start daemon: %v\n", err)
+	if err := a.ensureBackgroundHelper(ctx, manager); err != nil {
+		a.stderrf("agent-secret: %s\n", backgroundHelperError(err))
 		return 1
 	}
 	client, payload, err := requestDaemonPayload(ctx, manager, func(client daemonClient) (protocol.SessionListResponsePayload, error) {
@@ -117,11 +117,11 @@ func (a App) runSessionList(ctx context.Context, command Command) int {
 func (a App) runSessionDestroy(ctx context.Context, command Command) int {
 	manager, err := a.daemonManager()
 	if err != nil {
-		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		a.stderrf("agent-secret: initialize background helper manager: %v\n", err)
 		return 1
 	}
-	if err := manager.EnsureRunning(ctx); err != nil {
-		a.stderrf("agent-secret: start daemon: %v\n", err)
+	if err := a.ensureBackgroundHelper(ctx, manager); err != nil {
+		a.stderrf("agent-secret: %s\n", backgroundHelperError(err))
 		return 1
 	}
 	client, payload, err := requestDaemonPayload(ctx, manager, func(client daemonClient) (protocol.SessionDestroyResponsePayload, error) {
@@ -156,11 +156,11 @@ func (a App) runWithSession(ctx context.Context, command Command) int {
 	req := command.SessionResolveRequest.WithExpectedPeer(expectedPeer)
 	manager, err := a.daemonManager()
 	if err != nil {
-		a.stderrf("agent-secret: initialize daemon manager: %v\n", err)
+		a.stderrf("agent-secret: initialize background helper manager: %v\n", err)
 		return 1
 	}
-	if err := manager.EnsureRunning(ctx); err != nil {
-		a.stderrf("agent-secret: start daemon: %v\n", err)
+	if err := a.ensureBackgroundHelper(ctx, manager); err != nil {
+		a.stderrf("agent-secret: %s\n", backgroundHelperError(err))
 		return 1
 	}
 	correlation, err := a.newCorrelation()

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/peertrust"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 	"github.com/kovyrin/agent-secret/internal/daemon/socket"
+	"github.com/kovyrin/agent-secret/internal/helperidentity"
 	"github.com/kovyrin/agent-secret/internal/install"
 	"github.com/kovyrin/agent-secret/internal/itemmetadata"
 	"github.com/kovyrin/agent-secret/internal/peercred"
@@ -1194,6 +1195,92 @@ func TestAppExecRetriesOnceWhenDaemonRetiresBeforeSpawn(t *testing.T) {
 	}
 }
 
+func TestAppExecReportsBackgroundHelperRefreshBeforeRequest(t *testing.T) {
+	if os.Getenv("AGENT_SECRET_APP_EXEC_HELPER") == "1" {
+		runAppExecHelper()
+		return
+	}
+
+	client := &appFakeDaemonClient{
+		execPayload: protocol.ExecResponsePayload{
+			Env:           map[string]string{"TOKEN": "synthetic-secret-value"},
+			SecretAliases: []string{"TOKEN"},
+		},
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(t.TempDir(), "d.sock"),
+		client:     client,
+		status:     protocol.StatusPayload{PID: 1234},
+		repairResult: control.RepairResult{
+			Status: control.RepairStatusRefreshed,
+			PID:    1234,
+		},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	t.Setenv("AGENT_SECRET_APP_EXEC_HELPER", "1")
+
+	code := app.Run(context.Background(), []string{
+		"exec",
+		"--allow-mutable-executable",
+		"--reason", "Run helper",
+		"--account", "Work",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--",
+		os.Args[0], "-test.run=TestAppExecReportsBackgroundHelperRefreshBeforeRequest", "--", "child",
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Refreshing Agent Secret background helper") {
+		t.Fatalf("stderr = %q, want refresh status", stderr.String())
+	}
+	if manager.repairCalls != 1 || manager.connectCalls != 1 || client.requestExecCalls != 1 {
+		t.Fatalf("calls: repair=%d connect=%d request=%d", manager.repairCalls, manager.connectCalls, client.requestExecCalls)
+	}
+}
+
+func TestAppExecRefusesUnexpectedBackgroundHelperBeforeSecretRequest(t *testing.T) {
+	client := &appFakeDaemonClient{
+		execPayload: protocol.ExecResponsePayload{
+			Env:           map[string]string{"TOKEN": "synthetic-secret-value"},
+			SecretAliases: []string{"TOKEN"},
+		},
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(t.TempDir(), "d.sock"),
+		client:     client,
+		repairErr:  fmt.Errorf("%w: untrusted peer", control.ErrUnexpectedHelper),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	code := app.Run(context.Background(), []string{
+		"exec",
+		"--allow-mutable-executable",
+		"--reason", "Run helper",
+		"--account", "Work",
+		"--secret", "TOKEN=op://Example/Item/token",
+		"--",
+		os.Args[0], "-test.run=TestAppExecRefusesUnexpectedBackgroundHelperBeforeSecretRequest", "--", "child",
+	})
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "unexpected background helper") ||
+		!strings.Contains(stderr.String(), "Run `agent-secret repair`") {
+		t.Fatalf("stderr = %q, want unexpected helper guidance", stderr.String())
+	}
+	if manager.connectCalls != 0 || client.requestExecCalls != 0 {
+		t.Fatalf("secret request reached helper: connect=%d request=%d", manager.connectCalls, client.requestExecCalls)
+	}
+	if strings.Contains(stdout.String(), "synthetic-secret-value") || strings.Contains(stderr.String(), "synthetic-secret-value") {
+		t.Fatalf("secret leaked: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
 func TestAppExecReReadsConfigAccountForRunningDaemon(t *testing.T) {
 	if os.Getenv("AGENT_SECRET_APP_EXEC_HELPER") == "1" {
 		runAppExecHelper()
@@ -1393,7 +1480,7 @@ func TestAppDaemonStatusAndDoctor(t *testing.T) {
 		t.Fatalf("doctor exit=%d stderr=%q", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "audit log: writable") ||
-		!strings.Contains(stdout.String(), "daemon startup: ok") ||
+		!strings.Contains(stdout.String(), "Background helper: ok") ||
 		!strings.Contains(stdout.String(), "socket directory: private") ||
 		!strings.Contains(stdout.String(), "native approver: ok") ||
 		!strings.Contains(stdout.String(), "1password desktop integration: ok") {
@@ -1510,8 +1597,7 @@ func TestAppDoctorReportsJSONDependencyFailures(t *testing.T) {
 	}
 	manager := &appFakeDaemonManager{
 		socketPath: filepath.Join(socketDir, "d.sock"),
-		ensureErr:  errors.New("startup unavailable"),
-		statusErr:  errors.New("status unavailable"),
+		repairErr:  errors.New("startup unavailable"),
 		checkErr:   errors.New("desktop unavailable"),
 	}
 	var stdout bytes.Buffer
@@ -1528,15 +1614,23 @@ func TestAppDoctorReportsJSONDependencyFailures(t *testing.T) {
 	}
 	for _, name := range []string{
 		"audit_log",
-		"daemon_startup",
-		"daemon_status",
+		"background_helper",
 		"socket_directory",
 		"native_approver",
 		"1password_desktop_integration",
 	} {
 		check, found := findDoctorCheck(output.Checks, name)
-		if !found || check.Status != "failed" || check.Error == "" {
+		if !found || check.Error == "" {
 			t.Fatalf("doctor check %s = %+v found=%t output=%+v", name, check, found, output)
+		}
+		if name == "background_helper" {
+			if check.Status != string(control.RepairStatusRepairRequired) {
+				t.Fatalf("doctor check %s = %+v, want repair required", name, check)
+			}
+			continue
+		}
+		if check.Status != "failed" {
+			t.Fatalf("doctor check %s = %+v, want failed", name, check)
 		}
 	}
 }
@@ -2177,7 +2271,6 @@ func TestAppSkipsDaemonManagerForNonDaemonCommands(t *testing.T) {
 
 	for _, args := range [][]string{
 		{"help"},
-		{"install-cli", "--bin-dir", filepath.Join(t.TempDir(), "bin"), "--force"},
 		{"skill-install", "--skills-dir", filepath.Join(t.TempDir(), "skills"), "--force"},
 	} {
 		stdout.Reset()
@@ -2188,6 +2281,95 @@ func TestAppSkipsDaemonManagerForNonDaemonCommands(t *testing.T) {
 	}
 	if managerCalls != 0 {
 		t.Fatalf("daemon manager factory called %d times for non-daemon commands", managerCalls)
+	}
+}
+
+func TestAppInstallCLIAttemptsBackgroundHelperRepair(t *testing.T) {
+	binDir := filepath.Join(t.TempDir(), "bin")
+	manager := &appFakeDaemonManager{
+		repairResult: control.RepairResult{
+			Status: control.RepairStatusRefreshed,
+			PID:    5678,
+		},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	app.InstallCLI = func(options install.CLIOptions) (install.CLIResult, error) {
+		return install.CLIResult{
+			LinkPath:   filepath.Join(options.BinDir, "agent-secret"),
+			TargetPath: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		}, nil
+	}
+
+	code := app.Run(context.Background(), []string{"install-cli", "--bin-dir", binDir})
+	if code != 0 {
+		t.Fatalf("install-cli exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if manager.repairCalls != 1 {
+		t.Fatalf("repair calls = %d, want 1", manager.repairCalls)
+	}
+	if !strings.Contains(stderr.String(), "Refreshing Agent Secret background helper") {
+		t.Fatalf("install-cli stderr = %q, want helper refresh status", stderr.String())
+	}
+}
+
+func TestAppInstallCLIWarnsWhenBackgroundHelperRepairFails(t *testing.T) {
+	binDir := filepath.Join(t.TempDir(), "bin")
+	manager := &appFakeDaemonManager{
+		repairErr: fmt.Errorf("%w: untrusted peer", control.ErrUnexpectedHelper),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	app.InstallCLI = func(options install.CLIOptions) (install.CLIResult, error) {
+		return install.CLIResult{
+			LinkPath:   filepath.Join(options.BinDir, "agent-secret"),
+			TargetPath: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		}, nil
+	}
+
+	code := app.Run(context.Background(), []string{"install-cli", "--bin-dir", binDir})
+	if code != 0 {
+		t.Fatalf("install-cli exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if manager.repairCalls != 1 {
+		t.Fatalf("repair calls = %d, want 1", manager.repairCalls)
+	}
+	if !strings.Contains(stderr.String(), "unexpected background helper") ||
+		!strings.Contains(stderr.String(), "agent-secret repair") {
+		t.Fatalf("install-cli stderr = %q, want repair warning", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), filepath.Join(binDir, "agent-secret")) {
+		t.Fatalf("install-cli stdout = %q, want install success output", stdout.String())
+	}
+}
+
+func TestAppInstallCLIWarnsWhenBackgroundHelperManagerCannotInitialize(t *testing.T) {
+	binDir := filepath.Join(t.TempDir(), "bin")
+	managerErr := errors.New("manager unavailable")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := NewApp(func() (control.Manager, error) {
+		return control.Manager{}, managerErr
+	}, &stdout, &stderr)
+	app.InstallCLI = func(options install.CLIOptions) (install.CLIResult, error) {
+		return install.CLIResult{
+			LinkPath:   filepath.Join(options.BinDir, "agent-secret"),
+			TargetPath: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		}, nil
+	}
+
+	code := app.Run(context.Background(), []string{"install-cli", "--bin-dir", binDir})
+	if code != 0 {
+		t.Fatalf("install-cli exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "background helper repair skipped") ||
+		!strings.Contains(stderr.String(), managerErr.Error()) {
+		t.Fatalf("install-cli stderr = %q, want manager warning", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), filepath.Join(binDir, "agent-secret")) {
+		t.Fatalf("install-cli stdout = %q, want install success output", stdout.String())
 	}
 }
 
@@ -2277,16 +2459,241 @@ func TestAppDoctorUsesManagerWithoutSocket(t *testing.T) {
 		t.Fatalf("doctor exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
 	for _, want := range []string{
-		"daemon startup: ok",
-		"daemon: running pid=5678",
+		"Background helper: ok pid=5678",
 		"socket directory: private",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("doctor output = %q, want %q", stdout.String(), want)
 		}
 	}
-	if manager.ensureCalls != 1 || manager.statusCalls != 1 {
-		t.Fatalf("manager calls: ensure=%d status=%d", manager.ensureCalls, manager.statusCalls)
+	if manager.repairCalls != 1 || manager.statusCalls != 0 {
+		t.Fatalf("manager calls: repair=%d status=%d", manager.repairCalls, manager.statusCalls)
+	}
+}
+
+func TestAppDoctorReportsRefreshedBackgroundHelper(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	socketDir := t.TempDir()
+	//nolint:gosec // G302: daemon socket directories must be private but executable by their owner.
+	if err := os.Chmod(socketDir, 0o700); err != nil {
+		t.Fatalf("chmod socket dir: %v", err)
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(socketDir, "d.sock"),
+		repairResult: control.RepairResult{
+			Status: control.RepairStatusRefreshed,
+			PID:    5678,
+		},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	app.DoctorApproverCheck = nil
+
+	code := app.Run(context.Background(), []string{"doctor"})
+	if code != 0 {
+		t.Fatalf("doctor exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Background helper: refreshed pid=5678") {
+		t.Fatalf("doctor output = %q, want refreshed background helper", stdout.String())
+	}
+	if manager.repairCalls != 1 {
+		t.Fatalf("manager repair calls = %d, want 1", manager.repairCalls)
+	}
+}
+
+func TestAppDoctorReportsRepairRequiredBackgroundHelper(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	socketDir := t.TempDir()
+	//nolint:gosec // G302: daemon socket directories must be private but executable by their owner.
+	if err := os.Chmod(socketDir, 0o700); err != nil {
+		t.Fatalf("chmod socket dir: %v", err)
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(socketDir, "d.sock"),
+		repairErr:  fmt.Errorf("%w: untrusted peer", control.ErrUnexpectedHelper),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	app.DoctorApproverCheck = nil
+
+	code := app.Run(context.Background(), []string{"doctor", "--json"})
+	if code != 1 {
+		t.Fatalf("doctor exit=%d, want 1", code)
+	}
+	var got doctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode doctor json: %v; stdout=%q", err, stdout.String())
+	}
+	if got.OK {
+		t.Fatalf("doctor json ok = true, want false: %+v", got)
+	}
+	found := false
+	for _, check := range got.Checks {
+		if check.Name == "background_helper" {
+			found = true
+			if check.Status != string(control.RepairStatusRepairRequired) ||
+				!strings.Contains(check.Error, "untrusted peer") {
+				t.Fatalf("background helper check = %+v", check)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("doctor checks missing background helper: %+v", got.Checks)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("doctor stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAppDoctorReportsRepairRequiredBackgroundHelperText(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	socketDir := t.TempDir()
+	//nolint:gosec // G302: daemon socket directories must be private but executable by their owner.
+	if err := os.Chmod(socketDir, 0o700); err != nil {
+		t.Fatalf("chmod socket dir: %v", err)
+	}
+	manager := &appFakeDaemonManager{
+		socketPath: filepath.Join(socketDir, "d.sock"),
+		repairErr:  fmt.Errorf("%w: untrusted peer", control.ErrUnexpectedHelper),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+	app.DoctorApproverCheck = nil
+
+	code := app.Run(context.Background(), []string{"doctor"})
+	if code != 1 {
+		t.Fatalf("doctor exit=%d, want 1", code)
+	}
+	for _, want := range []string{
+		"Background helper: repair required",
+		"Run `agent-secret repair`",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output = %q, want %q", stdout.String(), want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("doctor stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAppRepairReportsRefreshedBackgroundHelper(t *testing.T) {
+	manager := &appFakeDaemonManager{
+		repairResult: control.RepairResult{
+			Status: control.RepairStatusRefreshed,
+			PID:    5678,
+		},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	code := app.Run(context.Background(), []string{"repair"})
+	if code != 0 {
+		t.Fatalf("repair exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "Background helper: refreshed" {
+		t.Fatalf("repair stdout = %q", stdout.String())
+	}
+	if manager.repairCalls != 1 || manager.connectCalls != 0 {
+		t.Fatalf("manager calls: repair=%d connect=%d", manager.repairCalls, manager.connectCalls)
+	}
+}
+
+func TestAppRepairJSONReportsBackgroundHelperStatus(t *testing.T) {
+	manager := &appFakeDaemonManager{
+		repairResult: control.RepairResult{
+			Status: control.RepairStatusOK,
+			PID:    5678,
+		},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	code := app.Run(context.Background(), []string{"repair", "--json"})
+	if code != 0 {
+		t.Fatalf("repair exit=%d stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var got repairOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode repair json: %v; stdout=%q", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.Status != string(control.RepairStatusOK) || got.PID != 5678 {
+		t.Fatalf("repair json = %+v", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("repair stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAppRepairJSONReportsWriteFailure(t *testing.T) {
+	manager := &appFakeDaemonManager{
+		repairResult: control.RepairResult{
+			Status: control.RepairStatusOK,
+			PID:    5678,
+		},
+	}
+	writeErr := errors.New("stdout closed")
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, failingWriter{err: writeErr}, &stderr)
+
+	code := app.Run(context.Background(), []string{"repair", "--json"})
+	if code != 1 {
+		t.Fatalf("repair exit=%d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "write repair json") ||
+		!strings.Contains(stderr.String(), writeErr.Error()) {
+		t.Fatalf("repair stderr = %q, want write failure", stderr.String())
+	}
+}
+
+func TestAppRepairReportsRepairRequired(t *testing.T) {
+	manager := &appFakeDaemonManager{
+		repairErr: fmt.Errorf("%w: untrusted peer", control.ErrUnexpectedHelper),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	code := app.Run(context.Background(), []string{"repair"})
+	if code != 1 {
+		t.Fatalf("repair exit=%d, want 1", code)
+	}
+	if !strings.Contains(stdout.String(), "Background helper: repair required") {
+		t.Fatalf("repair stdout = %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("repair stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAppRepairJSONReportsRepairRequired(t *testing.T) {
+	manager := &appFakeDaemonManager{
+		repairErr: fmt.Errorf("%w: untrusted peer", control.ErrUnexpectedHelper),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+	code := app.Run(context.Background(), []string{"repair", "--json"})
+	if code != 1 {
+		t.Fatalf("repair exit=%d, want 1", code)
+	}
+	var got repairOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode repair json: %v; stdout=%q", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" ||
+		got.Status != string(control.RepairStatusRepairRequired) ||
+		!strings.Contains(got.Error, "untrusted peer") {
+		t.Fatalf("repair json = %+v", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("repair stderr = %q, want empty", stderr.String())
 	}
 }
 
@@ -2325,7 +2732,7 @@ account: fixture.1password.com
 	}
 }
 
-func TestAppExecReportsDaemonStartFailureBeforeSpawn(t *testing.T) {
+func TestAppExecReportsBackgroundHelperFailureBeforeSpawn(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	app := newTestApp(
@@ -2341,13 +2748,13 @@ func TestAppExecReportsDaemonStartFailureBeforeSpawn(t *testing.T) {
 		"--account", "Work",
 		"--secret", "TOKEN=op://Example/Item/token",
 		"--",
-		os.Args[0], "-test.run=TestAppExecReportsDaemonStartFailureBeforeSpawn", "--", "child",
+		os.Args[0], "-test.run=TestAppExecReportsBackgroundHelperFailureBeforeSpawn", "--", "child",
 	})
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
-	if !strings.Contains(stderr.String(), "start daemon") {
-		t.Fatalf("stderr = %q, want start daemon failure", stderr.String())
+	if !strings.Contains(stderr.String(), "prepare background helper") {
+		t.Fatalf("stderr = %q, want background helper failure", stderr.String())
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want no child output", stdout.String())
@@ -2487,14 +2894,17 @@ type appFakeDaemonManager struct {
 	clients    []daemonClient
 	status     protocol.StatusPayload
 
-	ensureErr  error
-	connectErr error
-	statusErr  error
-	startErr   error
-	stopErr    error
-	checkErr   error
+	repairResult control.RepairResult
+	ensureErr    error
+	repairErr    error
+	connectErr   error
+	statusErr    error
+	startErr     error
+	stopErr      error
+	checkErr     error
 
 	ensureCalls  int
+	repairCalls  int
 	connectCalls int
 	statusCalls  int
 	startCalls   int
@@ -2507,6 +2917,18 @@ type appFakeDaemonManager struct {
 func (m *appFakeDaemonManager) EnsureRunning(context.Context) error {
 	m.ensureCalls++
 	return m.ensureErr
+}
+
+func (m *appFakeDaemonManager) Repair(context.Context) (control.RepairResult, error) {
+	m.repairCalls++
+	m.ensureCalls++
+	if m.repairErr != nil {
+		return control.RepairResult{Status: control.RepairStatusRepairRequired}, m.repairErr
+	}
+	if m.repairResult.Status != "" {
+		return m.repairResult, nil
+	}
+	return control.RepairResult{Status: control.RepairStatusOK, PID: m.status.PID}, nil
 }
 
 func (m *appFakeDaemonManager) Connect(context.Context) (daemonClient, error) {
@@ -2791,6 +3213,14 @@ func (r failingRandomReader) Read(_ []byte) (int, error) {
 	return 0, r.err
 }
 
+type failingWriter struct {
+	err error
+}
+
+func (f failingWriter) Write(_ []byte) (int, error) {
+	return 0, f.err
+}
+
 type appAllowPeer struct{}
 
 func (appAllowPeer) Info(conn *net.UnixConn) (peercred.Info, error) {
@@ -2945,6 +3375,10 @@ func handlePostStartStoppedDaemonConn(conn *net.UnixConn, events chan<- protocol
 		default:
 		}
 		switch env.Type {
+		case protocol.TypeHelperHello:
+			if err := writePostStartStoppedDaemonOK(encoder, env.RequestID, env.Nonce, helperidentity.Current()); err != nil {
+				return err
+			}
 		case protocol.TypeDaemonStatus:
 			if err := writePostStartStoppedDaemonOK(encoder, env.RequestID, env.Nonce, protocol.StatusPayload{PID: os.Getpid()}); err != nil {
 				return err

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -33,6 +33,7 @@ const (
 	KindProfileList    Kind = "profile_list"
 	KindProfileShow    Kind = "profile_show"
 	KindDoctor         Kind = "doctor"
+	KindRepair         Kind = "repair"
 	KindBitwarden      Kind = "bitwarden"
 	KindInstallCLI     Kind = "install_cli"
 	KindSkillInstall   Kind = "skill_install"
@@ -99,13 +100,15 @@ func (p Parser) Parse(args []string) (Command, error) {
 		return parseDaemon(args[1:])
 	case "doctor":
 		return parseDoctor(args[1:])
+	case "repair":
+		return parseRepair(args[1:])
 	case "install-cli":
 		return parseInstallCLI(args[1:])
 	case "skill-install":
 		return parseSkillInstall(args[1:])
 	default:
 		return Command{}, fmt.Errorf(
-			"%w: unknown command %q; expected one of: agent-context, bitwarden, daemon, doctor, exec, help, install-cli, item, profile, session, skill-install, version, with-session",
+			"%w: unknown command %q; expected one of: agent-context, bitwarden, daemon, doctor, exec, help, install-cli, item, profile, repair, session, skill-install, version, with-session",
 			ErrInvalidArguments,
 			args[0],
 		)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1308,6 +1308,7 @@ func TestParseDaemonAndDoctorCommands(t *testing.T) {
 		{args: []string{"daemon", "start"}, want: KindDaemonStart},
 		{args: []string{"daemon", "stop"}, want: KindDaemonStop},
 		{args: []string{"doctor"}, want: KindDoctor},
+		{args: []string{"repair"}, want: KindRepair},
 		{args: []string{"agent-context", "--json"}, want: KindAgentContext},
 		{args: []string{"profile", "list", "--json"}, want: KindProfileList},
 		{args: []string{"profile", "show", "--json"}, want: KindProfileShow},
@@ -1357,6 +1358,14 @@ func TestParseMachineReadableFlags(t *testing.T) {
 	}
 	if command.Kind != KindDaemonStatus || !command.OutputJSON {
 		t.Fatalf("daemon status json command = %+v", command)
+	}
+
+	command, err = parser.Parse([]string{"repair", "--json"})
+	if err != nil {
+		t.Fatalf("Parse repair json returned error: %v", err)
+	}
+	if command.Kind != KindRepair || !command.OutputJSON {
+		t.Fatalf("repair json command = %+v", command)
 	}
 
 	command, err = parser.Parse([]string{"version", "--json"})
@@ -1617,7 +1626,7 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 		{
 			name:  "top",
 			args:  []string{"--help"},
-			wants: []string{"agent-secret controls", "agent-context", "exec", "session", "with-session", "item", "profile", "install-cli", "skill-install", "daemon", "doctor", "version", "desktop account"},
+			wants: []string{"agent-secret controls", "agent-context", "exec", "session", "with-session", "item", "profile", "install-cli", "skill-install", "repair", "daemon", "doctor", "version", "desktop account"},
 		},
 		{
 			name:  "agent-context",
@@ -1667,12 +1676,17 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 		{
 			name:  "daemon",
 			args:  []string{"daemon", "--help"},
-			wants: []string{"daemon status", "daemon start", "daemon stop", "in-memory"},
+			wants: []string{"daemon status", "daemon start", "daemon stop", "agent-secret repair", "in-memory"},
 		},
 		{
 			name:  "doctor",
 			args:  []string{"doctor", "--help"},
-			wants: []string{"non-secret local diagnostics", "1Password", "--json"},
+			wants: []string{"non-secret local diagnostics", "background helper", "1Password", "--json"},
+		},
+		{
+			name:  "repair",
+			args:  []string{"repair", "--help"},
+			wants: []string{"background helper", "trusted old helpers", "--json"},
 		},
 		{
 			name:  "version",

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -9,23 +9,24 @@ agent-secret controls short-lived local access to approved secret refs for codin
 Secrets are never printed by agent-secret and are never written to disk. The normal path is:
 
   1. agent-secret validates the command, reason, cwd, TTL, and exact secret refs.
-  2. agent-secret starts or connects to the per-user daemon.
-  3. The daemon asks the native macOS approver before any secret-provider access.
-  4. If approved, the daemon fetches exactly the approved refs and sends an env payload to agent-secret exec.
+  2. agent-secret starts or connects to the per-user background helper.
+  3. The background helper asks the native macOS approver before any secret-provider access.
+  4. If approved, the background helper fetches exactly the approved refs and sends an env payload to agent-secret exec.
   5. agent-secret exec spawns the child process and passes stdin/stdout/stderr through unchanged.
 
 Commands:
 
   agent-context Print a machine-readable command and config discovery schema.
 	  exec       Run a command with approved secrets injected as environment variables.
-	  session    Create, list, and destroy bounded daemon-held secret sessions.
+	  session    Create, list, and destroy bounded background-helper secret sessions.
 	  with-session Run a command with secrets from an approved session.
 	  item       Inspect 1Password item metadata without revealing secret values.
   profile    Inspect project profiles without resolving secret values.
   bitwarden  Manage local Bitwarden Secrets Manager token aliases.
   install-cli Install or repair the agent-secret command symlink for this user.
   skill-install Install or repair the Agent Secret agent skill for this user.
-  daemon    Troubleshoot the hidden per-user daemon: status, start, stop.
+  repair    Inspect and repair Agent Secret background helper state.
+  daemon    Low-level daemon diagnostics: status, start, stop.
   doctor    Print non-secret local diagnostics for setup troubleshooting.
   version   Print the installed agent-secret version.
   help      Show this help.
@@ -72,10 +73,10 @@ Safety rules:
   - With no account override, agent-secret auto-selects the local personal 1Password desktop account.
   - The wrapped command must appear after -- as argv. agent-secret does not parse shell strings.
   - normal exec has no --json mode and never prints secret values.
-  - exec --dry-run --json validates locally without starting the daemon, prompting, resolving values, or spawning the child.
+  - exec --dry-run --json validates locally without starting the background helper, prompting, resolving values, or spawning the child.
   - exec --reuse-only uses a matching reusable approval or fails without opening a new approval prompt.
 	  - Text file/document refs such as op://Example/GitHub App/key.pem are injected as env values; binary attachments are not supported.
-	  - session create returns an opaque handle only; values stay in daemon memory and are injected only by with-session.
+	  - session create returns an opaque handle only; values stay in background helper memory and are injected only by with-session.
   - item describe requires approval and prints item metadata only: field labels, types, concealment flags, and refs.
   - agent-secret skill-install links the bundled Agent Secret skill into ~/.agents/skills/agent-secret.
   - Reusable approval is selected only in the approval UI, not by a CLI flag.
@@ -214,7 +215,7 @@ Examples:
 
 func ExecHelp() string {
 	return strings.TrimSpace(`
-agent-secret exec validates a command request, asks the local daemon for approved secrets, and then runs the wrapped command.
+agent-secret exec validates a command request, asks the local background helper for approved secrets, and then runs the wrapped command.
 
 Usage:
 
@@ -337,7 +338,7 @@ Examples:
 
 Exit behavior:
 
-  If approval, audit, daemon connection, or secret fetch fails before payload delivery, the child is not spawned.
+  If approval, audit, background helper connection, or secret fetch fails before payload delivery, the child is not spawned.
   If --reuse-only has no matching reusable approval, the child is not spawned and no new approval prompt opens.
   After the child starts, stdin, stdout, and stderr are passed through. The wrapper returns the child exit status.
   Audit metadata is written to ~/Library/Logs/agent-secret/audit.jsonl.
@@ -346,7 +347,7 @@ Exit behavior:
 
 func SessionHelp() string {
 	return strings.TrimSpace(`
-	agent-secret session creates short daemon-held sessions for bounded multi-command workflows.
+	agent-secret session creates short background-helper sessions for bounded multi-command workflows.
 
 	Commands:
 
@@ -361,8 +362,8 @@ func SessionHelp() string {
 	  agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN,STATE_TOKEN -- terraform apply
 	  agent-secret session destroy asess_123
 
-	Values are never printed. Session values live in daemon memory only until TTL,
-	read count exhaustion, destroy, or daemon stop.
+	Values are never printed. Session values live in Agent Secret's background helper memory
+	until TTL, read count exhaustion, destroy, or helper stop.
 	`)
 }
 
@@ -390,7 +391,7 @@ func WithSessionHelp() string {
 
 func DaemonHelp() string {
 	return strings.TrimSpace(`
-agent-secret daemon is for troubleshooting the hidden per-user daemon.
+agent-secret daemon is for low-level developer diagnostics of the per-user daemon.
 
 Usage:
 
@@ -398,19 +399,32 @@ Usage:
   agent-secret daemon start [--json]
   agent-secret daemon stop [--json]
 
-Normal agent-secret exec use starts the daemon automatically and does not print daemon lifecycle details unless something fails.
-Daemon stop clears daemon-owned in-memory reusable approvals, use counters, nonces, and cached values. It does not signal or manage already-running child processes.
+Normal agent-secret exec use prepares the background helper automatically. Use agent-secret repair for product-level helper recovery.
+Daemon stop clears helper-owned in-memory reusable approvals, use counters, nonces, and cached values. It does not signal or manage already-running child processes.
 `)
 }
 
 func DoctorHelp() string {
 	return strings.TrimSpace(`
-agent-secret doctor starts the daemon if needed and prints non-secret local diagnostics: platform, socket directory privacy, audit log writability, daemon status, native approver health, and 1Password desktop integration readiness.
+agent-secret doctor prepares the background helper if needed and prints non-secret local diagnostics: platform, socket directory privacy, audit log writability, background helper status, native approver health, and 1Password desktop integration readiness.
 It never prints secret values or resolves 1Password item references.
 
 Usage:
 
   agent-secret doctor [--json]
+`)
+}
+
+func RepairHelp() string {
+	return strings.TrimSpace(`
+agent-secret repair inspects and repairs Agent Secret background helper state.
+
+Usage:
+
+  agent-secret repair [--json]
+
+The command safely refreshes trusted old helpers, starts the current helper when
+none is running, and refuses unexpected socket owners without sending secrets.
 `)
 }
 

--- a/internal/cli/system_parse.go
+++ b/internal/cli/system_parse.go
@@ -175,6 +175,22 @@ func parseDoctor(args []string) (Command, error) {
 	return Command{Kind: KindDoctor, OutputJSON: *jsonOutput}, nil
 }
 
+func parseRepair(args []string) (Command, error) {
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
+		return Command{Kind: KindHelp, HelpText: RepairHelp()}, ErrHelpRequested
+	}
+	fs := flag.NewFlagSet("repair", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOutput := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if fs.NArg() != 0 {
+		return Command{}, fmt.Errorf("%w: repair accepts no positional arguments", ErrInvalidArguments)
+	}
+	return Command{Kind: KindRepair, OutputJSON: *jsonOutput}, nil
+}
+
 func parseInstallCLI(args []string) (Command, error) {
 	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
 		return Command{Kind: KindHelp, HelpText: InstallCLIHelp()}, ErrHelpRequested

--- a/internal/daemon/control/client.go
+++ b/internal/daemon/control/client.go
@@ -102,6 +102,17 @@ func (c *Client) Status(ctx context.Context) (protocol.StatusPayload, error) {
 	return payload, nil
 }
 
+func (c *Client) Hello(ctx context.Context) (protocol.HelperHelloPayload, error) {
+	payload, err := roundTripPayload[protocol.HelperHelloPayload](ctx, c, protocol.TypeHelperHello, protocol.Correlation{}, nil)
+	if err != nil {
+		return protocol.HelperHelloPayload{}, err
+	}
+	if err := validateHelperHelloPayload(payload); err != nil {
+		return protocol.HelperHelloPayload{}, err
+	}
+	return payload, nil
+}
+
 func (c *Client) RequestStop(ctx context.Context) (protocol.StatusPayload, error) {
 	payload, err := roundTripPayload[protocol.StatusPayload](ctx, c, protocol.TypeDaemonStop, protocol.Correlation{}, nil)
 	if err != nil {
@@ -307,6 +318,22 @@ func roundTripResponse[T any](
 func validateStatusPayload(messageType protocol.MessageType, payload protocol.StatusPayload) error {
 	if payload.PID <= 0 {
 		return fmt.Errorf("%w: %s response has invalid pid", protocol.ErrMalformedEnvelope, messageType)
+	}
+	return nil
+}
+
+func validateHelperHelloPayload(payload protocol.HelperHelloPayload) error {
+	if payload.Protocol != protocol.ProtocolVersion {
+		return fmt.Errorf("%w: helper protocol %d", protocol.ErrProtocolVersion, payload.Protocol)
+	}
+	if payload.AppVersion == "" {
+		return fmt.Errorf("%w: helper.hello response missing app_version", protocol.ErrMalformedEnvelope)
+	}
+	if payload.PID <= 0 {
+		return fmt.Errorf("%w: helper.hello response has invalid pid", protocol.ErrMalformedEnvelope)
+	}
+	if payload.Executable == "" {
+		return fmt.Errorf("%w: helper.hello response missing executable", protocol.ErrMalformedEnvelope)
 	}
 	return nil
 }

--- a/internal/daemon/control/client_test.go
+++ b/internal/daemon/control/client_test.go
@@ -380,6 +380,23 @@ func TestClientValidatesPayloadOKResponseShape(t *testing.T) {
 			wantErrMsg: "invalid pid",
 		},
 		{
+			name: "helper hello executable",
+			frame: func(t *testing.T, env protocol.Envelope) []byte {
+				t.Helper()
+
+				return okResponseFrame(t, env, protocol.HelperHelloPayload{
+					Protocol:   protocol.ProtocolVersion,
+					AppVersion: "dev",
+					PID:        1234,
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.Hello(ctx)
+				return err
+			},
+			wantErrMsg: "missing executable",
+		},
+		{
 			name: "exec aliases",
 			frame: func(t *testing.T, env protocol.Envelope) []byte {
 				t.Helper()

--- a/internal/daemon/control/manager.go
+++ b/internal/daemon/control/manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/socket"
 	"github.com/kovyrin/agent-secret/internal/helperidentity"
 	"github.com/kovyrin/agent-secret/internal/pathresolve"
+	"github.com/kovyrin/agent-secret/internal/peercred"
 )
 
 var ErrDaemonStillRunning = errors.New("daemon still running")
@@ -44,6 +45,7 @@ type Manager struct {
 	ProtocolTimeout time.Duration
 	daemonStdout    io.Writer
 	daemonStderr    io.Writer
+	signalProcess   func(int, os.Signal) error
 }
 
 func NewManager(socketPath string) (Manager, error) {
@@ -85,6 +87,24 @@ func (m Manager) Start(ctx context.Context) error {
 }
 
 func (m Manager) Repair(ctx context.Context) (RepairResult, error) {
+	result, err := m.repairOnce(ctx)
+	if err == nil {
+		return result, nil
+	}
+	if !helperUnavailableError(err) && !peerProcessGoneError(err) {
+		return result, err
+	}
+	if waitErr := m.waitUntilUnavailableWith(ctx, 25*time.Millisecond, "trusted helper", m.rawSocketUnavailable); waitErr != nil {
+		return result, err
+	}
+	retryResult, retryErr := m.repairOnce(ctx)
+	if retryErr == nil && retryResult.Status == RepairStatusOK && peerProcessGoneError(err) {
+		retryResult.Status = RepairStatusRefreshed
+	}
+	return retryResult, retryErr
+}
+
+func (m Manager) repairOnce(ctx context.Context) (RepairResult, error) {
 	inspection, err := m.inspectTrustedHelper(ctx)
 	if err == nil {
 		if inspection.matches {
@@ -92,19 +112,12 @@ func (m Manager) Repair(ctx context.Context) (RepairResult, error) {
 		}
 		return m.refreshTrustedHelper(ctx)
 	}
-	if errors.Is(err, socket.ErrDaemonUnavailable) {
-		if err := m.startCurrent(ctx); err != nil {
-			return RepairResult{Status: RepairStatusRepairRequired}, err
+	if helperUnavailableError(err) {
+		status := RepairStatusOK
+		if peerProcessGoneError(err) {
+			status = RepairStatusRefreshed
 		}
-		inspection, err := m.inspectTrustedHelper(ctx)
-		if err != nil {
-			return RepairResult{Status: RepairStatusRepairRequired}, err
-		}
-		if !inspection.matches {
-			return RepairResult{Status: RepairStatusRepairRequired, PID: inspection.hello.PID, Hello: inspection.hello},
-				fmt.Errorf("%w: started helper does not match current build", ErrHelperMismatch)
-		}
-		return RepairResult{Status: RepairStatusOK, PID: inspection.hello.PID, Hello: inspection.hello}, nil
+		return m.startCurrentWithStatusRetry(ctx, status)
 	}
 	if isRetiringDaemon(err) {
 		if err := m.waitUntilTrustedHelperUnavailable(ctx, 25*time.Millisecond); err != nil {
@@ -126,17 +139,54 @@ func (m Manager) Repair(ctx context.Context) (RepairResult, error) {
 	if errors.Is(err, ErrHelperMismatch) {
 		return m.refreshTrustedHelper(ctx)
 	}
+	if m.trustedHelperVanishedAfterTrustError(ctx, err) {
+		return m.startCurrentWithStatusRetry(ctx, RepairStatusRefreshed)
+	}
 	return RepairResult{Status: RepairStatusRepairRequired}, err
 }
 
+func (m Manager) startCurrentWithStatus(ctx context.Context, status RepairStatus) (RepairResult, error) {
+	if err := m.startCurrent(ctx); err != nil {
+		return RepairResult{Status: RepairStatusRepairRequired}, err
+	}
+	inspection, err := m.inspectTrustedHelper(ctx)
+	if err != nil {
+		return RepairResult{Status: RepairStatusRepairRequired}, err
+	}
+	if !inspection.matches {
+		return RepairResult{Status: RepairStatusRepairRequired, PID: inspection.hello.PID, Hello: inspection.hello},
+			fmt.Errorf("%w: started helper does not match current build", ErrHelperMismatch)
+	}
+	return RepairResult{Status: status, PID: inspection.hello.PID, Hello: inspection.hello}, nil
+}
+
+func (m Manager) startCurrentWithStatusRetry(ctx context.Context, status RepairStatus) (RepairResult, error) {
+	result, err := m.startCurrentWithStatus(ctx, status)
+	if err == nil {
+		return result, nil
+	}
+	if !helperUnavailableError(err) && !peerProcessGoneError(err) {
+		return result, err
+	}
+	if waitErr := m.waitUntilUnavailableWith(ctx, 25*time.Millisecond, "trusted helper", m.rawSocketUnavailable); waitErr != nil {
+		return result, err
+	}
+	return m.startCurrentWithStatus(ctx, status)
+}
+
 func (m Manager) startCurrent(ctx context.Context) error {
-	if err := m.statusBeforeStart(ctx); err == nil {
+	removePeerGoneSocket := false
+	err := m.statusBeforeStart(ctx)
+	switch {
+	case err == nil:
 		return nil
-	} else if isRetiringDaemon(err) {
+	case isRetiringDaemon(err):
 		if err := m.waitUntilUnavailable(ctx, 25*time.Millisecond); err != nil {
 			return err
 		}
-	} else if !errors.Is(err, socket.ErrDaemonUnavailable) {
+	case peerProcessGoneError(err):
+		removePeerGoneSocket = true
+	case !helperUnavailableError(err):
 		return err
 	}
 	if m.DaemonPath == "" {
@@ -145,8 +195,14 @@ func (m Manager) startCurrent(ctx context.Context) error {
 	if err := socket.PrepareDirectory(m.socketPath); err != nil {
 		return err
 	}
-	if err := socket.CleanupStale(m.socketPath); err != nil {
-		return err
+	if removePeerGoneSocket {
+		if err := os.Remove(m.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove stale daemon socket for exited peer: %w", err)
+		}
+	} else {
+		if err := socket.CleanupStale(m.socketPath); err != nil {
+			return err
+		}
 	}
 
 	cmd := daemonprocess.StartCommand(ctx, m.DaemonPath, m.daemonArgs())
@@ -390,6 +446,9 @@ func (m Manager) connectTrustedHelper(ctx context.Context) (*Client, error) {
 }
 
 func classifyHelperConnectError(err error) error {
+	if peerProcessGoneError(err) {
+		return fmt.Errorf("%w: %w", socket.ErrDaemonUnavailable, err)
+	}
 	if errors.Is(err, peertrust.ErrUntrustedDaemon) {
 		return fmt.Errorf("%w: %w", ErrUnexpectedHelper, err)
 	}
@@ -399,7 +458,8 @@ func classifyHelperConnectError(err error) error {
 func helperHelloMismatchError(err error) bool {
 	return errors.Is(err, protocol.ErrProtocolType) ||
 		errors.Is(err, protocol.ErrProtocolVersion) ||
-		IsProtocolError(err, protocol.ErrorCodeBadType)
+		IsProtocolError(err, protocol.ErrorCodeBadType) ||
+		IsProtocolError(err, protocol.ErrorCodeUntrustedClient)
 }
 
 func (m Manager) helperMatchesExpected(hello protocol.HelperHelloPayload) (bool, error) {
@@ -467,10 +527,106 @@ func (m Manager) stopTrustedHelper(ctx context.Context) error {
 	}
 	if _, err := client.RequestStop(ctx); err != nil {
 		_ = client.Close()
+		if IsProtocolError(err, protocol.ErrorCodeUntrustedClient) {
+			return m.signalTrustedHelper(ctx)
+		}
 		return err
 	}
 	_ = client.Close()
 	return m.waitUntilTrustedHelperUnavailable(ctx, 25*time.Millisecond)
+}
+
+func (m Manager) signalTrustedHelper(ctx context.Context) error {
+	info, err := m.inspectTrustedHelperPeer(ctx)
+	if errors.Is(err, socket.ErrDaemonUnavailable) {
+		return nil
+	}
+	if peerProcessGoneError(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.PID <= 0 {
+		return fmt.Errorf("%w: trusted helper pid is unavailable", ErrUnexpectedHelper)
+	}
+	signalFn := m.signalProcess
+	if signalFn == nil {
+		signalFn = signalProcess
+	}
+	if err := signalFn(info.PID, syscall.SIGTERM); err != nil {
+		return fmt.Errorf("signal trusted helper pid %d: %w", info.PID, err)
+	}
+	return m.waitUntilTrustedHelperUnavailable(ctx, 25*time.Millisecond)
+}
+
+func (m Manager) inspectTrustedHelperPeer(ctx context.Context) (peercred.Info, error) {
+	trustedPaths, err := m.trustedDaemonPaths()
+	if err != nil {
+		return peercred.Info{}, err
+	}
+	conn, err := socket.Dial(ctx, m.socketPath)
+	if err != nil {
+		return peercred.Info{}, err
+	}
+	defer func() { _ = conn.Close() }()
+	info, err := peercred.Inspect(conn)
+	if err != nil {
+		return peercred.Info{}, fmt.Errorf("%w: inspect daemon peer: %w", peertrust.ErrUntrustedDaemon, err)
+	}
+	if err := peertrust.NewDaemonProductValidator(trustedPaths).ValidateDaemonPeer(info); err != nil {
+		return peercred.Info{}, err
+	}
+	return info, nil
+}
+
+func peerProcessGoneError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.ESRCH) || strings.Contains(err.Error(), "no such process")
+}
+
+func signalProcess(pid int, sig os.Signal) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	if err := process.Signal(sig); err != nil {
+		if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (m Manager) trustedHelperVanishedAfterTrustError(ctx context.Context, err error) bool {
+	if !errors.Is(err, ErrUnexpectedHelper) && !errors.Is(err, peertrust.ErrUntrustedDaemon) {
+		return false
+	}
+	unavailable, unavailableErr := m.rawSocketUnavailable(ctx)
+	if unavailableErr == nil && unavailable {
+		return true
+	}
+	if peerProcessGoneError(err) {
+		return m.waitUntilUnavailableWith(ctx, 25*time.Millisecond, "trusted helper", m.rawSocketUnavailable) == nil
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	return m.waitUntilUnavailableWith(waitCtx, 25*time.Millisecond, "trusted helper", m.rawSocketUnavailable) == nil
+}
+
+func (m Manager) rawSocketUnavailable(ctx context.Context) (bool, error) {
+	conn, err := socket.Dial(ctx, m.socketPath)
+	if err != nil {
+		if isUnavailableDaemonStatusError(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	_ = conn.Close()
+	return false, nil
 }
 
 func (m Manager) protocolTimeout() time.Duration {
@@ -525,6 +681,11 @@ func isUnavailableDaemonStatusError(err error) bool {
 		errors.Is(err, io.EOF) ||
 		errors.Is(err, syscall.EPIPE) ||
 		errors.Is(err, syscall.ECONNRESET)
+}
+
+func helperUnavailableError(err error) bool {
+	return isUnavailableDaemonStatusError(err) ||
+		(peerProcessGoneError(err) && strings.Contains(err.Error(), socket.ErrDaemonUnavailable.Error()))
 }
 
 func (m Manager) daemonArgs() []string {

--- a/internal/daemon/control/manager.go
+++ b/internal/daemon/control/manager.go
@@ -14,9 +14,27 @@ import (
 	daemonprocess "github.com/kovyrin/agent-secret/internal/daemon/process"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 	"github.com/kovyrin/agent-secret/internal/daemon/socket"
+	"github.com/kovyrin/agent-secret/internal/helperidentity"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 )
 
 var ErrDaemonStillRunning = errors.New("daemon still running")
+var ErrUnexpectedHelper = errors.New("unexpected background helper")
+var ErrHelperMismatch = errors.New("background helper mismatch")
+
+type RepairStatus string
+
+const (
+	RepairStatusOK             RepairStatus = "ok"
+	RepairStatusRefreshed      RepairStatus = "refreshed"
+	RepairStatusRepairRequired RepairStatus = "repair_required"
+)
+
+type RepairResult struct {
+	Status RepairStatus
+	PID    int
+	Hello  protocol.HelperHelloPayload
+}
 
 type Manager struct {
 	socketPath      string
@@ -57,10 +75,61 @@ func (m Manager) SocketPath() string {
 }
 
 func (m Manager) EnsureRunning(ctx context.Context) error {
-	return m.Start(ctx)
+	_, err := m.Repair(ctx)
+	return err
 }
 
 func (m Manager) Start(ctx context.Context) error {
+	_, err := m.Repair(ctx)
+	return err
+}
+
+func (m Manager) Repair(ctx context.Context) (RepairResult, error) {
+	inspection, err := m.inspectTrustedHelper(ctx)
+	if err == nil {
+		if inspection.matches {
+			return RepairResult{Status: RepairStatusOK, PID: inspection.hello.PID, Hello: inspection.hello}, nil
+		}
+		return m.refreshTrustedHelper(ctx)
+	}
+	if errors.Is(err, socket.ErrDaemonUnavailable) {
+		if err := m.startCurrent(ctx); err != nil {
+			return RepairResult{Status: RepairStatusRepairRequired}, err
+		}
+		inspection, err := m.inspectTrustedHelper(ctx)
+		if err != nil {
+			return RepairResult{Status: RepairStatusRepairRequired}, err
+		}
+		if !inspection.matches {
+			return RepairResult{Status: RepairStatusRepairRequired, PID: inspection.hello.PID, Hello: inspection.hello},
+				fmt.Errorf("%w: started helper does not match current build", ErrHelperMismatch)
+		}
+		return RepairResult{Status: RepairStatusOK, PID: inspection.hello.PID, Hello: inspection.hello}, nil
+	}
+	if isRetiringDaemon(err) {
+		if err := m.waitUntilTrustedHelperUnavailable(ctx, 25*time.Millisecond); err != nil {
+			return RepairResult{Status: RepairStatusRepairRequired}, err
+		}
+		if err := m.startCurrent(ctx); err != nil {
+			return RepairResult{Status: RepairStatusRepairRequired}, err
+		}
+		inspection, err := m.inspectTrustedHelper(ctx)
+		if err != nil {
+			return RepairResult{Status: RepairStatusRepairRequired}, err
+		}
+		if !inspection.matches {
+			return RepairResult{Status: RepairStatusRepairRequired, PID: inspection.hello.PID, Hello: inspection.hello},
+				fmt.Errorf("%w: refreshed helper still does not match current build", ErrHelperMismatch)
+		}
+		return RepairResult{Status: RepairStatusRefreshed, PID: inspection.hello.PID, Hello: inspection.hello}, nil
+	}
+	if errors.Is(err, ErrHelperMismatch) {
+		return m.refreshTrustedHelper(ctx)
+	}
+	return RepairResult{Status: RepairStatusRepairRequired}, err
+}
+
+func (m Manager) startCurrent(ctx context.Context) error {
 	if err := m.statusBeforeStart(ctx); err == nil {
 		return nil
 	} else if isRetiringDaemon(err) {
@@ -173,8 +242,14 @@ func (m Manager) Connect(ctx context.Context) (*Client, error) {
 }
 
 func (m Manager) statusBeforeStart(ctx context.Context) error {
-	_, err := m.Status(ctx)
-	return err
+	inspection, err := m.inspectCurrentHelper(ctx)
+	if err != nil {
+		return err
+	}
+	if !inspection.matches {
+		return fmt.Errorf("%w: running helper does not match current build", ErrHelperMismatch)
+	}
+	return nil
 }
 
 func (m Manager) waitUntilReady(ctx context.Context, interval time.Duration) error {
@@ -205,6 +280,19 @@ func (m Manager) waitUntilReady(ctx context.Context, interval time.Duration) err
 }
 
 func (m Manager) waitUntilUnavailable(ctx context.Context, interval time.Duration) error {
+	return m.waitUntilUnavailableWith(ctx, interval, "retiring daemon", m.statusUnavailable)
+}
+
+func (m Manager) waitUntilTrustedHelperUnavailable(ctx context.Context, interval time.Duration) error {
+	return m.waitUntilUnavailableWith(ctx, interval, "trusted helper", m.trustedHelperUnavailable)
+}
+
+func (m Manager) waitUntilUnavailableWith(
+	ctx context.Context,
+	interval time.Duration,
+	label string,
+	check func(context.Context) (bool, error),
+) error {
 	if interval <= 0 {
 		interval = 25 * time.Millisecond
 	}
@@ -219,7 +307,7 @@ func (m Manager) waitUntilUnavailable(ctx context.Context, interval time.Duratio
 	defer ticker.Stop()
 
 	for {
-		unavailable, err := m.statusUnavailable(waitCtx)
+		unavailable, err := check(waitCtx)
 		if err != nil {
 			return err
 		}
@@ -232,7 +320,7 @@ func (m Manager) waitUntilUnavailable(ctx context.Context, interval time.Duratio
 			if cause := context.Cause(waitCtx); cause != nil && !errors.Is(cause, ctxErr) {
 				ctxErr = errors.Join(ctxErr, cause)
 			}
-			return fmt.Errorf("%w: retiring daemon still responds: %w", ErrDaemonStillRunning, ctxErr)
+			return fmt.Errorf("%w: %s still responds: %w", ErrDaemonStillRunning, label, ctxErr)
 		case <-ticker.C:
 		}
 	}
@@ -250,6 +338,141 @@ func (m Manager) trustedDaemonPaths() ([]string, error) {
 	return peertrust.DaemonPathsForPath(daemonPath)
 }
 
+type helperInspection struct {
+	hello   protocol.HelperHelloPayload
+	matches bool
+}
+
+func (m Manager) inspectCurrentHelper(ctx context.Context) (helperInspection, error) {
+	client, err := m.Connect(ctx)
+	if err != nil {
+		return helperInspection{}, classifyHelperConnectError(err)
+	}
+	defer func() { _ = client.Close() }()
+	return m.inspectConnectedHelper(ctx, client)
+}
+
+func (m Manager) inspectTrustedHelper(ctx context.Context) (helperInspection, error) {
+	client, err := m.connectTrustedHelper(ctx)
+	if err != nil {
+		return helperInspection{}, classifyHelperConnectError(err)
+	}
+	defer func() { _ = client.Close() }()
+	return m.inspectConnectedHelper(ctx, client)
+}
+
+func (m Manager) inspectConnectedHelper(ctx context.Context, client *Client) (helperInspection, error) {
+	hello, err := client.Hello(ctx)
+	if err != nil {
+		if helperHelloMismatchError(err) {
+			return helperInspection{}, fmt.Errorf("%w: %w", ErrHelperMismatch, err)
+		}
+		return helperInspection{}, err
+	}
+	matches, err := m.helperMatchesExpected(hello)
+	if err != nil {
+		return helperInspection{}, err
+	}
+	return helperInspection{hello: hello, matches: matches}, nil
+}
+
+func (m Manager) connectTrustedHelper(ctx context.Context) (*Client, error) {
+	trustedPaths, err := m.trustedDaemonPaths()
+	if err != nil {
+		return nil, err
+	}
+	client, err := ConnectWithPeerValidator(ctx, m.socketPath, peertrust.NewDaemonProductValidator(trustedPaths))
+	if err != nil {
+		return nil, err
+	}
+	client.DefaultTimeout = m.protocolTimeout()
+	return client, nil
+}
+
+func classifyHelperConnectError(err error) error {
+	if errors.Is(err, peertrust.ErrUntrustedDaemon) {
+		return fmt.Errorf("%w: %w", ErrUnexpectedHelper, err)
+	}
+	return err
+}
+
+func helperHelloMismatchError(err error) bool {
+	return errors.Is(err, protocol.ErrProtocolType) ||
+		errors.Is(err, protocol.ErrProtocolVersion) ||
+		IsProtocolError(err, protocol.ErrorCodeBadType)
+}
+
+func (m Manager) helperMatchesExpected(hello protocol.HelperHelloPayload) (bool, error) {
+	expected, err := m.expectedHelperHello()
+	if err != nil {
+		return false, err
+	}
+	if hello.Protocol != expected.Protocol ||
+		hello.AppVersion != expected.AppVersion ||
+		hello.BuildID != expected.BuildID {
+		return false, nil
+	}
+	if !samePath(hello.Executable, expected.Executable) {
+		return false, nil
+	}
+	if expected.TeamID != "" && hello.TeamID != expected.TeamID {
+		return false, nil
+	}
+	if expected.BundleID != "" && hello.BundleID != expected.BundleID {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m Manager) expectedHelperHello() (protocol.HelperHelloPayload, error) {
+	trustedPaths, err := m.trustedDaemonPaths()
+	if err != nil {
+		return protocol.HelperHelloPayload{}, err
+	}
+	if len(trustedPaths) == 0 {
+		return protocol.HelperHelloPayload{}, errors.New("daemon path is required")
+	}
+	return helperidentity.ForExecutable(trustedPaths[0], os.Getpid()), nil
+}
+
+func samePath(a string, b string) bool {
+	return pathresolve.BestEffort(a) == pathresolve.BestEffort(b)
+}
+
+func (m Manager) refreshTrustedHelper(ctx context.Context) (RepairResult, error) {
+	if err := m.stopTrustedHelper(ctx); err != nil {
+		return RepairResult{Status: RepairStatusRepairRequired}, err
+	}
+	if err := m.startCurrent(ctx); err != nil {
+		return RepairResult{Status: RepairStatusRepairRequired}, err
+	}
+	inspection, err := m.inspectTrustedHelper(ctx)
+	if err != nil {
+		return RepairResult{Status: RepairStatusRepairRequired}, err
+	}
+	if !inspection.matches {
+		return RepairResult{Status: RepairStatusRepairRequired, PID: inspection.hello.PID, Hello: inspection.hello},
+			fmt.Errorf("%w: refreshed helper still does not match current build", ErrHelperMismatch)
+	}
+	return RepairResult{Status: RepairStatusRefreshed, PID: inspection.hello.PID, Hello: inspection.hello}, nil
+}
+
+func (m Manager) stopTrustedHelper(ctx context.Context) error {
+	client, err := m.connectTrustedHelper(ctx)
+	if errors.Is(err, socket.ErrDaemonUnavailable) {
+		return nil
+	}
+	if err != nil {
+		return classifyHelperConnectError(err)
+	}
+	if _, err := client.RequestStop(ctx); err != nil {
+		_ = client.Close()
+		return err
+	}
+	_ = client.Close()
+	return m.waitUntilTrustedHelperUnavailable(ctx, 25*time.Millisecond)
+}
+
 func (m Manager) protocolTimeout() time.Duration {
 	if m.ProtocolTimeout > 0 {
 		return m.ProtocolTimeout
@@ -259,6 +482,28 @@ func (m Manager) protocolTimeout() time.Duration {
 
 func (m Manager) statusUnavailable(ctx context.Context) (bool, error) {
 	_, err := m.Status(ctx)
+	if err == nil {
+		return false, nil
+	}
+	if isUnavailableDaemonStatusError(err) {
+		return true, nil
+	}
+	if isRetiringDaemon(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (m Manager) trustedHelperUnavailable(ctx context.Context) (bool, error) {
+	client, err := m.connectTrustedHelper(ctx)
+	if err != nil {
+		if isUnavailableDaemonStatusError(err) {
+			return true, nil
+		}
+		return false, classifyHelperConnectError(err)
+	}
+	defer func() { _ = client.Close() }()
+	_, err = client.Status(ctx)
 	if err == nil {
 		return false, nil
 	}

--- a/internal/daemon/control/manager_test.go
+++ b/internal/daemon/control/manager_test.go
@@ -25,6 +25,7 @@ import (
 	daemonprocess "github.com/kovyrin/agent-secret/internal/daemon/process"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 	"github.com/kovyrin/agent-secret/internal/daemon/socket"
+	"github.com/kovyrin/agent-secret/internal/helperidentity"
 	"github.com/kovyrin/agent-secret/internal/itemmetadata"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
@@ -344,6 +345,294 @@ func TestManagerStatusUnavailableReturnsOtherStatusErrors(t *testing.T) {
 	}
 }
 
+func TestManagerRepairReportsRunningCurrentHelper(t *testing.T) {
+	t.Parallel()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	hello := helperidentity.ForExecutable(executable, os.Getpid())
+	path, stop := startFakeHelperDaemon(t, hello)
+	defer stop()
+	manager := Manager{
+		socketPath: path,
+		DaemonPath: executable,
+	}
+
+	result, err := manager.Repair(context.Background())
+	if err != nil {
+		t.Fatalf("Repair returned error: %v", err)
+	}
+	if result.Status != RepairStatusOK || result.PID != os.Getpid() {
+		t.Fatalf("Repair result = %+v, want ok for current pid", result)
+	}
+	if !samePath(result.Hello.Executable, executable) {
+		t.Fatalf("Repair hello executable = %q, want %q", result.Hello.Executable, executable)
+	}
+}
+
+func TestManagerRepairRefreshesMismatchedTrustedHelper(t *testing.T) {
+	if os.Getenv("AGENT_SECRET_DAEMON_MANAGER_REPAIR_HELPER") == "1" {
+		runDaemonManagerHelper(t)
+		return
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	staleHello := helperidentity.ForExecutable(executable, os.Getpid())
+	staleHello.BuildID += "-stale"
+	path, stopStale := startFakeHelperDaemon(t, staleHello)
+	defer stopStale()
+
+	output, err := os.Create(filepath.Join(t.TempDir(), "repair-helper.log"))
+	if err != nil {
+		t.Fatalf("create helper output log: %v", err)
+	}
+	defer func() { _ = output.Close() }()
+	manager := Manager{
+		socketPath:     path,
+		DaemonPath:     executable,
+		DaemonArgs:     []string{"-test.run=TestManagerRepairRefreshesMismatchedTrustedHelper", "--", "--socket", "{socket}"},
+		StartupTimeout: 2 * time.Second,
+		daemonStdout:   output,
+		daemonStderr:   output,
+	}
+	t.Setenv("AGENT_SECRET_DAEMON_MANAGER_REPAIR_HELPER", "1")
+
+	result, err := manager.Repair(context.Background())
+	if err != nil {
+		helperOutput := readManagerHelperOutput(t, output.Name())
+		if strings.Contains(helperOutput, managerHelperBindUnavailablePrefix) {
+			t.Skipf("Unix socket bind unavailable in daemon repair helper: %s", helperOutput)
+		}
+		t.Fatalf("Repair returned error: %v\nhelper output:\n%s", err, helperOutput)
+	}
+	defer func() { _ = manager.Stop(context.Background()) }()
+	if result.Status != RepairStatusRefreshed {
+		t.Fatalf("Repair status = %q, want refreshed", result.Status)
+	}
+	if result.PID <= 0 || result.PID == os.Getpid() {
+		t.Fatalf("Repair pid = %d, want fresh helper process", result.PID)
+	}
+	if result.Hello.BuildID != helperidentity.ForExecutable(executable, os.Getpid()).BuildID {
+		t.Fatalf("Repair hello build id = %q, want current build id", result.Hello.BuildID)
+	}
+}
+
+func TestManagerRepairRejectsUnexpectedHelper(t *testing.T) {
+	t.Parallel()
+
+	path, stop := startFakeExecDaemon(t)
+	defer stop()
+	manager := Manager{
+		socketPath: path,
+		DaemonPath: writeDaemonExecutableAt(t, t.TempDir()),
+	}
+
+	_, err := manager.Repair(context.Background())
+	if !errors.Is(err, ErrUnexpectedHelper) {
+		t.Fatalf("Repair error = %v, want %v", err, ErrUnexpectedHelper)
+	}
+}
+
+func TestManagerInspectConnectedHelperClassifiesLegacyHello(t *testing.T) {
+	t.Parallel()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	path, stop := startFakeStatusErrorDaemon(t, protocol.ErrorCodeBadType)
+	defer stop()
+	manager := Manager{
+		socketPath: path,
+		DaemonPath: executable,
+	}
+	client, err := manager.connectTrustedHelper(context.Background())
+	if err != nil {
+		t.Fatalf("connectTrustedHelper returned error: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	_, err = manager.inspectConnectedHelper(context.Background(), client)
+	if !errors.Is(err, ErrHelperMismatch) {
+		t.Fatalf("inspectConnectedHelper error = %v, want helper mismatch", err)
+	}
+}
+
+func TestManagerStopTrustedHelperStopsMatchingSocket(t *testing.T) {
+	t.Parallel()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	path, stop := startFakeHelperDaemon(t, helperidentity.ForExecutable(executable, os.Getpid()))
+	defer stop()
+	manager := Manager{
+		socketPath:     path,
+		DaemonPath:     executable,
+		StartupTimeout: time.Second,
+	}
+
+	if err := manager.stopTrustedHelper(context.Background()); err != nil {
+		t.Fatalf("stopTrustedHelper returned error: %v", err)
+	}
+	if _, err := manager.Status(context.Background()); !errors.Is(err, socket.ErrDaemonUnavailable) {
+		t.Fatalf("Status after stop error = %v, want daemon unavailable", err)
+	}
+}
+
+func TestManagerStopTrustedHelperIgnoresMissingSocket(t *testing.T) {
+	t.Parallel()
+
+	manager := Manager{
+		socketPath: filepath.Join(t.TempDir(), "missing.sock"),
+		DaemonPath: writeDaemonExecutableAt(t, t.TempDir()),
+	}
+
+	if err := manager.stopTrustedHelper(context.Background()); err != nil {
+		t.Fatalf("stopTrustedHelper returned error: %v", err)
+	}
+}
+
+func TestManagerTrustedHelperUnavailableStates(t *testing.T) {
+	t.Parallel()
+
+	manager := Manager{
+		socketPath: filepath.Join(t.TempDir(), "missing.sock"),
+		DaemonPath: writeDaemonExecutableAt(t, t.TempDir()),
+	}
+	unavailable, err := manager.trustedHelperUnavailable(context.Background())
+	if err != nil {
+		t.Fatalf("trustedHelperUnavailable missing socket returned error: %v", err)
+	}
+	if !unavailable {
+		t.Fatal("trustedHelperUnavailable missing socket = false, want true")
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	path, stop := startFakeStatusErrorDaemon(t, protocol.ErrorCodeDaemonStopped)
+	defer stop()
+	manager = Manager{
+		socketPath: path,
+		DaemonPath: executable,
+	}
+	unavailable, err = manager.trustedHelperUnavailable(context.Background())
+	if err != nil {
+		t.Fatalf("trustedHelperUnavailable retiring helper returned error: %v", err)
+	}
+	if unavailable {
+		t.Fatal("trustedHelperUnavailable retiring helper = true, want false")
+	}
+}
+
+func TestManagerHelperMatchesExpectedBuild(t *testing.T) {
+	t.Parallel()
+
+	manager := Manager{DaemonPath: writeDaemonExecutableAt(t, t.TempDir())}
+	expected, err := manager.expectedHelperHello()
+	if err != nil {
+		t.Fatalf("expectedHelperHello returned error: %v", err)
+	}
+
+	matches, err := manager.helperMatchesExpected(expected)
+	if err != nil {
+		t.Fatalf("helperMatchesExpected returned error: %v", err)
+	}
+	if !matches {
+		t.Fatal("helperMatchesExpected returned false for expected helper hello")
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*protocol.HelperHelloPayload)
+	}{
+		{
+			name: "protocol",
+			mutate: func(hello *protocol.HelperHelloPayload) {
+				hello.Protocol++
+			},
+		},
+		{
+			name: "app version",
+			mutate: func(hello *protocol.HelperHelloPayload) {
+				hello.AppVersion = "0.0.0-test"
+			},
+		},
+		{
+			name: "build id",
+			mutate: func(hello *protocol.HelperHelloPayload) {
+				hello.BuildID += "-old"
+			},
+		},
+		{
+			name: "executable",
+			mutate: func(hello *protocol.HelperHelloPayload) {
+				hello.Executable = writeDaemonExecutableAt(t, t.TempDir())
+			},
+		},
+	} {
+		hello := expected
+		tc.mutate(&hello)
+		matches, err := manager.helperMatchesExpected(hello)
+		if err != nil {
+			t.Fatalf("%s: helperMatchesExpected returned error: %v", tc.name, err)
+		}
+		if matches {
+			t.Fatalf("%s: helperMatchesExpected returned true for mismatched hello %+v", tc.name, hello)
+		}
+	}
+}
+
+func TestManagerExpectedHelperHelloRequiresDaemonPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := (Manager{DaemonPath: " \t "}).expectedHelperHello()
+	if err == nil || !strings.Contains(err.Error(), "daemon path is required") {
+		t.Fatalf("expectedHelperHello error = %v, want daemon path required", err)
+	}
+}
+
+func TestClassifyHelperConnectErrorHidesPeerTrustBehindUnexpectedHelper(t *testing.T) {
+	t.Parallel()
+
+	err := classifyHelperConnectError(fmt.Errorf("dial helper: %w", peertrust.ErrUntrustedDaemon))
+	if !errors.Is(err, ErrUnexpectedHelper) {
+		t.Fatalf("classifyHelperConnectError = %v, want unexpected helper", err)
+	}
+	if !errors.Is(err, peertrust.ErrUntrustedDaemon) {
+		t.Fatalf("classifyHelperConnectError = %v, want original peer trust cause", err)
+	}
+	plainErr := errors.New("plain failure")
+	if !errors.Is(classifyHelperConnectError(plainErr), plainErr) {
+		t.Fatal("classifyHelperConnectError wrapped a non-peer-trust error")
+	}
+}
+
+func TestHelperHelloMismatchError(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{
+		protocol.ErrProtocolType,
+		protocol.ErrProtocolVersion,
+		&ProtocolError{Code: protocol.ErrorCodeBadType, Message: "bad type"},
+	} {
+		if !helperHelloMismatchError(err) {
+			t.Fatalf("helperHelloMismatchError(%v) = false, want true", err)
+		}
+	}
+	if helperHelloMismatchError(errors.New("plain failure")) {
+		t.Fatal("plain error was classified as helper hello mismatch")
+	}
+}
+
 func TestManagerStatusUnavailableTreatsRetiringDaemonAsStillRunning(t *testing.T) {
 	t.Parallel()
 
@@ -655,6 +944,94 @@ func startFakeStatusErrorDaemon(t *testing.T, code protocol.ErrorCode) (string, 
 		<-done
 		_ = os.RemoveAll(dir)
 	}
+}
+
+func startFakeHelperDaemon(t *testing.T, hello protocol.HelperHelloPayload) (string, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "agent-secret-fake-helper-")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	path := filepath.Join(dir, "d.sock")
+	listener, err := socket.ListenUnix(path)
+	unixsocket.SkipIfBindUnavailable(t, err)
+	if err != nil {
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+	done := make(chan struct{})
+	var closeOnce sync.Once
+	shutdown := func() {
+		closeOnce.Do(func() {
+			_ = listener.Close()
+			_ = os.Remove(path)
+		})
+	}
+	go func() {
+		defer close(done)
+		for {
+			conn, err := listener.AcceptUnix()
+			if err != nil {
+				return
+			}
+			go serveFakeHelperDaemonConn(conn, hello, shutdown)
+		}
+	}()
+	return path, func() {
+		shutdown()
+		<-done
+		_ = os.RemoveAll(dir)
+	}
+}
+
+func serveFakeHelperDaemonConn(
+	conn *net.UnixConn,
+	hello protocol.HelperHelloPayload,
+	shutdown func(),
+) {
+	defer func() { _ = conn.Close() }()
+	decoder := json.NewDecoder(conn)
+	encoder := json.NewEncoder(conn)
+	for {
+		var env protocol.Envelope
+		if err := decoder.Decode(&env); err != nil {
+			return
+		}
+		switch env.Type { //nolint:exhaustive // Fake helper handles only manager repair requests.
+		case protocol.TypeHelperHello:
+			if !writeFakeHelperResponse(encoder, env.Correlation(), hello) {
+				return
+			}
+		case protocol.TypeDaemonStatus:
+			if !writeFakeHelperResponse(encoder, env.Correlation(), protocol.StatusPayload{PID: hello.PID}) {
+				return
+			}
+		case protocol.TypeDaemonStop:
+			if !writeFakeHelperResponse(encoder, env.Correlation(), protocol.StatusPayload{PID: hello.PID}) {
+				return
+			}
+			shutdown()
+			return
+		default:
+			resp, err := protocol.NewEnvelope(protocol.TypeError, env.Correlation(), protocol.ErrorPayload{
+				Code:    protocol.ErrorCodeBadType,
+				Message: "unsupported fake helper request",
+			})
+			if err != nil {
+				return
+			}
+			if err := encoder.Encode(resp); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func writeFakeHelperResponse(encoder *json.Encoder, correlation protocol.Correlation, payload any) bool {
+	resp, err := protocol.NewEnvelope(protocol.TypeOK, correlation, payload)
+	if err != nil {
+		return false
+	}
+	return encoder.Encode(resp) == nil
 }
 
 func serveFakeStatusError(conn *net.UnixConn, code protocol.ErrorCode) {

--- a/internal/daemon/control/manager_test.go
+++ b/internal/daemon/control/manager_test.go
@@ -422,6 +422,187 @@ func TestManagerRepairRefreshesMismatchedTrustedHelper(t *testing.T) {
 	}
 }
 
+func TestManagerRepairSignalsTrustedHelperWhenStopRejectsClient(t *testing.T) {
+	if os.Getenv("AGENT_SECRET_DAEMON_MANAGER_REPAIR_SIGNAL_HELPER") == "1" {
+		runDaemonManagerHelper(t)
+		return
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	staleHello := helperidentity.ForExecutable(executable, os.Getpid())
+	staleHello.BuildID += "-stale"
+	path, stopStale := startFakeHelperDaemonWithOptions(t, fakeHelperOptions{
+		hello:         staleHello,
+		stopErrorCode: protocol.ErrorCodeUntrustedClient,
+	})
+	defer stopStale()
+
+	output, err := os.Create(filepath.Join(t.TempDir(), "repair-helper.log"))
+	if err != nil {
+		t.Fatalf("create helper output log: %v", err)
+	}
+	defer func() { _ = output.Close() }()
+	signalCalls := 0
+	manager := Manager{
+		socketPath:     path,
+		DaemonPath:     executable,
+		DaemonArgs:     []string{"-test.run=TestManagerRepairSignalsTrustedHelperWhenStopRejectsClient", "--", "--socket", "{socket}"},
+		StartupTimeout: 2 * time.Second,
+		daemonStdout:   output,
+		daemonStderr:   output,
+		signalProcess: func(pid int, sig os.Signal) error {
+			signalCalls++
+			if pid != os.Getpid() {
+				t.Fatalf("signal pid = %d, want current fake helper process pid %d", pid, os.Getpid())
+			}
+			if sig != syscall.SIGTERM {
+				t.Fatalf("signal = %v, want SIGTERM", sig)
+			}
+			stopStale()
+			return nil
+		},
+	}
+	t.Setenv("AGENT_SECRET_DAEMON_MANAGER_REPAIR_SIGNAL_HELPER", "1")
+
+	result, err := manager.Repair(context.Background())
+	if err != nil {
+		helperOutput := readManagerHelperOutput(t, output.Name())
+		if strings.Contains(helperOutput, managerHelperBindUnavailablePrefix) {
+			t.Skipf("Unix socket bind unavailable in daemon repair helper: %s", helperOutput)
+		}
+		t.Fatalf("Repair returned error: %v\nhelper output:\n%s", err, helperOutput)
+	}
+	defer func() { _ = manager.Stop(context.Background()) }()
+	if result.Status != RepairStatusRefreshed {
+		t.Fatalf("Repair status = %q, want refreshed", result.Status)
+	}
+	if signalCalls != 1 {
+		t.Fatalf("signal calls = %d, want 1", signalCalls)
+	}
+	if result.Hello.BuildID != helperidentity.ForExecutable(executable, os.Getpid()).BuildID {
+		t.Fatalf("Repair hello build id = %q, want current build id", result.Hello.BuildID)
+	}
+}
+
+func TestManagerRepairErrorClassifiers(t *testing.T) {
+	t.Parallel()
+
+	if peerProcessGoneError(nil) {
+		t.Fatal("peerProcessGoneError(nil) = true, want false")
+	}
+	if !peerProcessGoneError(fmt.Errorf("inspect peer: %w", syscall.ESRCH)) {
+		t.Fatal("peerProcessGoneError did not detect wrapped ESRCH")
+	}
+	if !peerProcessGoneError(errors.New("inspect daemon peer: proc_pidpath: no such process")) {
+		t.Fatal("peerProcessGoneError did not detect proc_pidpath text")
+	}
+	if !helperUnavailableError(fmt.Errorf("%w: dial failed", socket.ErrDaemonUnavailable)) {
+		t.Fatal("helperUnavailableError did not detect socket unavailable")
+	}
+	peerGoneUnavailable := fmt.Errorf(
+		"%w: untrusted daemon peer: inspect daemon peer: proc_pidpath: no such process",
+		socket.ErrDaemonUnavailable,
+	)
+	if !helperUnavailableError(peerGoneUnavailable) {
+		t.Fatal("helperUnavailableError did not detect peer-gone unavailable error")
+	}
+	peerGoneUnexpected := errors.New("unexpected helper: proc_pidpath: no such process")
+	if helperUnavailableError(peerGoneUnexpected) {
+		t.Fatal("helperUnavailableError accepted peer-gone error without daemon unavailable")
+	}
+	classified := classifyHelperConnectError(errors.New("inspect daemon peer: proc_pidpath: no such process"))
+	if !helperUnavailableError(classified) {
+		t.Fatalf("classifyHelperConnectError = %v, want helper unavailable", classified)
+	}
+	unexpected := classifyHelperConnectError(peertrust.ErrUntrustedDaemon)
+	if !errors.Is(unexpected, ErrUnexpectedHelper) {
+		t.Fatalf("classifyHelperConnectError = %v, want ErrUnexpectedHelper", unexpected)
+	}
+}
+
+func TestManagerTrustedHelperVanishedAfterTrustErrorRequiresUnavailableSocket(t *testing.T) {
+	t.Parallel()
+
+	manager := Manager{socketPath: filepath.Join(t.TempDir(), "missing.sock")}
+	err := fmt.Errorf("%w: %w", ErrUnexpectedHelper, socket.ErrDaemonUnavailable)
+	if !manager.trustedHelperVanishedAfterTrustError(context.Background(), err) {
+		t.Fatal("trustedHelperVanishedAfterTrustError = false, want true for missing socket")
+	}
+	if manager.trustedHelperVanishedAfterTrustError(context.Background(), errors.New("plain error")) {
+		t.Fatal("trustedHelperVanishedAfterTrustError = true for plain error")
+	}
+}
+
+func TestManagerRawSocketUnavailableReportsListeningSocket(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("/tmp", "agent-secret-raw-socket-")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	path := filepath.Join(dir, "daemon.sock")
+	addr := net.UnixAddr{Name: path, Net: "unix"}
+	listener, err := net.ListenUnix("unix", &addr)
+	unixsocket.SkipIfBindUnavailable(t, err)
+	if err != nil {
+		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	manager := Manager{socketPath: path}
+	unavailable, err := manager.rawSocketUnavailable(context.Background())
+	if err != nil {
+		t.Fatalf("rawSocketUnavailable returned error: %v", err)
+	}
+	if unavailable {
+		t.Fatal("rawSocketUnavailable = true for listening socket")
+	}
+}
+
+func TestSignalProcessReportsCurrentProcessSignalZero(t *testing.T) {
+	t.Parallel()
+
+	if err := signalProcess(os.Getpid(), syscall.Signal(0)); err != nil {
+		t.Fatalf("signalProcess current process signal 0 returned error: %v", err)
+	}
+}
+
+func TestManagerSignalTrustedHelperMissingSocketIsNoop(t *testing.T) {
+	t.Parallel()
+
+	manager := Manager{socketPath: filepath.Join(t.TempDir(), "missing.sock")}
+	if err := manager.signalTrustedHelper(context.Background()); err != nil {
+		t.Fatalf("signalTrustedHelper returned error: %v", err)
+	}
+}
+
+func TestManagerStartCurrentWithStatusRetryReturnsNonRetryableError(t *testing.T) {
+	t.Parallel()
+
+	manager := Manager{socketPath: filepath.Join(t.TempDir(), "missing.sock")}
+	_, err := manager.startCurrentWithStatusRetry(context.Background(), RepairStatusOK)
+	if err == nil || !strings.Contains(err.Error(), "daemon path is required") {
+		t.Fatalf("startCurrentWithStatusRetry error = %v, want daemon path required", err)
+	}
+}
+
+func TestManagerWriterUsesConfiguredWriterWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	fallback := io.Discard
+	configured := strings.Builder{}
+	if got := managerWriter(fallback, &configured); got != &configured {
+		t.Fatal("managerWriter did not return configured writer")
+	}
+	if got := managerWriter(fallback, nil); got != fallback {
+		t.Fatal("managerWriter did not return fallback writer")
+	}
+}
+
 func TestManagerRepairRejectsUnexpectedHelper(t *testing.T) {
 	t.Parallel()
 
@@ -948,6 +1129,16 @@ func startFakeStatusErrorDaemon(t *testing.T, code protocol.ErrorCode) (string, 
 
 func startFakeHelperDaemon(t *testing.T, hello protocol.HelperHelloPayload) (string, func()) {
 	t.Helper()
+	return startFakeHelperDaemonWithOptions(t, fakeHelperOptions{hello: hello})
+}
+
+type fakeHelperOptions struct {
+	hello         protocol.HelperHelloPayload
+	stopErrorCode protocol.ErrorCode
+}
+
+func startFakeHelperDaemonWithOptions(t *testing.T, opts fakeHelperOptions) (string, func()) {
+	t.Helper()
 	dir, err := os.MkdirTemp("/tmp", "agent-secret-fake-helper-")
 	if err != nil {
 		t.Fatalf("MkdirTemp returned error: %v", err)
@@ -973,7 +1164,7 @@ func startFakeHelperDaemon(t *testing.T, hello protocol.HelperHelloPayload) (str
 			if err != nil {
 				return
 			}
-			go serveFakeHelperDaemonConn(conn, hello, shutdown)
+			go serveFakeHelperDaemonConn(conn, opts, shutdown)
 		}
 	}()
 	return path, func() {
@@ -985,7 +1176,7 @@ func startFakeHelperDaemon(t *testing.T, hello protocol.HelperHelloPayload) (str
 
 func serveFakeHelperDaemonConn(
 	conn *net.UnixConn,
-	hello protocol.HelperHelloPayload,
+	opts fakeHelperOptions,
 	shutdown func(),
 ) {
 	defer func() { _ = conn.Close() }()
@@ -998,15 +1189,21 @@ func serveFakeHelperDaemonConn(
 		}
 		switch env.Type { //nolint:exhaustive // Fake helper handles only manager repair requests.
 		case protocol.TypeHelperHello:
-			if !writeFakeHelperResponse(encoder, env.Correlation(), hello) {
+			if !writeFakeHelperResponse(encoder, env.Correlation(), opts.hello) {
 				return
 			}
 		case protocol.TypeDaemonStatus:
-			if !writeFakeHelperResponse(encoder, env.Correlation(), protocol.StatusPayload{PID: hello.PID}) {
+			if !writeFakeHelperResponse(encoder, env.Correlation(), protocol.StatusPayload{PID: opts.hello.PID}) {
 				return
 			}
 		case protocol.TypeDaemonStop:
-			if !writeFakeHelperResponse(encoder, env.Correlation(), protocol.StatusPayload{PID: hello.PID}) {
+			if opts.stopErrorCode != "" {
+				if !writeFakeHelperError(encoder, env.Correlation(), opts.stopErrorCode) {
+					return
+				}
+				return
+			}
+			if !writeFakeHelperResponse(encoder, env.Correlation(), protocol.StatusPayload{PID: opts.hello.PID}) {
 				return
 			}
 			shutdown()
@@ -1024,6 +1221,17 @@ func serveFakeHelperDaemonConn(
 			}
 		}
 	}
+}
+
+func writeFakeHelperError(encoder *json.Encoder, correlation protocol.Correlation, code protocol.ErrorCode) bool {
+	resp, err := protocol.NewEnvelope(protocol.TypeError, correlation, protocol.ErrorPayload{
+		Code:    code,
+		Message: "fake helper rejected request",
+	})
+	if err != nil {
+		return false
+	}
+	return encoder.Encode(resp) == nil
 }
 
 func writeFakeHelperResponse(encoder *json.Encoder, correlation protocol.Correlation, payload any) bool {

--- a/internal/daemon/peertrust/daemon.go
+++ b/internal/daemon/peertrust/daemon.go
@@ -5,13 +5,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/kovyrin/agent-secret/internal/daemon/trust"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 )
 
 var ErrUntrustedDaemon = errors.New("untrusted daemon peer")
+
+const DefaultDaemonBundleID = "com.kovyrin.agent-secret.daemon"
 
 type DaemonPeerValidator interface {
 	ValidateDaemonPeer(info peercred.Info) error
@@ -21,6 +25,13 @@ type DaemonValidator struct {
 	set executableSet
 }
 
+type DaemonProductValidator struct {
+	current         DaemonValidator
+	expectedTeamID  string
+	verifier        trust.CodeSignatureVerifier
+	verifySignature bool
+}
+
 func NewDaemonValidator(paths []string) DaemonValidator {
 	return newDaemonValidator(paths, trust.DefaultExpectedTeamID())
 }
@@ -28,6 +39,29 @@ func NewDaemonValidator(paths []string) DaemonValidator {
 func newDaemonValidator(paths []string, expectedTeamID string) DaemonValidator {
 	return DaemonValidator{
 		set: newExecutableSet(paths, expectedTeamID, ErrUntrustedDaemon),
+	}
+}
+
+func NewDaemonProductValidator(paths []string) DaemonProductValidator {
+	return newDaemonProductValidatorWithVerifier(
+		paths,
+		trust.DefaultExpectedTeamID(),
+		trust.CodesignSignatureVerifier{},
+		runtime.GOOS == "darwin",
+	)
+}
+
+func newDaemonProductValidatorWithVerifier(
+	paths []string,
+	expectedTeamID string,
+	verifier trust.CodeSignatureVerifier,
+	verifySignature bool,
+) DaemonProductValidator {
+	return DaemonProductValidator{
+		current:         newDaemonValidator(paths, expectedTeamID),
+		expectedTeamID:  strings.TrimSpace(expectedTeamID),
+		verifier:        verifier,
+		verifySignature: verifySignature,
 	}
 }
 
@@ -63,4 +97,45 @@ func (v DaemonValidator) ValidateDaemonPeer(info peercred.Info) error {
 		return fmt.Errorf("%w: daemon gid %d != %d", ErrUntrustedDaemon, info.GID, os.Getgid())
 	}
 	return v.set.validatePeer(info)
+}
+
+func (v DaemonProductValidator) ValidateDaemonPeer(info peercred.Info) error {
+	if err := v.current.ValidateDaemonPeer(info); err == nil {
+		return nil
+	}
+	if info.UID != os.Getuid() {
+		return fmt.Errorf("%w: daemon uid %d != %d", ErrUntrustedDaemon, info.UID, os.Getuid())
+	}
+	if info.GID != os.Getgid() {
+		return fmt.Errorf("%w: daemon gid %d != %d", ErrUntrustedDaemon, info.GID, os.Getgid())
+	}
+	if !v.verifySignature {
+		return fmt.Errorf("%w: executable %q is not a current trusted helper", ErrUntrustedDaemon, info.ExecutablePath)
+	}
+	requiredTeamID, enforceTeamID, err := trust.ExpectedTeamIDForSignatureValidation(v.expectedTeamID, ErrUntrustedDaemon)
+	if err != nil {
+		return err
+	}
+	if !enforceTeamID {
+		return fmt.Errorf("%w: broad helper repair trust requires a release Team ID", ErrUntrustedDaemon)
+	}
+	executable, err := pathresolve.Strict(info.ExecutablePath)
+	if err != nil {
+		return fmt.Errorf("%w: normalize daemon executable %q: %w", ErrUntrustedDaemon, info.ExecutablePath, err)
+	}
+	bundlePath, ok := containingAppBundlePath(executable)
+	if !ok || filepath.Base(bundlePath) != "AgentSecretDaemon.app" {
+		return fmt.Errorf("%w: executable %q is not an Agent Secret daemon helper app", ErrUntrustedDaemon, executable)
+	}
+	bundleID, err := trust.PlistString(filepath.Join(bundlePath, "Contents", "Info.plist"), "CFBundleIdentifier", ErrUntrustedDaemon)
+	if err != nil {
+		return err
+	}
+	if bundleID != DefaultDaemonBundleID {
+		return fmt.Errorf("%w: daemon bundle id %q != %q", ErrUntrustedDaemon, bundleID, DefaultDaemonBundleID)
+	}
+	if err := trust.ValidatePeerSignature(info, bundlePath, requiredTeamID, v.verifier, ErrUntrustedDaemon); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/daemon/peertrust/daemon_test.go
+++ b/internal/daemon/peertrust/daemon_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/kovyrin/agent-secret/internal/daemon/approval"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/testsupport/appbundle"
 )
@@ -102,6 +103,53 @@ func TestDaemonValidatorAllowsTrustedExecutable(t *testing.T) {
 	}
 }
 
+func TestDaemonProductValidatorAllowsSignedAgentSecretHelperBundle(t *testing.T) {
+	t.Parallel()
+
+	current := writeExecutableAt(t, t.TempDir(), "agent-secretd")
+	helper := writeDaemonProductBundle(t, DefaultDaemonBundleID)
+	bundlePath := filepath.Clean(filepath.Join(filepath.Dir(helper), "..", ".."))
+	verifier := &recordingSignatureVerifier{
+		pathTeamID:    "TEAMID",
+		processTeamID: "TEAMID",
+	}
+	validator := newDaemonProductValidatorWithVerifier([]string{current}, "TEAMID", verifier, true)
+	info := trustedDaemonPeerInfo(helper)
+	info.PID = 4321
+
+	if err := validator.ValidateDaemonPeer(info); err != nil {
+		t.Fatalf("ValidateDaemonPeer returned error: %v", err)
+	}
+	if len(verifier.paths) != 1 || verifier.paths[0] != pathresolve.BestEffort(bundlePath) {
+		t.Fatalf("verified paths = %v, want [%s]", verifier.paths, bundlePath)
+	}
+	if len(verifier.pids) != 1 || verifier.pids[0] != 4321 {
+		t.Fatalf("verified pids = %v, want [4321]", verifier.pids)
+	}
+}
+
+func TestDaemonProductValidatorRejectsWrongHelperBundleID(t *testing.T) {
+	t.Parallel()
+
+	current := writeExecutableAt(t, t.TempDir(), "agent-secretd")
+	helper := writeDaemonProductBundle(t, "com.example.not-agent-secret")
+	verifier := &recordingSignatureVerifier{
+		pathTeamID:    "TEAMID",
+		processTeamID: "TEAMID",
+	}
+	validator := newDaemonProductValidatorWithVerifier([]string{current}, "TEAMID", verifier, true)
+	err := validator.ValidateDaemonPeer(trustedDaemonPeerInfo(helper))
+	if !errors.Is(err, ErrUntrustedDaemon) {
+		t.Fatalf("ValidateDaemonPeer error = %v, want %v", err, ErrUntrustedDaemon)
+	}
+	if !strings.Contains(err.Error(), "bundle id") {
+		t.Fatalf("ValidateDaemonPeer error = %q, want bundle id context", err.Error())
+	}
+	if len(verifier.paths) != 0 || len(verifier.pids) != 0 {
+		t.Fatalf("signature verifier called for wrong bundle id: paths=%v pids=%v", verifier.paths, verifier.pids)
+	}
+}
+
 func TestDaemonValidatorRejectsDifferentUID(t *testing.T) {
 	t.Parallel()
 
@@ -143,4 +191,26 @@ func trustedDaemonPeerInfo(executable string) peercred.Info {
 		PID:            os.Getpid(),
 		ExecutablePath: executable,
 	}
+}
+
+func writeDaemonProductBundle(t *testing.T, bundleID string) string {
+	t.Helper()
+
+	bundlePath := filepath.Join(t.TempDir(), "AgentSecretDaemon.app")
+	macOSPath := filepath.Join(bundlePath, "Contents", "MacOS")
+	if err := os.MkdirAll(macOSPath, 0o750); err != nil {
+		t.Fatalf("mkdir daemon bundle: %v", err)
+	}
+	executable := filepath.Join(macOSPath, "Agent Secret")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: peer trust tests need executable fixtures.
+		t.Fatalf("write daemon executable: %v", err)
+	}
+	plist := `<plist><dict>
+<key>CFBundleExecutable</key><string>Agent Secret</string>
+<key>CFBundleIdentifier</key><string>` + bundleID + `</string>
+</dict></plist>`
+	if err := os.WriteFile(filepath.Join(bundlePath, "Contents", "Info.plist"), []byte(plist), 0o600); err != nil {
+		t.Fatalf("write daemon Info.plist: %v", err)
+	}
+	return executable
 }

--- a/internal/daemon/protocol/protocol.go
+++ b/internal/daemon/protocol/protocol.go
@@ -18,6 +18,7 @@ const DefaultMaxProtocolFrameBytes int64 = 1 << 20
 type MessageType string
 
 const (
+	TypeHelperHello       MessageType = "helper.hello"
 	TypeDaemonStatus      MessageType = "daemon.status"
 	TypeDaemonStop        MessageType = "daemon.stop"
 	TypeOnePasswordStatus MessageType = "onepassword.status"
@@ -152,6 +153,16 @@ type CommandCompletedPayload struct {
 
 type StatusPayload struct {
 	PID int `json:"pid"`
+}
+
+type HelperHelloPayload struct {
+	Protocol   int    `json:"protocol"`
+	AppVersion string `json:"app_version"`
+	BuildID    string `json:"build_id,omitempty"`
+	PID        int    `json:"pid"`
+	Executable string `json:"executable"`
+	TeamID     string `json:"team_id,omitempty"`
+	BundleID   string `json:"bundle_id,omitempty"`
 }
 
 type OnePasswordStatusPayload struct {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/peertrust"
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 	"github.com/kovyrin/agent-secret/internal/daemon/socket"
+	"github.com/kovyrin/agent-secret/internal/helperidentity"
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
 )
@@ -372,6 +373,9 @@ func (s *Server) dispatchClientEnvelope(
 ) connectionDispatchAction {
 	//nolint:exhaustive // Response envelopes are invalid client requests; default rejects them with unknown request types.
 	switch env.Type {
+	case protocol.TypeHelperHello:
+		s.handleHelperHello(encoder, env)
+		return connectionDispatchAction{accepted: true}
 	case protocol.TypeDaemonStatus:
 		s.handleDaemonStatus(encoder, env)
 		return connectionDispatchAction{accepted: true}
@@ -627,6 +631,10 @@ func (s *Server) handleSessionList(
 
 func (s *Server) handleDaemonStatus(encoder *json.Encoder, env protocol.Envelope) {
 	_ = writeOK(encoder, env.Correlation(), protocol.StatusPayload{PID: os.Getpid()})
+}
+
+func (s *Server) handleHelperHello(encoder *json.Encoder, env protocol.Envelope) {
+	_ = writeOK(encoder, env.Correlation(), helperidentity.Current())
 }
 
 func (s *Server) handleOnePasswordStatus(

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -80,6 +80,28 @@ func TestNewServerRequiresClientValidator(t *testing.T) {
 	}
 }
 
+func TestServerHelperHello(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := startSocketPairTestServer(t, daemonbroker.Options{
+		Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver: &mockResolver{},
+		Audit:    &memoryAudit{},
+	})
+	defer cleanup()
+
+	hello, err := client.Hello(context.Background())
+	if err != nil {
+		t.Fatalf("Hello returned error: %v", err)
+	}
+	if hello.Protocol != protocol.ProtocolVersion ||
+		hello.AppVersion == "" ||
+		hello.PID <= 0 ||
+		hello.Executable == "" {
+		t.Fatalf("hello payload = %+v", hello)
+	}
+}
+
 func TestServerExecProtocolLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/helperidentity/helperidentity.go
+++ b/internal/helperidentity/helperidentity.go
@@ -1,0 +1,59 @@
+package helperidentity
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/kovyrin/agent-secret/internal/buildinfo"
+	"github.com/kovyrin/agent-secret/internal/daemon/peertrust"
+	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
+	"github.com/kovyrin/agent-secret/internal/daemon/trust"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
+)
+
+func Current() protocol.HelperHelloPayload {
+	executable, _ := os.Executable()
+	return ForExecutable(executable, os.Getpid())
+}
+
+func ForExecutable(executable string, pid int) protocol.HelperHelloPayload {
+	executable = pathresolve.BestEffort(executable)
+	return protocol.HelperHelloPayload{
+		Protocol:   protocol.ProtocolVersion,
+		AppVersion: buildinfo.Version,
+		BuildID:    buildinfo.Revision,
+		PID:        pid,
+		Executable: executable,
+		TeamID:     trust.DefaultExpectedTeamID(),
+		BundleID:   BundleIDForExecutable(executable),
+	}
+}
+
+func BundleIDForExecutable(executable string) string {
+	bundlePath, ok := containingAppBundlePath(executable)
+	if !ok {
+		return ""
+	}
+	bundleID, err := trust.PlistString(
+		filepath.Join(bundlePath, "Contents", "Info.plist"),
+		"CFBundleIdentifier",
+		peertrust.ErrUntrustedDaemon,
+	)
+	if err != nil {
+		return ""
+	}
+	return bundleID
+}
+
+func containingAppBundlePath(path string) (string, bool) {
+	path = pathresolve.BestEffort(path)
+	for current := filepath.Dir(path); ; current = filepath.Dir(current) {
+		if filepath.Ext(current) == ".app" {
+			return filepath.Clean(current), true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", false
+		}
+	}
+}

--- a/internal/helperidentity/helperidentity_test.go
+++ b/internal/helperidentity/helperidentity_test.go
@@ -1,0 +1,77 @@
+package helperidentity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovyrin/agent-secret/internal/buildinfo"
+	"github.com/kovyrin/agent-secret/internal/daemon/peertrust"
+	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
+	"github.com/kovyrin/agent-secret/internal/pathresolve"
+)
+
+func TestForExecutableReturnsCurrentBuildMetadata(t *testing.T) {
+	t.Parallel()
+
+	executable := filepath.Join(t.TempDir(), "agent-secretd")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: helper identity test needs an executable fixture.
+		t.Fatalf("write executable: %v", err)
+	}
+
+	hello := ForExecutable(executable, 1234)
+	if hello.Protocol != protocol.ProtocolVersion ||
+		hello.AppVersion != buildinfo.Version ||
+		hello.BuildID != buildinfo.Revision ||
+		hello.PID != 1234 ||
+		hello.Executable != pathresolve.BestEffort(executable) {
+		t.Fatalf("hello = %+v", hello)
+	}
+	if hello.BundleID != "" {
+		t.Fatalf("direct executable bundle id = %q, want empty", hello.BundleID)
+	}
+}
+
+func TestBundleIDForExecutableReadsContainingAppBundle(t *testing.T) {
+	t.Parallel()
+
+	executable := writeHelperIdentityBundle(t, peertrust.DefaultDaemonBundleID)
+	if got := BundleIDForExecutable(executable); got != peertrust.DefaultDaemonBundleID {
+		t.Fatalf("BundleIDForExecutable = %q, want %q", got, peertrust.DefaultDaemonBundleID)
+	}
+	if got := ForExecutable(executable, 5678).BundleID; got != peertrust.DefaultDaemonBundleID {
+		t.Fatalf("ForExecutable bundle id = %q, want %q", got, peertrust.DefaultDaemonBundleID)
+	}
+}
+
+func TestBundleIDForExecutableIgnoresMalformedBundles(t *testing.T) {
+	t.Parallel()
+
+	executable := writeHelperIdentityBundle(t, "")
+	if got := BundleIDForExecutable(executable); got != "" {
+		t.Fatalf("BundleIDForExecutable malformed bundle = %q, want empty", got)
+	}
+}
+
+func writeHelperIdentityBundle(t *testing.T, bundleID string) string {
+	t.Helper()
+
+	bundlePath := filepath.Join(t.TempDir(), "AgentSecretDaemon.app")
+	macOSPath := filepath.Join(bundlePath, "Contents", "MacOS")
+	if err := os.MkdirAll(macOSPath, 0o750); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	executable := filepath.Join(macOSPath, "Agent Secret")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // G306: helper identity test needs an executable fixture.
+		t.Fatalf("write executable: %v", err)
+	}
+	plist := `<plist><dict><key>CFBundleExecutable</key><string>Agent Secret</string>`
+	if bundleID != "" {
+		plist += `<key>CFBundleIdentifier</key><string>` + bundleID + `</string>`
+	}
+	plist += `</dict></plist>`
+	if err := os.WriteFile(filepath.Join(bundlePath, "Contents", "Info.plist"), []byte(plist), 0o600); err != nil {
+		t.Fatalf("write Info.plist: %v", err)
+	}
+	return executable
+}

--- a/site/docs.html
+++ b/site/docs.html
@@ -48,7 +48,7 @@
           Secrets Manager, keep references in project profiles, and validate
           requests without printing secret values.
         </p>
-        <p class="legal-date">Last updated: June 8, 2026</p>
+        <p class="legal-date">Last updated: June 9, 2026</p>
       </section>
 
       <div class="docs-layout">
@@ -82,9 +82,11 @@ agent-secret doctor</code></pre>
             </div>
             <p>
               Run <code>agent-secret doctor</code> after install or upgrade. It
-              starts the daemon if needed and checks the socket directory, audit
-              log, native approver, and 1Password desktop integration without
-              resolving any item references.
+              prepares the background helper if needed and checks the socket
+              directory, audit log, native approver, and 1Password desktop
+              integration without resolving any item references.
+              <code>agent-secret install-cli</code> also tries to refresh the
+              local background helper after repairing the command symlink.
             </p>
           </section>
 
@@ -209,8 +211,9 @@ profiles:
             <h2>Approve a bag once, then run bounded commands.</h2>
             <p>
               Sessions are for short workflows where an agent needs the same
-              approved set of references in different combinations. The daemon
-              stores values in memory and returns only an opaque session ID.
+              approved set of references in different combinations. Agent
+              Secret stores values in background helper memory and returns only
+              an opaque session ID.
             </p>
             <div class="code-panel">
               <pre><code>agent-secret session create --profile terraform-cloudflare --max-reads 3
@@ -229,7 +232,7 @@ agent-secret session destroy asess_123</code></pre>
             </p>
             <p>
               Sessions end when TTL passes, the read count is exhausted,
-              <code>session destroy</code> succeeds, or the daemon stops. V1
+              <code>session destroy</code> succeeds, or the helper stops. V1
               sessions do not expose raw socket reads or long-lived interactive
               shells.
             </p>
@@ -240,8 +243,9 @@ agent-secret session destroy asess_123</code></pre>
             <h2>Check requests without leaking values.</h2>
             <p>
               Use <code>--dry-run --json</code> to inspect exactly what an agent
-              is about to ask for. Dry runs do not start the daemon, prompt for
-              approval, resolve secret values, or spawn the child process.
+              is about to ask for. Dry runs do not start the background helper,
+              prompt for approval, resolve secret values, or spawn the child
+              process.
             </p>
             <div class="code-panel">
               <pre><code>agent-secret exec --dry-run --json --profile deploy -- terraform plan</code></pre>
@@ -282,11 +286,11 @@ agent-secret session destroy asess_123</code></pre>
                 </p>
               </details>
               <details>
-                <summary>Doctor reports an untrusted daemon peer.</summary>
+                <summary>Doctor reports an unexpected background helper.</summary>
                 <p>
-                  An old development daemon may still be listening on the socket.
-                  Stop it with the matching old CLI or restart the Mac, then run
-                  <code>/opt/homebrew/bin/agent-secret doctor</code> again.
+                  Run <code>agent-secret repair</code>. Agent Secret refreshes
+                  trusted old helpers automatically and refuses unexpected
+                  socket owners without sending secrets.
                 </p>
               </details>
               <details>
@@ -307,9 +311,9 @@ agent-secret session destroy asess_123</code></pre>
                 <summary>Does Agent Secret store raw secret values?</summary>
                 <p>
                   It does not write raw secret values to project files or audit
-                  logs. Reusable approvals may keep approved values in daemon
-                  memory until the TTL or use count expires, then they are
-                  cleared.
+                  logs. Reusable approvals may keep approved values in
+                  background helper memory until the TTL or use count expires,
+                  then they are cleared.
                 </p>
               </details>
               <details>

--- a/site/index.html
+++ b/site/index.html
@@ -359,7 +359,7 @@ profiles:
             <h3>What it protects</h3>
             <ul>
               <li>Configs and command flags carry references, not values.</li>
-              <li>The daemon fetches only the secrets you approved for the request.</li>
+              <li>The background helper fetches only the secrets you approved for the request.</li>
               <li>Audit logs record metadata, never raw secrets.</li>
               <li>Reusable approvals stay bounded by command, cwd, references, account, TTL, and use count.</li>
               <li>Sessions stay bounded by cwd, aliases, TTL, read count, and the <code>with-session</code> wrapper.</li>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -75,9 +75,9 @@
         <p>
           Agent Secret runs locally on your Mac. Configuration files contain
           secret references, not secret values. When you approve a request, the
-          daemon fetches the approved values from your configured provider and
-          passes them to the approved child process. The maintainer does not
-          receive those values.
+          background helper fetches the approved values from your configured
+          provider and passes them to the approved child process. The maintainer
+          does not receive those values.
         </p>
         <p>
           Agent Secret may write local audit metadata such as request time,


### PR DESCRIPTION
## Summary
- add a non-secret helper hello handshake and helper identity metadata so the CLI can distinguish current, stale, incompatible, and untrusted helpers
- add trusted background-helper repair/refresh, `agent-secret repair`, doctor/install convergence, and fail-closed unexpected-helper UX before secret-bearing requests
- update docs, site, bundled Agent Secret skill, PRD, changelog, and tests for the new helper repair flow

## Validation
- `mise run lint`
- `mise run test`
- `mise run build`
- `scripts/deploy-site.sh --check-only`
- `mise exec -- npx --no-install markdownlint README.md CHANGELOG.md docs/configuration.md docs/session-e2e-validation.md docs/prd.md .agents/skills/agent-secret/SKILL.md`
- `git diff --check`

Closes #299