### PR TITLE
Repair stale alternate helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
+## [0.0.20] - Pending
+
+### Fixed
+
+- Made `agent-secret repair` self-heal a stale Agent Secret background helper
+  from another install path instead of requiring manual process cleanup.
+
 ## [0.0.19] - 2026-06-09
 
 ### Added

--- a/internal/daemon/control/manager.go
+++ b/internal/daemon/control/manager.go
@@ -139,6 +139,15 @@ func (m Manager) repairOnce(ctx context.Context) (RepairResult, error) {
 	if errors.Is(err, ErrHelperMismatch) {
 		return m.refreshTrustedHelper(ctx)
 	}
+	if errors.Is(err, ErrUnexpectedHelper) {
+		if signalErr := m.signalRepairableHelper(ctx); signalErr != nil {
+			if errors.Is(signalErr, peertrust.ErrUntrustedDaemon) {
+				return RepairResult{Status: RepairStatusRepairRequired}, err
+			}
+			return RepairResult{Status: RepairStatusRepairRequired}, signalErr
+		}
+		return m.startCurrentWithStatusRetry(ctx, RepairStatusRefreshed)
+	}
 	if m.trustedHelperVanishedAfterTrustError(ctx, err) {
 		return m.startCurrentWithStatusRetry(ctx, RepairStatusRefreshed)
 	}
@@ -537,7 +546,23 @@ func (m Manager) stopTrustedHelper(ctx context.Context) error {
 }
 
 func (m Manager) signalTrustedHelper(ctx context.Context) error {
-	info, err := m.inspectTrustedHelperPeer(ctx)
+	return m.signalHelper(ctx, "trusted helper", m.inspectTrustedHelperPeer, m.waitUntilTrustedHelperUnavailable)
+}
+
+func (m Manager) signalRepairableHelper(ctx context.Context) error {
+	wait := func(ctx context.Context, interval time.Duration) error {
+		return m.waitUntilUnavailableWith(ctx, interval, "repairable helper", m.rawSocketUnavailable)
+	}
+	return m.signalHelper(ctx, "repairable helper", m.inspectRepairableHelperPeer, wait)
+}
+
+func (m Manager) signalHelper(
+	ctx context.Context,
+	label string,
+	inspect func(context.Context) (peercred.Info, error),
+	waitUntilUnavailable func(context.Context, time.Duration) error,
+) error {
+	info, err := inspect(ctx)
 	if errors.Is(err, socket.ErrDaemonUnavailable) {
 		return nil
 	}
@@ -548,16 +573,16 @@ func (m Manager) signalTrustedHelper(ctx context.Context) error {
 		return err
 	}
 	if info.PID <= 0 {
-		return fmt.Errorf("%w: trusted helper pid is unavailable", ErrUnexpectedHelper)
+		return fmt.Errorf("%w: %s pid is unavailable", ErrUnexpectedHelper, label)
 	}
 	signalFn := m.signalProcess
 	if signalFn == nil {
 		signalFn = signalProcess
 	}
 	if err := signalFn(info.PID, syscall.SIGTERM); err != nil {
-		return fmt.Errorf("signal trusted helper pid %d: %w", info.PID, err)
+		return fmt.Errorf("signal %s pid %d: %w", label, info.PID, err)
 	}
-	return m.waitUntilTrustedHelperUnavailable(ctx, 25*time.Millisecond)
+	return waitUntilUnavailable(ctx, 25*time.Millisecond)
 }
 
 func (m Manager) inspectTrustedHelperPeer(ctx context.Context) (peercred.Info, error) {
@@ -575,6 +600,22 @@ func (m Manager) inspectTrustedHelperPeer(ctx context.Context) (peercred.Info, e
 		return peercred.Info{}, fmt.Errorf("%w: inspect daemon peer: %w", peertrust.ErrUntrustedDaemon, err)
 	}
 	if err := peertrust.NewDaemonProductValidator(trustedPaths).ValidateDaemonPeer(info); err != nil {
+		return peercred.Info{}, err
+	}
+	return info, nil
+}
+
+func (m Manager) inspectRepairableHelperPeer(ctx context.Context) (peercred.Info, error) {
+	conn, err := socket.Dial(ctx, m.socketPath)
+	if err != nil {
+		return peercred.Info{}, err
+	}
+	defer func() { _ = conn.Close() }()
+	info, err := peercred.Inspect(conn)
+	if err != nil {
+		return peercred.Info{}, fmt.Errorf("%w: inspect daemon peer: %w", peertrust.ErrUntrustedDaemon, err)
+	}
+	if err := peertrust.NewDaemonRepairValidator().ValidateDaemonPeer(info); err != nil {
 		return peercred.Info{}, err
 	}
 	return info, nil

--- a/internal/daemon/control/manager_test.go
+++ b/internal/daemon/control/manager_test.go
@@ -261,6 +261,45 @@ func TestManagerControlMethodsReportMissingDaemon(t *testing.T) {
 	}
 }
 
+func TestManagerCheckOnePasswordUsesRunningHelper(t *testing.T) {
+	t.Parallel()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	path, stop := startFakeHelperDaemon(t, helperidentity.ForExecutable(executable, os.Getpid()))
+	defer stop()
+	manager := Manager{
+		socketPath: path,
+		DaemonPath: executable,
+	}
+
+	if err := manager.CheckOnePassword(context.Background(), "my.1password.ca"); err != nil {
+		t.Fatalf("CheckOnePassword returned error: %v", err)
+	}
+}
+
+func TestManagerStopReturnsDaemonStopError(t *testing.T) {
+	t.Parallel()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	path, stop := startFakeStatusErrorDaemon(t, protocol.ErrorCodeDaemonStopped)
+	defer stop()
+	manager := Manager{
+		socketPath: path,
+		DaemonPath: executable,
+	}
+
+	err = manager.Stop(context.Background())
+	if !IsProtocolError(err, protocol.ErrorCodeDaemonStopped) {
+		t.Fatalf("Stop error = %v, want daemon stopped protocol error", err)
+	}
+}
+
 func TestManagerWaitUntilReadyPreservesStartupDeadline(t *testing.T) {
 	t.Parallel()
 
@@ -484,6 +523,185 @@ func TestManagerRepairSignalsTrustedHelperWhenStopRejectsClient(t *testing.T) {
 	}
 	if result.Hello.BuildID != helperidentity.ForExecutable(executable, os.Getpid()).BuildID {
 		t.Fatalf("Repair hello build id = %q, want current build id", result.Hello.BuildID)
+	}
+}
+
+func TestManagerRepairRefreshesRepairableUnexpectedHelper(t *testing.T) {
+	if os.Getenv("AGENT_SECRET_DAEMON_MANAGER_REPAIRABLE_UNEXPECTED_HELPER") == "1" {
+		runDaemonManagerHelper(t)
+		return
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	socketDir, err := os.MkdirTemp("/tmp", "agent-secret-repairable-helper-")
+	if err != nil {
+		t.Fatalf("MkdirTemp returned error: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(socketDir) }()
+	socketPath := filepath.Join(socketDir, "d.sock")
+	alternateHelper := copyCurrentTestBinaryToDaemonBundleAt(t, t.TempDir(), peertrust.DefaultDaemonBundleID)
+	staleOutput, err := os.Create(filepath.Join(t.TempDir(), "repairable-stale-helper.log"))
+	if err != nil {
+		t.Fatalf("create stale helper output log: %v", err)
+	}
+	defer func() { _ = staleOutput.Close() }()
+	staleCmd := daemonprocess.StartCommand(
+		context.Background(),
+		alternateHelper,
+		[]string{"-test.run=TestManagerRepairRefreshesRepairableUnexpectedHelper", "--", "--socket", socketPath},
+	)
+	staleCmd.Env = append(os.Environ(), "AGENT_SECRET_DAEMON_MANAGER_REPAIRABLE_UNEXPECTED_HELPER=1")
+	staleCmd.Stdout = staleOutput
+	staleCmd.Stderr = staleOutput
+	if err := staleCmd.Start(); err != nil {
+		t.Fatalf("start alternate helper: %v", err)
+	}
+	staleDone := make(chan error, 1)
+	go func() { staleDone <- staleCmd.Wait() }()
+	defer func() {
+		if processIsRunning(staleCmd.Process.Pid) {
+			_ = staleCmd.Process.Kill()
+		}
+		select {
+		case <-staleDone:
+		case <-time.After(2 * time.Second):
+		}
+	}()
+	waitForRawSocket(t, socketPath)
+
+	output, err := os.Create(filepath.Join(t.TempDir(), "repair-helper.log"))
+	if err != nil {
+		t.Fatalf("create helper output log: %v", err)
+	}
+	defer func() { _ = output.Close() }()
+	manager := Manager{
+		socketPath:     socketPath,
+		DaemonPath:     executable,
+		DaemonArgs:     []string{"-test.run=TestManagerRepairRefreshesRepairableUnexpectedHelper", "--", "--socket", "{socket}"},
+		StartupTimeout: 2 * time.Second,
+		daemonStdout:   output,
+		daemonStderr:   output,
+	}
+	t.Setenv("AGENT_SECRET_DAEMON_MANAGER_REPAIRABLE_UNEXPECTED_HELPER", "1")
+
+	result, err := manager.Repair(context.Background())
+	if err != nil {
+		helperOutput := readManagerHelperOutput(t, output.Name()) + "\n" + readManagerHelperOutput(t, staleOutput.Name())
+		if strings.Contains(helperOutput, managerHelperBindUnavailablePrefix) {
+			t.Skipf("Unix socket bind unavailable in daemon repair helper: %s", helperOutput)
+		}
+		t.Fatalf("Repair returned error: %v\nhelper output:\n%s", err, helperOutput)
+	}
+	defer func() { _ = manager.Stop(context.Background()) }()
+	select {
+	case <-staleDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("repair did not terminate alternate helper process")
+	}
+	if result.Status != RepairStatusRefreshed {
+		t.Fatalf("Repair status = %q, want refreshed", result.Status)
+	}
+	if result.PID <= 0 || result.PID == staleCmd.Process.Pid {
+		t.Fatalf("Repair pid = %d, want fresh helper process", result.PID)
+	}
+	if samePath(result.Hello.Executable, alternateHelper) {
+		t.Fatalf("Repair hello executable = %q, want current helper, not alternate helper", result.Hello.Executable)
+	}
+}
+
+func TestManagerSignalHelperEdges(t *testing.T) {
+	t.Parallel()
+
+	err := (Manager{}).signalHelper(
+		context.Background(),
+		"repairable helper",
+		func(context.Context) (peercred.Info, error) {
+			return peercred.Info{}, socket.ErrDaemonUnavailable
+		},
+		func(context.Context, time.Duration) error {
+			t.Fatal("wait should not run for missing socket")
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("missing socket signalHelper returned error: %v", err)
+	}
+
+	err = (Manager{}).signalHelper(
+		context.Background(),
+		"repairable helper",
+		func(context.Context) (peercred.Info, error) {
+			return peercred.Info{}, errors.New("proc_pidpath: no such process")
+		},
+		func(context.Context, time.Duration) error {
+			t.Fatal("wait should not run for vanished peer")
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("vanished peer signalHelper returned error: %v", err)
+	}
+
+	inspectErr := errors.New("inspect failed")
+	err = (Manager{}).signalHelper(
+		context.Background(),
+		"repairable helper",
+		func(context.Context) (peercred.Info, error) {
+			return peercred.Info{}, inspectErr
+		},
+		nil,
+	)
+	if !errors.Is(err, inspectErr) {
+		t.Fatalf("inspect failure signalHelper error = %v, want %v", err, inspectErr)
+	}
+
+	err = (Manager{}).signalHelper(
+		context.Background(),
+		"repairable helper",
+		func(context.Context) (peercred.Info, error) {
+			return peercred.Info{}, nil
+		},
+		nil,
+	)
+	if !errors.Is(err, ErrUnexpectedHelper) || !strings.Contains(err.Error(), "pid is unavailable") {
+		t.Fatalf("missing pid signalHelper error = %v, want unexpected helper pid error", err)
+	}
+
+	signalErr := errors.New("signal failed")
+	manager := Manager{
+		signalProcess: func(int, os.Signal) error {
+			return signalErr
+		},
+	}
+	err = manager.signalHelper(
+		context.Background(),
+		"repairable helper",
+		func(context.Context) (peercred.Info, error) {
+			return peercred.Info{PID: 1234}, nil
+		},
+		nil,
+	)
+	if !errors.Is(err, signalErr) {
+		t.Fatalf("signal failure signalHelper error = %v, want %v", err, signalErr)
+	}
+
+	waitErr := errors.New("still running")
+	manager.signalProcess = func(int, os.Signal) error { return nil }
+	err = manager.signalHelper(
+		context.Background(),
+		"repairable helper",
+		func(context.Context) (peercred.Info, error) {
+			return peercred.Info{PID: 1234}, nil
+		},
+		func(context.Context, time.Duration) error {
+			return waitErr
+		},
+	)
+	if !errors.Is(err, waitErr) {
+		t.Fatalf("wait failure signalHelper error = %v, want %v", err, waitErr)
 	}
 }
 
@@ -1217,6 +1435,10 @@ func serveFakeHelperDaemonConn(
 			if !writeFakeHelperResponse(encoder, env.Correlation(), protocol.StatusPayload{PID: opts.hello.PID}) {
 				return
 			}
+		case protocol.TypeOnePasswordStatus:
+			if !writeFakeHelperEmptyResponse(encoder, env.Correlation()) {
+				return
+			}
 		case protocol.TypeDaemonStop:
 			if opts.stopErrorCode != "" {
 				if !writeFakeHelperError(encoder, env.Correlation(), opts.stopErrorCode) {
@@ -1259,6 +1481,16 @@ func writeFakeHelperResponse(encoder *json.Encoder, correlation protocol.Correla
 	resp, err := protocol.NewEnvelope(protocol.TypeOK, correlation, payload)
 	if err != nil {
 		return false
+	}
+	return encoder.Encode(resp) == nil
+}
+
+func writeFakeHelperEmptyResponse(encoder *json.Encoder, correlation protocol.Correlation) bool {
+	resp := protocol.Envelope{
+		Version:   protocol.ProtocolVersion,
+		Type:      protocol.TypeOK,
+		RequestID: correlation.RequestID,
+		Nonce:     correlation.Nonce,
 	}
 	return encoder.Encode(resp) == nil
 }
@@ -1327,4 +1559,49 @@ func writeDaemonBundleExecutableAt(t *testing.T, dir string, bundleID string) st
 		t.Fatalf("write Info.plist: %v", err)
 	}
 	return executable
+}
+
+func copyCurrentTestBinaryToDaemonBundleAt(t *testing.T, dir string, bundleID string) string {
+	t.Helper()
+	bundlePath := filepath.Join(dir, "AgentSecretDaemon.app")
+	macOSPath := filepath.Join(bundlePath, "Contents", "MacOS")
+	if err := os.MkdirAll(macOSPath, 0o750); err != nil {
+		t.Fatalf("mkdir daemon bundle: %v", err)
+	}
+	source, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable returned error: %v", err)
+	}
+	data, err := os.ReadFile(source) //nolint:gosec // G304: test binary path comes from os.Executable.
+	if err != nil {
+		t.Fatalf("read current test binary: %v", err)
+	}
+	executable := filepath.Join(macOSPath, "Agent Secret")
+	if err := os.WriteFile(executable, data, 0o755); err != nil { //nolint:gosec // G306: daemon control tests need runnable fixture executables.
+		t.Fatalf("write bundled test binary: %v", err)
+	}
+	plist := `<plist><dict><key>CFBundleExecutable</key><string>Agent Secret</string>` +
+		`<key>CFBundleIdentifier</key><string>` + bundleID + `</string></dict></plist>`
+	if err := os.WriteFile(filepath.Join(bundlePath, "Contents", "Info.plist"), []byte(plist), 0o600); err != nil {
+		t.Fatalf("write Info.plist: %v", err)
+	}
+	return executable
+}
+
+func waitForRawSocket(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := socket.Dial(context.Background(), path)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for raw socket %s", path)
+}
+
+func processIsRunning(pid int) bool {
+	return pid > 0 && syscall.Kill(pid, 0) == nil
 }

--- a/internal/daemon/peertrust/daemon.go
+++ b/internal/daemon/peertrust/daemon.go
@@ -32,6 +32,8 @@ type DaemonProductValidator struct {
 	verifySignature bool
 }
 
+type DaemonRepairValidator struct{}
+
 func NewDaemonValidator(paths []string) DaemonValidator {
 	return newDaemonValidator(paths, trust.DefaultExpectedTeamID())
 }
@@ -103,11 +105,8 @@ func (v DaemonProductValidator) ValidateDaemonPeer(info peercred.Info) error {
 	if err := v.current.ValidateDaemonPeer(info); err == nil {
 		return nil
 	}
-	if info.UID != os.Getuid() {
-		return fmt.Errorf("%w: daemon uid %d != %d", ErrUntrustedDaemon, info.UID, os.Getuid())
-	}
-	if info.GID != os.Getgid() {
-		return fmt.Errorf("%w: daemon gid %d != %d", ErrUntrustedDaemon, info.GID, os.Getgid())
+	if err := validateDaemonPeerOwner(info); err != nil {
+		return err
 	}
 	if !v.verifySignature {
 		return fmt.Errorf("%w: executable %q is not a current trusted helper", ErrUntrustedDaemon, info.ExecutablePath)
@@ -119,23 +118,53 @@ func (v DaemonProductValidator) ValidateDaemonPeer(info peercred.Info) error {
 	if !enforceTeamID {
 		return fmt.Errorf("%w: broad helper repair trust requires a release Team ID", ErrUntrustedDaemon)
 	}
-	executable, err := pathresolve.Strict(info.ExecutablePath)
-	if err != nil {
-		return fmt.Errorf("%w: normalize daemon executable %q: %w", ErrUntrustedDaemon, info.ExecutablePath, err)
-	}
-	bundlePath, ok := containingAppBundlePath(executable)
-	if !ok || filepath.Base(bundlePath) != "AgentSecretDaemon.app" {
-		return fmt.Errorf("%w: executable %q is not an Agent Secret daemon helper app", ErrUntrustedDaemon, executable)
-	}
-	bundleID, err := trust.PlistString(filepath.Join(bundlePath, "Contents", "Info.plist"), "CFBundleIdentifier", ErrUntrustedDaemon)
+	bundlePath, err := daemonProductBundlePath(info.ExecutablePath)
 	if err != nil {
 		return err
-	}
-	if bundleID != DefaultDaemonBundleID {
-		return fmt.Errorf("%w: daemon bundle id %q != %q", ErrUntrustedDaemon, bundleID, DefaultDaemonBundleID)
 	}
 	if err := trust.ValidatePeerSignature(info, bundlePath, requiredTeamID, v.verifier, ErrUntrustedDaemon); err != nil {
 		return err
 	}
 	return nil
+}
+
+func NewDaemonRepairValidator() DaemonRepairValidator {
+	return DaemonRepairValidator{}
+}
+
+func (DaemonRepairValidator) ValidateDaemonPeer(info peercred.Info) error {
+	if err := validateDaemonPeerOwner(info); err != nil {
+		return err
+	}
+	_, err := daemonProductBundlePath(info.ExecutablePath)
+	return err
+}
+
+func validateDaemonPeerOwner(info peercred.Info) error {
+	if info.UID != os.Getuid() {
+		return fmt.Errorf("%w: daemon uid %d != %d", ErrUntrustedDaemon, info.UID, os.Getuid())
+	}
+	if info.GID != os.Getgid() {
+		return fmt.Errorf("%w: daemon gid %d != %d", ErrUntrustedDaemon, info.GID, os.Getgid())
+	}
+	return nil
+}
+
+func daemonProductBundlePath(executablePath string) (string, error) {
+	executable, err := pathresolve.Strict(executablePath)
+	if err != nil {
+		return "", fmt.Errorf("%w: normalize daemon executable %q: %w", ErrUntrustedDaemon, executablePath, err)
+	}
+	bundlePath, ok := containingAppBundlePath(executable)
+	if !ok || filepath.Base(bundlePath) != "AgentSecretDaemon.app" {
+		return "", fmt.Errorf("%w: executable %q is not an Agent Secret daemon helper app", ErrUntrustedDaemon, executable)
+	}
+	bundleID, err := trust.PlistString(filepath.Join(bundlePath, "Contents", "Info.plist"), "CFBundleIdentifier", ErrUntrustedDaemon)
+	if err != nil {
+		return "", err
+	}
+	if bundleID != DefaultDaemonBundleID {
+		return "", fmt.Errorf("%w: daemon bundle id %q != %q", ErrUntrustedDaemon, bundleID, DefaultDaemonBundleID)
+	}
+	return bundlePath, nil
 }

--- a/internal/daemon/peertrust/daemon_test.go
+++ b/internal/daemon/peertrust/daemon_test.go
@@ -150,6 +150,35 @@ func TestDaemonProductValidatorRejectsWrongHelperBundleID(t *testing.T) {
 	}
 }
 
+func TestDaemonRepairValidatorAllowsSameUserAgentSecretHelperBundle(t *testing.T) {
+	t.Parallel()
+
+	helper := writeDaemonProductBundle(t, DefaultDaemonBundleID)
+	info := trustedDaemonPeerInfo(helper)
+	info.PID = 4321
+
+	if err := NewDaemonRepairValidator().ValidateDaemonPeer(info); err != nil {
+		t.Fatalf("ValidateDaemonPeer returned error: %v", err)
+	}
+}
+
+func TestDaemonRepairValidatorRejectsNonProductPeers(t *testing.T) {
+	t.Parallel()
+
+	validator := NewDaemonRepairValidator()
+	if err := validator.ValidateDaemonPeer(trustedDaemonPeerInfo(writeExecutableAt(t, t.TempDir(), "agent-secretd"))); !errors.Is(err, ErrUntrustedDaemon) {
+		t.Fatalf("direct executable error = %v, want %v", err, ErrUntrustedDaemon)
+	}
+	if err := validator.ValidateDaemonPeer(trustedDaemonPeerInfo(writeDaemonProductBundle(t, "com.example.not-agent-secret"))); !errors.Is(err, ErrUntrustedDaemon) {
+		t.Fatalf("wrong bundle id error = %v, want %v", err, ErrUntrustedDaemon)
+	}
+	info := trustedDaemonPeerInfo(writeDaemonProductBundle(t, DefaultDaemonBundleID))
+	info.UID = os.Getuid() + 1
+	if err := validator.ValidateDaemonPeer(info); !errors.Is(err, ErrUntrustedDaemon) || !strings.Contains(err.Error(), "uid") {
+		t.Fatalf("wrong uid error = %v, want uid trust error", err)
+	}
+}
+
 func TestDaemonValidatorRejectsDifferentUID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- let `agent-secret repair` self-heal same-user Agent Secret daemon helpers from stale or alternate install paths
- keep secret-bearing connections strict while using a repair-only daemon validator for process replacement
- add daemon control and peer-trust tests for the alternate-helper repair path
- add the fix to the pending changelog

## Validation

- `mise exec -- go test ./internal/daemon/peertrust ./internal/daemon/control`
- `mise exec -- npx --no-install markdownlint CHANGELOG.md`
- `mise run lint`
- `mise run build`
- `git diff --check`
- live smoke: started the alternate-path helper from `/Users/kovyrin/Applications/Agent Secret.app`, ran patched `repair --json`, observed `status: "refreshed"`, confirmed the stale helper exited by SIGTERM, then restored the installed Homebrew helper from `/Applications`
