### PR TITLE
[codex] Split session IDs from session tokens

### DIFF
--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -107,24 +107,24 @@ Approve a bounded multi-command session:
 
 ```bash
 agent-secret session create --profile terraform-cloudflare --max-reads 3
-agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN -- \
+agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- \
   terraform plan
-agent-secret with-session asess_123 \
+agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
   -- terraform apply
-agent-secret session destroy asess_123
+agent-secret session destroy asid_123
 ```
 
 Use sessions when the user approves a bag of secrets once and later commands
 need different subsets. `session create` accepts the same config, profile,
-env-file, and `--secret` inputs as `exec`, then returns only an opaque session
-ID. Agent Secret keeps resolved values in background helper memory until TTL,
-read count, explicit destroy, or helper stop clears them. `session list` shows
-active-session metadata but does not reveal session IDs or working directories;
-keep the handle returned by `session create` for later `with-session` or
-`session destroy` calls. `with-session` injects every approved alias by default;
-add `--only ALIAS[,ALIAS...]` to deliver only the aliases needed by that child
-command. Unknown aliases fail before the child process starts.
+env-file, and `--secret` inputs as `exec`, then returns a public `session_id`
+for list/destroy operations and a secret `session_token` for `with-session`.
+Agent Secret keeps resolved values in background helper memory until TTL, read
+count, explicit destroy, or helper stop clears them. `session list` shows active
+session IDs and metadata, but never session tokens. `with-session` injects every
+approved alias by default; add `--only ALIAS[,ALIAS...]` to deliver only the
+aliases needed by that child command. Unknown aliases fail before the child
+process starts.
 
 Use a shell only when the shell is the command you actually want approved:
 

--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -128,6 +128,15 @@ aliases needed by that child command. Unknown aliases fail before the child
 process starts. Use `session destroy SESSION_ID` for one session or
 `session destroy --all` to clear every active session.
 
+Treat `session_token` as a short-lived bearer capability. Keep it in the current
+task context or a local shell variable only for the duration of the bounded
+workflow; do not write it to repo files, durable agent memory, PR comments,
+logs, `.env` files, or documentation. Keep the public `session_id` separately
+for cleanup. If separate processes must share the token, use a private per-user
+temporary file outside the repo with mode `0600`, delete it during cleanup, and
+prefer `session destroy SESSION_ID` or `session destroy --all` when the workflow
+is done.
+
 Use a shell only when the shell is the command you actually want approved:
 
 ```bash

--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -106,14 +106,25 @@ agent-secret exec --reuse-only --profile terraform-cloudflare -- terraform plan
 Approve a bounded multi-command session:
 
 ```bash
-agent-secret session create --profile terraform-cloudflare --max-reads 3
-agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- \
+session_json="$(agent-secret session create \
+  --json \
+  --profile terraform-cloudflare \
+  --max-reads 3)"
+session_id="$(printf '%s' "$session_json" |
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"
+session_token="$(printf '%s' "$session_json" |
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["session_token"])')"
+
+cleanup_session() {
+  agent-secret session destroy "$session_id" >/dev/null 2>&1 || true
+}
+trap cleanup_session EXIT
+
+agent-secret with-session "$session_token" --only CLOUDFLARE_API_TOKEN -- \
   terraform plan
-agent-secret with-session astok_123 \
+agent-secret with-session "$session_token" \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
   -- terraform apply
-agent-secret session destroy asid_123
-agent-secret session destroy --all
 ```
 
 Use sessions when the user approves a bag of secrets once and later commands

--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -119,10 +119,12 @@ Use sessions when the user approves a bag of secrets once and later commands
 need different subsets. `session create` accepts the same config, profile,
 env-file, and `--secret` inputs as `exec`, then returns only an opaque session
 ID. Agent Secret keeps resolved values in background helper memory until TTL,
-read count, explicit destroy, or helper stop clears them. `with-session`
-injects every approved alias by default; add `--only ALIAS[,ALIAS...]` to
-deliver only the aliases needed by that child command. Unknown aliases fail
-before the child process starts.
+read count, explicit destroy, or helper stop clears them. `session list` shows
+active-session metadata but does not reveal session IDs or working directories;
+keep the handle returned by `session create` for later `with-session` or
+`session destroy` calls. `with-session` injects every approved alias by default;
+add `--only ALIAS[,ALIAS...]` to deliver only the aliases needed by that child
+command. Unknown aliases fail before the child process starts.
 
 Use a shell only when the shell is the command you actually want approved:
 

--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -113,6 +113,7 @@ agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
   -- terraform apply
 agent-secret session destroy asid_123
+agent-secret session destroy --all
 ```
 
 Use sessions when the user approves a bag of secrets once and later commands
@@ -124,7 +125,8 @@ count, explicit destroy, or helper stop clears them. `session list` shows active
 session IDs and metadata, but never session tokens. `with-session` injects every
 approved alias by default; add `--only ALIAS[,ALIAS...]` to deliver only the
 aliases needed by that child command. Unknown aliases fail before the child
-process starts.
+process starts. Use `session destroy SESSION_ID` for one session or
+`session destroy --all` to clear every active session.
 
 Use a shell only when the shell is the command you actually want approved:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ version numbers for public releases.
 
 ### Security
 
-- Stopped `agent-secret session list` from returning session IDs or working
-  directories, preventing active session handles from being enumerated and
-  replayed by another local trusted CLI process.
+- Split bounded sessions into listable `session_id` values for management and
+  secret `session_token` values for `with-session`, preventing active session
+  resolve capabilities from being enumerated through `agent-secret session list`.
+- Added `agent-secret session destroy --all` for clearing every active
+  background-helper session without needing individual session IDs.
 
 ## [0.0.22] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
   file before a release is published.
 
+## [0.0.23] - Pending
+
+### Security
+
+- Stopped `agent-secret session list` from returning session IDs or working
+  directories, preventing active session handles from being enumerated and
+  replayed by another local trusted CLI process.
+
 ## [0.0.22] - 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -132,11 +132,13 @@ agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- terraform pla
 agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
   -- terraform apply
+agent-secret session list
 agent-secret session destroy asid_123
 ```
 
 Keep the `session_token` returned by `session create` for `with-session`.
-Use the `session_id` shown by `session list` for inspection and cleanup.
+Use the `session_id` returned by `session create` or shown by `session list`
+for inspection and cleanup. `session list` never shows session tokens.
 
 Inspect item metadata without revealing values:
 

--- a/README.md
+++ b/README.md
@@ -128,15 +128,15 @@ Approve a bounded multi-command session and run commands through the wrapper:
 
 ```bash
 agent-secret session create --profile terraform-cloudflare --max-reads 2
-agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN -- terraform plan
-agent-secret with-session asess_123 \
+agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- terraform plan
+agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
   -- terraform apply
-agent-secret session destroy asess_123
+agent-secret session destroy asid_123
 ```
 
-Keep the session handle returned by `session create`; `session list` reports
-active-session metadata without revealing session IDs or working directories.
+Keep the `session_token` returned by `session create` for `with-session`.
+Use the `session_id` shown by `session list` for inspection and cleanup.
 
 Inspect item metadata without revealing values:
 
@@ -200,7 +200,7 @@ precedence, env-file migration, and the full schema.
 - `agent-secret exec -- COMMAND [ARG...]`: run a command with approved secrets.
 - `agent-secret session create|list|destroy`: manage bounded background-helper
   sessions.
-- `agent-secret with-session SESSION_ID -- COMMAND [ARG...]`: run one command
+- `agent-secret with-session SESSION_TOKEN -- COMMAND [ARG...]`: run one command
   with secrets from an approved session. Add `--only ALIAS[,ALIAS...]` to inject
   a per-command subset of the approved session bag.
 - `agent-secret item describe REF`: inspect 1Password item fields without

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ agent-secret with-session asess_123 \
 agent-secret session destroy asess_123
 ```
 
+Keep the session handle returned by `session create`; `session list` reports
+active-session metadata without revealing session IDs or working directories.
+
 Inspect item metadata without revealing values:
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,11 @@ The supported runtime scope is narrow:
 - macOS on Apple Silicon.
 - 1Password Desktop integration through the official 1Password SDK.
 - CLI-supervised `agent-secret exec` with environment injection.
+- Bounded background-helper sessions through `session create`, `session list`,
+  `session destroy`, and `with-session`.
 
-Linux, Windows, session handles, credential helpers, automatic updates, and
-alternative secret backends are not supported security surfaces yet.
+Linux, Windows, credential helpers, automatic updates, and alternative secret
+backends are not supported security surfaces yet.
 
 ## Reporting A Vulnerability
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,11 +356,14 @@ agent-secret with-session asess_123 \
   -- terraform apply
 ```
 
-`session create` returns only an opaque session ID and non-secret metadata. It
-does not print secret values. Without `--only`, `with-session` injects every
-approved session alias into that child process. With `--only`, it injects only
-the requested approved aliases. If any requested alias was not in the approved
-session, Agent Secret fails before spawning the child command.
+`session create` returns the opaque session ID needed by `with-session`, plus
+non-secret metadata. It does not print secret values. `session list` reports
+active-session metadata without session IDs or working directories, so listing
+cannot be used to discover another workflow's `with-session` handle. Without
+`--only`, `with-session` injects every approved session alias into that child
+process. With `--only`, it injects only the requested approved aliases. If any
+requested alias was not in the approved session, Agent Secret fails before
+spawning the child command.
 
 `with-session` accepts `--cwd DIR`, `--only ALIAS[,ALIAS...]`, and
 `--allow-mutable-executable`. The `--cwd` value defaults to the caller's current

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -364,10 +364,12 @@ agent-secret with-session astok_123 \
 - `session_token`: a secret bearer token accepted by `with-session` and never
   shown by `session list`.
 
-It does not print secret values. Without `--only`, `with-session` injects every
-approved session alias into that child process. With `--only`, it injects only
-the requested approved aliases. If any requested alias was not in the approved
-session, Agent Secret fails before spawning the child command.
+It does not print secret values. `session list` shows active `session_id` values
+and non-secret metadata for inspection and cleanup. Without `--only`,
+`with-session` injects every approved session alias into that child process.
+With `--only`, it injects only the requested approved aliases. If any requested
+alias was not in the approved session, Agent Secret fails before spawning the
+child command.
 
 `with-session` accepts `--cwd DIR`, `--only ALIAS[,ALIAS...]`, and
 `--allow-mutable-executable`. The `--cwd` value defaults to the caller's current

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -314,10 +314,11 @@ different combinations.
 
 ```bash
 agent-secret session create [flags]
-agent-secret with-session SESSION_ID [--cwd DIR] \
+agent-secret with-session SESSION_TOKEN [--cwd DIR] \
   [--only ALIAS[,ALIAS...]] [--allow-mutable-executable] -- COMMAND [ARG...]
 agent-secret session list [--json]
 agent-secret session destroy [--json] SESSION_ID
+agent-secret session destroy [--json] --all
 ```
 
 `session create` accepts the same secret-source flags as `exec`:
@@ -348,31 +349,35 @@ agent-secret session create \
   --max-reads 3 \
   --json
 
-agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN -- \
+agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- \
   terraform plan
 
-agent-secret with-session asess_123 \
+agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
   -- terraform apply
 ```
 
-`session create` returns the opaque session ID needed by `with-session`, plus
-non-secret metadata. It does not print secret values. `session list` reports
-active-session metadata without session IDs or working directories, so listing
-cannot be used to discover another workflow's `with-session` handle. Without
-`--only`, `with-session` injects every approved session alias into that child
-process. With `--only`, it injects only the requested approved aliases. If any
-requested alias was not in the approved session, Agent Secret fails before
-spawning the child command.
+`session create` returns two identifiers and non-secret metadata:
+
+- `session_id`: a management identifier shown by `session list` and accepted by
+  `session destroy`.
+- `session_token`: a secret bearer token accepted by `with-session` and never
+  shown by `session list`.
+
+It does not print secret values. Without `--only`, `with-session` injects every
+approved session alias into that child process. With `--only`, it injects only
+the requested approved aliases. If any requested alias was not in the approved
+session, Agent Secret fails before spawning the child command.
 
 `with-session` accepts `--cwd DIR`, `--only ALIAS[,ALIAS...]`, and
 `--allow-mutable-executable`. The `--cwd` value defaults to the caller's current
 directory and must match the session working directory.
 
 Sessions are background-helper-memory only. They expire when TTL passes, the
-read count is exhausted, `agent-secret session destroy SESSION_ID` succeeds, or
-the helper stops. V1 sessions intentionally do not expose raw socket value
-reads, credential-helper protocols, or long-lived interactive shells.
+read count is exhausted, `agent-secret session destroy SESSION_ID` or
+`agent-secret session destroy --all` succeeds, or the helper stops. V1 sessions
+intentionally do not expose raw socket value reads, credential-helper protocols,
+or long-lived interactive shells.
 
 ## Agent-Friendly Introspection
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -935,7 +935,7 @@ Status: Not started
   reusable-approval infrastructure.
 - Failing test/check: daemon tests fail until the server accepts valid session
   requests, rejects malformed versions, rejects wrong-UID peers, and enforces
-  strict PID/executable/cwd checks before resolving session handles.
+  strict PID/executable/cwd checks before resolving session tokens.
 - Implementation:
   - add session request, list, destroy, and value-read envelopes
   - persist session metadata and approved references in daemon memory only

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -898,17 +898,17 @@ Status: Complete
   - `go test ./...`
   - manual smoke with the native helper
 
-## Epic 6: Session Handles And `with-session`
+## Epic 6: Bounded Sessions And `with-session`
 
-Status: Not started
+Status: Complete
 
 ### Epic 6 Acceptance Criteria
 
 - Session state lives inside the existing hidden per-user daemon.
 - `session create`, `session list`, `session destroy`, and `with-session` work.
-- Handles cannot be resolved after TTL, max-read exhaustion, or destroy.
-- Handles cannot be resolved when macOS peer UID, PID, executable path, or cwd
-  is missing or mismatched.
+- Session tokens cannot be resolved after TTL, max-read exhaustion, or destroy.
+- Session tokens cannot be resolved when macOS peer UID, PID, executable path,
+  or cwd is missing or mismatched.
 - Sessions approve a bounded set of references and allow those references to be
   read in any order the approved workflow needs.
 - Socket directories and files use restrictive permissions.
@@ -929,7 +929,7 @@ Status: Not started
 
 #### Task 1: Add session endpoints to the daemon socket
 
-- Goal: add session-handle lifecycle and value-read messages to the existing
+- Goal: add session lifecycle and value-read messages to the existing
   per-user Unix socket.
 - Preconditions/inputs: working daemon socket, approval, resolver, audit, and
   reusable-approval infrastructure.
@@ -954,7 +954,7 @@ Status: Not started
   - implement `session create`
   - implement `session list`
   - implement `session destroy`
-  - return handles, not values
+  - return identifiers, not values
 - Verification:
   - `go test ./...`
 
@@ -966,8 +966,8 @@ Status: Not started
   session secrets into the child and rejects expired, destroyed, or peer-policy
   mismatched sessions.
 - Implementation:
-  - resolve handles internally through the daemon
-  - enforce strict macOS peer validation before resolving handles
+  - resolve session tokens internally through the daemon
+  - enforce strict macOS peer validation before resolving session tokens
   - reuse the CLI-owned process supervisor
   - preserve command exit behavior
 - Verification:
@@ -1052,8 +1052,8 @@ Status: Not started
 - Epic 6 depends on the completed `exec`, daemon socket, native approval, and
   reusable approval paths. It should not block initial Terraform/Ansible
   validation.
-- Epic 7 should follow the first working `exec` path, then broaden after session
-  handles land.
+- Epic 7 should follow the first working `exec` path, then broaden after
+  bounded sessions land.
 
 ## Testing Strategy
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -130,11 +130,10 @@ terraform apply
 ansible-playbook site.yml --check
 ```
 
-The user approves once for a TTL and max-read count. The broker returns an
-opaque session ID, keeps values in Agent Secret's background helper memory, and
-subsequent commands must run through `agent-secret with-session`. The wrapper
-resolves values over the daemon command channel and injects them only into the
-approved child process.
+The user approves once for a TTL and max-read count. The broker returns a
+public `session_id` for management plus a secret `session_token` for
+`agent-secret with-session`, keeps values in Agent Secret's background helper
+memory, and injects them only into the approved child process.
 V1 sessions do not add generic socket reads or credential-helper protocols.
 
 ### Use Case 3: Config-Driven Secret Sync
@@ -362,7 +361,7 @@ Each approved request should bind these fields:
 The broker rejects access if the request is expired, the requested
 reference/alias is not approved, the reusable or session read count is
 exhausted, the command or cwd policy mismatches, the nonce is invalid, the
-session ID is unknown, peer metadata mismatches, or the request was denied or
+session token is unknown, peer metadata mismatches, or the request was denied or
 canceled.
 
 For `agent-secret exec`, `--cwd` is operational. It sets the child process
@@ -676,12 +675,13 @@ Limitations:
 - Environment variables can still be exposed by child process behavior, crash
   reporters, debuggers, or subprocesses.
 
-### Mode 2: Background-Helper Session IDs
+### Mode 2: Background-Helper Sessions
 
-The broker creates a short-lived session and returns an opaque session ID
-instead of values. Values stay in Agent Secret's background helper memory and
-are useful only through `agent-secret with-session`, matching peer credentials,
-cwd, remaining read count, and unexpired policy.
+The broker creates a short-lived session and returns a public `session_id` for
+list/destroy operations plus a secret `session_token` instead of values. Values
+stay in Agent Secret's background helper memory and are useful only through
+`agent-secret with-session`, matching peer credentials, cwd, remaining read
+count, and unexpired policy.
 
 Unlike same-command reuse, sessions approve a bounded set of references for a
 workflow lifetime and allow those approved references to be injected into
@@ -693,10 +693,10 @@ exhausted, the daemon stops, or the session is destroyed.
 
 ### Mode 3: `with-session`
 
-The agent receives a session ID but must wrap each command:
+The agent receives a session token but must wrap each command:
 
 ```bash
-agent-secret with-session asess_123 \
+agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
   -- terraform apply
 ```
@@ -855,9 +855,10 @@ V1 commands:
 ```bash
 agent-secret exec [options] -- command [args...]
 agent-secret session create [options]
-agent-secret with-session asess_123 [--only ALIAS[,ALIAS...]] -- command [args...]
+agent-secret with-session astok_123 [--only ALIAS[,ALIAS...]] -- command [args...]
 agent-secret session list
-agent-secret session destroy asess_123
+agent-secret session destroy asid_123
+agent-secret session destroy --all
 agent-secret repair
 agent-secret daemon status
 agent-secret daemon start
@@ -1085,7 +1086,7 @@ Exit criteria:
 Deliverables:
 
 - session create, list, and destroy
-- opaque session IDs
+- public session IDs for management and secret session tokens for resolution
 - `with-session` wrapper
 - background-helper-memory value storage and wrapper-only resolution
 - TTL and max-read enforcement
@@ -1185,12 +1186,12 @@ Exit criteria:
 
 ### Session Mode Criteria
 
-- Session create returns opaque session IDs only.
-- Session IDs cannot be resolved after TTL.
-- Session IDs cannot be resolved more than the allowed read count.
+- Session create returns a public session ID and secret session token.
+- Session tokens cannot be resolved after TTL.
+- Session tokens cannot be resolved more than the allowed read count.
 - On macOS, session resolution fails closed if peer UID, PID, executable path, or
   cwd cannot be obtained or does not match the approved session policy.
-- Destroying a session invalidates the session ID.
+- Destroying a session invalidates the session token.
 
 ### Audit Criteria
 

--- a/docs/security-boundary-review-2026-05-05.md
+++ b/docs/security-boundary-review-2026-05-05.md
@@ -23,7 +23,7 @@ This review covered the shipped macOS Apple Silicon surface:
 - Metadata-only audit log.
 - Release DMG, install, and uninstall trust checks.
 
-This review did not cover unshipped session handles, `with-session`, credential
+This review did not cover unshipped bounded sessions, `with-session`, credential
 helpers, Linux, Windows, automatic updates, or alternative secret backends.
 
 ## Boundary Walk

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -45,7 +45,9 @@ cli_ref="${AGENT_SECRET_E2E_CLI_REF:-op://Agent Secret Integration/Another Test 
 
 workdir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-session-e2e.XXXXXX")"
 SESSION_ID=""
+SESSION_TOKEN=""
 EXHAUST_ID=""
+EXHAUST_TOKEN=""
 
 cleanup() {
   if [[ -n "${SESSION_ID:-}" ]]; then
@@ -104,34 +106,37 @@ SESSION_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
     --max-reads 5)"
 SESSION_ID="$(printf '%s' "$SESSION_JSON" |
   python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"
+SESSION_TOKEN="$(printf '%s' "$SESSION_JSON" |
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["session_token"])')"
 printf 'created mixed config+CLI session: %s\n' "$SESSION_ID"
 
 agent-secret session list --json |
-  python3 -c '
-import json, sys
+  python3 -c 'import os, json, sys
+session_id = sys.argv[1]
 data = json.load(sys.stdin)
 matches = [
     s for s in data["sessions"]
-    if s["remaining_reads"] == 5 and s["secret_aliases"] == [
+    if s["session_id"] == session_id
+    and s["remaining_reads"] == 5 and s["secret_aliases"] == [
         "SESSION_E2E_CLI_TOKEN",
         "SESSION_E2E_PROFILE_TOKEN",
     ]
 ]
 assert len(matches) >= 1, data
-assert "session_id" not in matches[0], matches[0]
-assert "cwd" not in matches[0], matches[0]
-print("session list ok")'
+assert matches[0]["cwd"] == os.getcwd(), matches[0]
+assert "session_token" not in matches[0], matches[0]
+print("session list ok")' "$SESSION_ID"
 
-run_with_session "$SESSION_ID" \
+run_with_session "$SESSION_TOKEN" \
   --allow-mutable-executable \
   -- python3 -c "$check_py" full
-run_with_session "$SESSION_ID" \
+run_with_session "$SESSION_TOKEN" \
   --only SESSION_E2E_PROFILE_TOKEN \
   --allow-mutable-executable \
   -- python3 -c "$check_py" profile
 
 missing_output="$workdir/missing-alias.out"
-if run_with_session "$SESSION_ID" \
+if run_with_session "$SESSION_TOKEN" \
   --only SESSION_E2E_MISSING_TOKEN \
   --allow-mutable-executable \
   -- python3 -c 'print("UNEXPECTED_CHILD_STARTED")' \
@@ -145,34 +150,35 @@ if grep -q 'UNEXPECTED_CHILD_STARTED' "$missing_output"; then
 fi
 echo 'missing alias rejected before child spawn'
 
-run_with_session "$SESSION_ID" \
+run_with_session "$SESSION_TOKEN" \
   --only SESSION_E2E_CLI_TOKEN \
   --allow-mutable-executable \
   -- python3 -c "$check_py" cli
-run_with_session "$SESSION_ID" \
+run_with_session "$SESSION_TOKEN" \
   --only SESSION_E2E_PROFILE_TOKEN,SESSION_E2E_CLI_TOKEN \
   --allow-mutable-executable \
   -- python3 -c "$check_py" both
 
 agent-secret session list --json |
-  python3 -c '
-import json, sys
+  python3 -c 'import os, json, sys
+session_id = sys.argv[1]
 data = json.load(sys.stdin)
 matches = [
     s for s in data["sessions"]
-    if s["remaining_reads"] == 1 and s["secret_aliases"] == [
+    if s["session_id"] == session_id
+    and s["remaining_reads"] == 1 and s["secret_aliases"] == [
         "SESSION_E2E_CLI_TOKEN",
         "SESSION_E2E_PROFILE_TOKEN",
     ]
 ]
 assert len(matches) >= 1, data
-assert "session_id" not in matches[0], matches[0]
-assert "cwd" not in matches[0], matches[0]
-print("read count after subset runs ok")'
+assert matches[0]["cwd"] == os.getcwd(), matches[0]
+assert "session_token" not in matches[0], matches[0]
+print("read count after subset runs ok")' "$SESSION_ID"
 
 agent-secret session destroy "$SESSION_ID" >/dev/null
 destroyed_output="$workdir/destroyed.out"
-if run_with_session "$SESSION_ID" \
+if run_with_session "$SESSION_TOKEN" \
   --only SESSION_E2E_PROFILE_TOKEN \
   --allow-mutable-executable \
   -- python3 -c 'print("UNEXPECTED_CHILD_STARTED")' \
@@ -186,6 +192,7 @@ if grep -q 'UNEXPECTED_CHILD_STARTED' "$destroyed_output"; then
 fi
 echo 'destroyed session rejected before child spawn'
 SESSION_ID=""
+SESSION_TOKEN=""
 
 EXHAUST_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
   agent-secret session create \
@@ -195,14 +202,16 @@ EXHAUST_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
     --max-reads 1)"
 EXHAUST_ID="$(printf '%s' "$EXHAUST_JSON" |
   python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"
+EXHAUST_TOKEN="$(printf '%s' "$EXHAUST_JSON" |
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["session_token"])')"
 printf 'created one-read session: %s\n' "$EXHAUST_ID"
-run_with_session "$EXHAUST_ID" \
+run_with_session "$EXHAUST_TOKEN" \
   --only SESSION_E2E_PROFILE_TOKEN \
   --allow-mutable-executable \
   -- python3 -c "$check_py" profile
 
 exhausted_output="$workdir/exhausted.out"
-if run_with_session "$EXHAUST_ID" \
+if run_with_session "$EXHAUST_TOKEN" \
   --only SESSION_E2E_PROFILE_TOKEN \
   --allow-mutable-executable \
   -- python3 -c 'print("UNEXPECTED_CHILD_STARTED")' \
@@ -216,6 +225,7 @@ if grep -q 'UNEXPECTED_CHILD_STARTED' "$exhausted_output"; then
 fi
 echo 'read exhaustion rejected before child spawn'
 EXHAUST_ID=""
+EXHAUST_TOKEN=""
 
 python3 - "$audit_log" "$start_lines" <<'PY'
 import json
@@ -265,7 +275,7 @@ echo 'session E2E ok'
 The exact session IDs vary, but a passing run prints these checkpoints:
 
 ```text
-created mixed config+CLI session: asess_...
+created mixed config+CLI session: asid_...
 session list ok
 full ok
 profile ok
@@ -274,7 +284,7 @@ cli ok
 both ok
 read count after subset runs ok
 destroyed session rejected before child spawn
-created one-read session: asess_...
+created one-read session: asid_...
 profile ok
 read exhaustion rejected before child spawn
 audit metadata ok
@@ -286,8 +296,8 @@ session E2E ok
 This E2E run proves:
 
 - `session create` accepts secrets from a project config profile and CLI args.
-- `session list` shows metadata for active sessions without values, session
-  IDs, or working directories.
+- `session list` shows public session IDs and working directories for active
+  sessions without values or session tokens.
 - `with-session` injects the full approved bag when `--only` is omitted.
 - `with-session --only` injects config-only, CLI-only, and combined subsets.
 - Unknown aliases fail before the child process starts.

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -107,18 +107,19 @@ SESSION_ID="$(printf '%s' "$SESSION_JSON" |
 printf 'created mixed config+CLI session: %s\n' "$SESSION_ID"
 
 agent-secret session list --json |
-  SESSION_ID="$SESSION_ID" python3 -c '
-import json, os, sys
+  python3 -c '
+import json, sys
 data = json.load(sys.stdin)
-sid = os.environ["SESSION_ID"]
-matches = [s for s in data["sessions"] if s["session_id"] == sid]
-assert len(matches) == 1, matches
-s = matches[0]
-assert s["remaining_reads"] == 5, s
-assert s["secret_aliases"] == [
-    "SESSION_E2E_CLI_TOKEN",
-    "SESSION_E2E_PROFILE_TOKEN",
-], s
+matches = [
+    s for s in data["sessions"]
+    if s["remaining_reads"] == 5 and s["secret_aliases"] == [
+        "SESSION_E2E_CLI_TOKEN",
+        "SESSION_E2E_PROFILE_TOKEN",
+    ]
+]
+assert len(matches) >= 1, data
+assert "session_id" not in matches[0], matches[0]
+assert "cwd" not in matches[0], matches[0]
 print("session list ok")'
 
 run_with_session "$SESSION_ID" \
@@ -154,13 +155,19 @@ run_with_session "$SESSION_ID" \
   -- python3 -c "$check_py" both
 
 agent-secret session list --json |
-  SESSION_ID="$SESSION_ID" python3 -c '
-import json, os, sys
+  python3 -c '
+import json, sys
 data = json.load(sys.stdin)
-sid = os.environ["SESSION_ID"]
-matches = [s for s in data["sessions"] if s["session_id"] == sid]
-assert len(matches) == 1, matches
-assert matches[0]["remaining_reads"] == 1, matches[0]
+matches = [
+    s for s in data["sessions"]
+    if s["remaining_reads"] == 1 and s["secret_aliases"] == [
+        "SESSION_E2E_CLI_TOKEN",
+        "SESSION_E2E_PROFILE_TOKEN",
+    ]
+]
+assert len(matches) >= 1, data
+assert "session_id" not in matches[0], matches[0]
+assert "cwd" not in matches[0], matches[0]
 print("read count after subset runs ok")'
 
 agent-secret session destroy "$SESSION_ID" >/dev/null
@@ -279,7 +286,8 @@ session E2E ok
 This E2E run proves:
 
 - `session create` accepts secrets from a project config profile and CLI args.
-- `session list` shows metadata for active sessions without values.
+- `session list` shows metadata for active sessions without values, session
+  IDs, or working directories.
 - `with-session` injects the full approved bag when `--only` is omitted.
 - `with-session --only` injects config-only, CLI-only, and combined subsets.
 - Unknown aliases fail before the child process starts.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -106,8 +106,8 @@ Agent Secret must meet these goals:
   behavior.
 - Reusable approvals expire at their TTL, consume uses correctly, and clear
   cached raw values when exhausted, expired, or rolled back.
-- Bounded session handles are returned only to the creator at `session create`
-  time and are not enumerable through session listing.
+- Bounded session tokens are returned only at `session create` time and are not
+  enumerable through session listing.
 - The daemon accepts exec and stop requests only from trusted Agent Secret CLI
   executables.
 - The CLI accepts secret-bearing responses only from a trusted Agent Secret

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -106,6 +106,8 @@ Agent Secret must meet these goals:
   behavior.
 - Reusable approvals expire at their TTL, consume uses correctly, and clear
   cached raw values when exhausted, expired, or rolled back.
+- Bounded session handles are returned only to the creator at `session create`
+  time and are not enumerable through session listing.
 - The daemon accepts exec and stop requests only from trusted Agent Secret CLI
   executables.
 - The CLI accepts secret-bearing responses only from a trusted Agent Secret

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -108,7 +108,6 @@ func FromSessionResolveRequest(eventType EventType, requestID string, req reques
 	return Event{
 		Type:               eventType,
 		RequestID:          requestID,
-		SessionID:          req.SessionID,
 		Command:            slices.Clone(req.Command),
 		ResolvedExecutable: req.ResolvedExecutable,
 		CWD:                req.CWD,

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -369,7 +369,7 @@ func TestFromSessionRequestsUseMetadataOnly(t *testing.T) {
 	}
 
 	resolveReq, err := request.NewSessionResolve(
-		"asess_abc123",
+		"astok_abc123",
 		[]string{"/usr/bin/env", "terraform", "plan"},
 		"/usr/bin/env",
 		fileidentity.Identity{Device: 1, Inode: 2, Mode: 0o755, Size: 64},
@@ -386,7 +386,7 @@ func TestFromSessionRequestsUseMetadataOnly(t *testing.T) {
 		[]SecretRef{{Alias: "TOKEN", Ref: "op://Example Vault/Deploy Token/token", Account: "Work"}},
 	)
 	if resolveEvent.Type != EventSessionResolved ||
-		resolveEvent.SessionID != "asess_abc123" ||
+		resolveEvent.SessionID != "" ||
 		resolveEvent.CWD != dir ||
 		len(resolveEvent.SecretRefs) != 1 {
 		t.Fatalf("resolve event missing expected metadata: %+v", resolveEvent)

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -106,7 +106,7 @@ func (a App) runAgentContext(command Command) int {
 				"secret values are never printed by agent-secret",
 				"exec passes child stdin/stdout/stderr through unchanged",
 				"item describe returns metadata only",
-				"session create returns opaque handles only and with-session never prints values",
+				"session create returns a public session id and secret session token; with-session never prints values",
 			},
 			MutationBoundary: []string{
 				"exec --dry-run validates without prompting or spawning",
@@ -204,7 +204,7 @@ func agentContextCommands() map[string]commandContext {
 			Summary: "Create, list, and destroy bounded background-helper secret sessions.",
 			Subcommands: map[string]commandContext{
 				"create": {
-					Summary: "Ask for approval, resolve refs, and return an opaque session id.",
+					Summary: "Ask for approval, resolve refs, and return a session id plus token.",
 					Flags: []flagContext{
 						{Name: "--reason", Type: "string", Description: "Human-readable reason shown to the approver."},
 						{Name: "--secret", Type: "mapping", Repeatable: true, Description: "Secret alias mapping: ALIAS=op://vault/item/field or ALIAS=bws://source/secret-uuid."},
@@ -220,16 +220,18 @@ func agentContextCommands() map[string]commandContext {
 						{Name: "--json", Type: "bool", Description: "Print session metadata as JSON."},
 					},
 					Outputs: []string{"text", "json"},
-					Notes:   []string{"returns a session id only", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
+					Notes:   []string{"returns a public session id for management and a secret session token for with-session", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
 				},
 				"list": {
-					Summary: "List active sessions without session ids or working directories.",
+					Summary: "List active session ids and non-secret metadata.",
 					Flags:   jsonFlag(),
 					Outputs: []string{"text", "json"},
 				},
 				"destroy": {
 					Summary: "Destroy one session and clear its cached values.",
-					Flags:   jsonFlag(),
+					Flags: append([]flagContext{
+						{Name: "--all", Type: "bool", Description: "Destroy all active sessions."},
+					}, jsonFlag()...),
 					Outputs: []string{"text", "json"},
 				},
 			},
@@ -241,7 +243,7 @@ func agentContextCommands() map[string]commandContext {
 				{Name: "--allow-mutable-executable", Type: "bool", Description: "Allow a user-owned or writable executable path after surfacing the approval warning."},
 			},
 			Outputs: []string{"child passthrough"},
-			Notes:   []string{"usage: agent-secret with-session SESSION_ID -- COMMAND [ARG...]", "session values are injected into the child environment and never printed"},
+			Notes:   []string{"usage: agent-secret with-session SESSION_TOKEN -- COMMAND [ARG...]", "session values are injected into the child environment and never printed"},
 		},
 		"bitwarden": {
 			Summary: "Manage local Bitwarden Secrets Manager token aliases.",

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -223,7 +223,7 @@ func agentContextCommands() map[string]commandContext {
 					Notes:   []string{"returns a session id only", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
 				},
 				"list": {
-					Summary: "List active session ids and non-secret metadata.",
+					Summary: "List active sessions without session ids or working directories.",
 					Flags:   jsonFlag(),
 					Outputs: []string{"text", "json"},
 				},

--- a/internal/cli/app_session.go
+++ b/internal/cli/app_session.go
@@ -17,6 +17,7 @@ import (
 type sessionCreateOutput struct {
 	SchemaVersion  string    `json:"schema_version"`
 	SessionID      string    `json:"session_id"`
+	SessionToken   string    `json:"session_token"`
 	SecretAliases  []string  `json:"secret_aliases"`
 	ExpiresAt      time.Time `json:"expires_at"`
 	MaxReads       int       `json:"max_reads"`
@@ -52,6 +53,7 @@ func (a App) runSessionCreate(ctx context.Context, command Command) int {
 	output := sessionCreateOutput{
 		SchemaVersion:  "1",
 		SessionID:      payload.SessionID,
+		SessionToken:   payload.SessionToken,
 		SecretAliases:  payload.SecretAliases,
 		ExpiresAt:      payload.ExpiresAt,
 		MaxReads:       payload.MaxReads,
@@ -64,7 +66,8 @@ func (a App) runSessionCreate(ctx context.Context, command Command) int {
 		}
 		return 0
 	}
-	a.stdoutf("session: %s\n", payload.SessionID)
+	a.stdoutf("session id: %s\n", payload.SessionID)
+	a.stdoutf("session token: %s\n", payload.SessionToken)
 	a.stdoutf("expires: %s\n", payload.ExpiresAt.Format(time.RFC3339))
 	a.stdoutf("reads: %d/%d remaining\n", payload.RemainingReads, payload.MaxReads)
 	a.stdoutf("secrets: %s\n", strings.Join(payload.SecretAliases, ", "))
@@ -102,10 +105,12 @@ func (a App) runSessionList(ctx context.Context, command Command) int {
 	}
 	for _, session := range payload.Sessions {
 		a.stdoutf(
-			"expires=%s reads=%d/%d secrets=%s reason=%s\n",
+			"%s expires=%s reads=%d/%d cwd=%s secrets=%s reason=%s\n",
+			session.SessionID,
 			session.ExpiresAt.Format(time.RFC3339),
 			session.RemainingReads,
 			session.MaxReads,
+			session.CWD,
 			strings.Join(session.SecretAliases, ","),
 			session.Reason,
 		)
@@ -136,6 +141,10 @@ func (a App) runSessionDestroy(ctx context.Context, command Command) int {
 			a.stderrf("agent-secret: write session destroy json: %v\n", err)
 			return 1
 		}
+		return 0
+	}
+	if command.SessionDestroyRequest.All {
+		a.stdoutf("destroyed sessions: %d\n", payload.DestroyedCount)
 		return 0
 	}
 	a.stdoutf("destroyed session: %s\n", payload.SessionID)

--- a/internal/cli/app_session.go
+++ b/internal/cli/app_session.go
@@ -102,13 +102,12 @@ func (a App) runSessionList(ctx context.Context, command Command) int {
 	}
 	for _, session := range payload.Sessions {
 		a.stdoutf(
-			"%s expires=%s reads=%d/%d cwd=%s secrets=%s\n",
-			session.SessionID,
+			"expires=%s reads=%d/%d secrets=%s reason=%s\n",
 			session.ExpiresAt.Format(time.RFC3339),
 			session.RemainingReads,
 			session.MaxReads,
-			session.CWD,
 			strings.Join(session.SecretAliases, ","),
+			session.Reason,
 		)
 	}
 	return 0

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -276,9 +276,7 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		client := &appFakeDaemonClient{
 			sessionListPayload: protocol.SessionListResponsePayload{
 				Sessions: []protocol.SessionInfoPayload{{
-					SessionID:      "asess_test",
 					Reason:         "Deploy workflow",
-					CWD:            "/tmp/project",
 					SecretAliases:  []string{"TOKEN"},
 					ExpiresAt:      expiresAt,
 					MaxReads:       2,
@@ -302,9 +300,14 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		if client.sessionListCalls != 1 || client.closeCalls != 1 {
 			t.Fatalf("client calls: list=%d close=%d", client.sessionListCalls, client.closeCalls)
 		}
-		for _, want := range []string{"asess_test", "reads=1/2", "secrets=TOKEN"} {
+		for _, want := range []string{"reads=1/2", "secrets=TOKEN", "reason=Deploy workflow"} {
 			if !strings.Contains(stdout.String(), want) {
 				t.Fatalf("session list stdout = %q, want %q", stdout.String(), want)
+			}
+		}
+		for _, forbidden := range []string{"asess_test", "/tmp/project", "cwd="} {
+			if strings.Contains(stdout.String(), forbidden) {
+				t.Fatalf("session list stdout = %q, must not include %q", stdout.String(), forbidden)
 			}
 		}
 	})
@@ -315,9 +318,7 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		client := &appFakeDaemonClient{
 			sessionListPayload: protocol.SessionListResponsePayload{
 				Sessions: []protocol.SessionInfoPayload{{
-					SessionID:      "asess_test",
 					Reason:         "Deploy workflow",
-					CWD:            "/tmp/project",
 					SecretAliases:  []string{"TOKEN"},
 					ExpiresAt:      expiresAt,
 					MaxReads:       2,
@@ -342,8 +343,11 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 			t.Fatalf("decode session list json: %v; stdout=%q", err, stdout.String())
 		}
-		if len(got.Sessions) != 1 || got.Sessions[0].SessionID != "asess_test" {
+		if len(got.Sessions) != 1 || got.Sessions[0].RemainingReads != 1 {
 			t.Fatalf("session list json = %+v", got)
+		}
+		if strings.Contains(stdout.String(), "session_id") || strings.Contains(stdout.String(), "cwd") {
+			t.Fatalf("session list json exposes a session capability or cwd: %s", stdout.String())
 		}
 	})
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -179,7 +179,8 @@ profiles:
 	expiresAt := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
 	client := &appFakeDaemonClient{
 		sessionCreatePayload: protocol.SessionCreateResponsePayload{
-			SessionID:      "asess_test",
+			SessionID:      "asid_test",
+			SessionToken:   "astok_test",
 			SecretAliases:  []string{"TOKEN"},
 			ExpiresAt:      expiresAt,
 			MaxReads:       2,
@@ -219,7 +220,7 @@ profiles:
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("decode stdout JSON: %v; stdout=%q", err, stdout.String())
 	}
-	if got.SessionID != "asess_test" || got.RemainingReads != 2 || got.MaxReads != 2 {
+	if got.SessionID != "asid_test" || got.SessionToken != "astok_test" || got.RemainingReads != 2 || got.MaxReads != 2 {
 		t.Fatalf("session create json = %+v", got)
 	}
 	if strings.Contains(stdout.String(), "synthetic-secret-value") || strings.Contains(stderr.String(), "synthetic-secret-value") {
@@ -233,7 +234,8 @@ func TestAppSessionCreatePrintsText(t *testing.T) {
 	expiresAt := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
 	client := &appFakeDaemonClient{
 		sessionCreatePayload: protocol.SessionCreateResponsePayload{
-			SessionID:      "asess_text",
+			SessionID:      "asid_text",
+			SessionToken:   "astok_text",
 			SecretAliases:  []string{"TOKEN"},
 			ExpiresAt:      expiresAt,
 			MaxReads:       1,
@@ -259,14 +261,14 @@ func TestAppSessionCreatePrintsText(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"session: asess_text", "reads: 1/1 remaining", "secrets: TOKEN"} {
+	for _, want := range []string{"session id: asid_text", "session token: astok_text", "reads: 1/1 remaining", "secrets: TOKEN"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("session create stdout = %q, want %q", stdout.String(), want)
 		}
 	}
 }
 
-func TestAppSessionListAndDestroy(t *testing.T) {
+func TestAppSessionList(t *testing.T) {
 	t.Parallel()
 
 	expiresAt := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
@@ -276,7 +278,9 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		client := &appFakeDaemonClient{
 			sessionListPayload: protocol.SessionListResponsePayload{
 				Sessions: []protocol.SessionInfoPayload{{
+					SessionID:      "asid_test",
 					Reason:         "Deploy workflow",
+					CWD:            "/tmp/project",
 					SecretAliases:  []string{"TOKEN"},
 					ExpiresAt:      expiresAt,
 					MaxReads:       2,
@@ -300,14 +304,14 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		if client.sessionListCalls != 1 || client.closeCalls != 1 {
 			t.Fatalf("client calls: list=%d close=%d", client.sessionListCalls, client.closeCalls)
 		}
-		for _, want := range []string{"reads=1/2", "secrets=TOKEN", "reason=Deploy workflow"} {
+		for _, want := range []string{"asid_test", "reads=1/2", "cwd=/tmp/project", "secrets=TOKEN", "reason=Deploy workflow"} {
 			if !strings.Contains(stdout.String(), want) {
 				t.Fatalf("session list stdout = %q, want %q", stdout.String(), want)
 			}
 		}
-		for _, forbidden := range []string{"asess_test", "/tmp/project", "cwd="} {
+		for _, forbidden := range []string{"session_token", "astok_test"} {
 			if strings.Contains(stdout.String(), forbidden) {
-				t.Fatalf("session list stdout = %q, must not include %q", stdout.String(), forbidden)
+				t.Fatalf("session list stdout = %q, must not include token data %q", stdout.String(), forbidden)
 			}
 		}
 	})
@@ -318,7 +322,9 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		client := &appFakeDaemonClient{
 			sessionListPayload: protocol.SessionListResponsePayload{
 				Sessions: []protocol.SessionInfoPayload{{
+					SessionID:      "asid_test",
 					Reason:         "Deploy workflow",
+					CWD:            "/tmp/project",
 					SecretAliases:  []string{"TOKEN"},
 					ExpiresAt:      expiresAt,
 					MaxReads:       2,
@@ -343,11 +349,14 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 			t.Fatalf("decode session list json: %v; stdout=%q", err, stdout.String())
 		}
-		if len(got.Sessions) != 1 || got.Sessions[0].RemainingReads != 1 {
+		if len(got.Sessions) != 1 ||
+			got.Sessions[0].SessionID != "asid_test" ||
+			got.Sessions[0].CWD != "/tmp/project" ||
+			got.Sessions[0].RemainingReads != 1 {
 			t.Fatalf("session list json = %+v", got)
 		}
-		if strings.Contains(stdout.String(), "session_id") || strings.Contains(stdout.String(), "cwd") {
-			t.Fatalf("session list json exposes a session capability or cwd: %s", stdout.String())
+		if strings.Contains(stdout.String(), "session_token") || strings.Contains(stdout.String(), "astok_") {
+			t.Fatalf("session list json exposes a session token: %s", stdout.String())
 		}
 	})
 
@@ -372,13 +381,17 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 			t.Fatalf("session list empty stdout = %q", stdout.String())
 		}
 	})
+}
+
+func TestAppSessionDestroy(t *testing.T) {
+	t.Parallel()
 
 	t.Run("destroy", func(t *testing.T) {
 		t.Parallel()
 
 		client := &appFakeDaemonClient{
 			sessionDestroyPayload: protocol.SessionDestroyResponsePayload{
-				SessionID: "asess_test",
+				SessionID: "asid_test",
 				Destroyed: true,
 			},
 		}
@@ -391,18 +404,48 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		var stderr bytes.Buffer
 		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
 
-		code := app.Run(context.Background(), []string{"session", "destroy", "asess_test"})
+		code := app.Run(context.Background(), []string{"session", "destroy", "asid_test"})
 		if code != 0 {
 			t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 		}
 		if client.sessionDestroyCalls != 1 || client.closeCalls != 1 {
 			t.Fatalf("client calls: destroy=%d close=%d", client.sessionDestroyCalls, client.closeCalls)
 		}
-		if len(client.sessionDestroyRequests) != 1 || client.sessionDestroyRequests[0].SessionID != "asess_test" {
+		if len(client.sessionDestroyRequests) != 1 || client.sessionDestroyRequests[0].SessionID != "asid_test" {
 			t.Fatalf("destroy requests = %+v", client.sessionDestroyRequests)
 		}
-		if !strings.Contains(stdout.String(), "destroyed session: asess_test") {
+		if !strings.Contains(stdout.String(), "destroyed session: asid_test") {
 			t.Fatalf("session destroy stdout = %q", stdout.String())
+		}
+	})
+
+	t.Run("destroy all", func(t *testing.T) {
+		t.Parallel()
+
+		client := &appFakeDaemonClient{
+			sessionDestroyPayload: protocol.SessionDestroyResponsePayload{
+				Destroyed:      true,
+				DestroyedCount: 2,
+			},
+		}
+		manager := &appFakeDaemonManager{
+			socketPath: filepath.Join(t.TempDir(), "d.sock"),
+			client:     client,
+			status:     protocol.StatusPayload{PID: 1234},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
+
+		code := app.Run(context.Background(), []string{"session", "destroy", "--all"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		}
+		if len(client.sessionDestroyRequests) != 1 || !client.sessionDestroyRequests[0].All {
+			t.Fatalf("destroy requests = %+v", client.sessionDestroyRequests)
+		}
+		if !strings.Contains(stdout.String(), "destroyed sessions: 2") {
+			t.Fatalf("session destroy --all stdout = %q", stdout.String())
 		}
 	})
 
@@ -411,7 +454,7 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 
 		client := &appFakeDaemonClient{
 			sessionDestroyPayload: protocol.SessionDestroyResponsePayload{
-				SessionID: "asess_test",
+				SessionID: "asid_test",
 				Destroyed: true,
 			},
 		}
@@ -424,7 +467,7 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		var stderr bytes.Buffer
 		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
 
-		code := app.Run(context.Background(), []string{"session", "destroy", "--json", "asess_test"})
+		code := app.Run(context.Background(), []string{"session", "destroy", "--json", "asid_test"})
 		if code != 0 {
 			t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 		}
@@ -432,7 +475,7 @@ func TestAppSessionListAndDestroy(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 			t.Fatalf("decode session destroy json: %v; stdout=%q", err, stdout.String())
 		}
-		if got.SessionID != "asess_test" || !got.Destroyed {
+		if got.SessionID != "asid_test" || !got.Destroyed {
 			t.Fatalf("session destroy json = %+v", got)
 		}
 	})
@@ -531,7 +574,7 @@ func TestAppSessionCommandFailures(t *testing.T) {
 		var stderr bytes.Buffer
 		app := newTestAppWithDaemonManager(manager, &stdout, &stderr)
 
-		code := app.Run(context.Background(), []string{"session", "destroy", "asess_missing"})
+		code := app.Run(context.Background(), []string{"session", "destroy", "asid_missing"})
 		if code != 1 {
 			t.Fatalf("exit code = %d, want 1", code)
 		}
@@ -555,7 +598,7 @@ func TestAppSessionCommandFailures(t *testing.T) {
 
 		code := app.Run(context.Background(), []string{
 			"with-session",
-			"asess_test",
+			"astok_test",
 			"--cwd", root,
 			"--allow-mutable-executable",
 			"--",
@@ -599,7 +642,7 @@ func TestAppWithSessionRunsChildWithResolvedEnv(t *testing.T) {
 
 	code := app.Run(context.Background(), []string{
 		"with-session",
-		"asess_test",
+		"astok_test",
 		"--cwd", root,
 		"--only", "TOKEN",
 		"--allow-mutable-executable",
@@ -619,7 +662,7 @@ func TestAppWithSessionRunsChildWithResolvedEnv(t *testing.T) {
 		t.Fatalf("session resolve requests = %d", len(client.sessionResolveRequests))
 	}
 	req := client.sessionResolveRequests[0]
-	if req.SessionID != "asess_test" || req.ExpectedPeer.PID <= 0 || req.CWD == "" {
+	if req.SessionToken != "astok_test" || req.ExpectedPeer.PID <= 0 || req.CWD == "" {
 		t.Fatalf("session resolve request = %+v", req)
 	}
 	if len(req.RequestedAliases) != 1 || req.RequestedAliases[0] != "TOKEN" {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1488,14 +1488,21 @@ func TestParseSessionListDestroyAndHelp(t *testing.T) {
 		t.Fatalf("session list command = %+v", listCommand)
 	}
 
-	destroyCommand, err := parser.Parse([]string{"session", "destroy", "--json", "asess_abc123"})
+	destroyCommand, err := parser.Parse([]string{"session", "destroy", "--json", "asid_abc123"})
 	if err != nil {
 		t.Fatalf("Parse session destroy returned error: %v", err)
 	}
 	if destroyCommand.Kind != KindSessionDestroy ||
 		!destroyCommand.OutputJSON ||
-		destroyCommand.SessionDestroyRequest.SessionID != "asess_abc123" {
+		destroyCommand.SessionDestroyRequest.SessionID != "asid_abc123" {
 		t.Fatalf("session destroy command = %+v", destroyCommand)
+	}
+	destroyAllCommand, err := parser.Parse([]string{"session", "destroy", "--all"})
+	if err != nil {
+		t.Fatalf("Parse session destroy --all returned error: %v", err)
+	}
+	if destroyAllCommand.Kind != KindSessionDestroy || !destroyAllCommand.SessionDestroyRequest.All {
+		t.Fatalf("session destroy --all command = %+v", destroyAllCommand)
 	}
 
 	for _, args := range [][]string{
@@ -1565,7 +1572,7 @@ func TestParseWithSessionRecordsRequestedAliases(t *testing.T) {
 
 	command, err := NewParser().Parse([]string{
 		"with-session",
-		"asess_abc123",
+		"astok_abc123",
 		"--cwd", root,
 		"--only", "B_TOKEN,A_TOKEN",
 		"--allow-mutable-executable",
@@ -1579,6 +1586,9 @@ func TestParseWithSessionRecordsRequestedAliases(t *testing.T) {
 		t.Fatalf("kind = %s, want with-session", command.Kind)
 	}
 	req := command.SessionResolveRequest
+	if req.SessionToken != "astok_abc123" {
+		t.Fatalf("session token = %q, want astok_abc123", req.SessionToken)
+	}
 	if strings.Join(req.RequestedAliases, ",") != "A_TOKEN,B_TOKEN" {
 		t.Fatalf("requested aliases = %v, want sorted A_TOKEN,B_TOKEN", req.RequestedAliases)
 	}
@@ -1595,12 +1605,14 @@ func TestParseSessionRejectsInvalidForms(t *testing.T) {
 	}{
 		{name: "unknown session command", args: []string{"session", "open"}, want: ErrInvalidArguments},
 		{name: "create child command", args: []string{"session", "create", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token", "--", "tool"}, want: ErrInvalidArguments},
-		{name: "list args", args: []string{"session", "list", "asess_abc"}, want: ErrInvalidArguments},
+		{name: "list args", args: []string{"session", "list", "asid_abc"}, want: ErrInvalidArguments},
 		{name: "destroy missing id", args: []string{"session", "destroy"}, want: ErrInvalidArguments},
 		{name: "destroy bad id", args: []string{"session", "destroy", "bad"}, want: request.ErrInvalidSessionID},
-		{name: "with-session missing boundary", args: []string{"with-session", "asess_abc", "tool"}, want: ErrShellStringCommand},
-		{name: "with-session missing command", args: []string{"with-session", "asess_abc", "--"}, want: ErrShellStringCommand},
-		{name: "with-session misplaced arg", args: []string{"with-session", "asess_abc", "extra", "--", "tool"}, want: ErrInvalidArguments},
+		{name: "destroy all with id", args: []string{"session", "destroy", "--all", "asid_abc"}, want: ErrInvalidArguments},
+		{name: "with-session public id", args: []string{"with-session", "asid_abc", "--", "tool"}, want: request.ErrInvalidSessionToken},
+		{name: "with-session missing boundary", args: []string{"with-session", "astok_abc", "tool"}, want: ErrShellStringCommand},
+		{name: "with-session missing command", args: []string{"with-session", "astok_abc", "--"}, want: ErrShellStringCommand},
+		{name: "with-session misplaced arg", args: []string{"with-session", "astok_abc", "extra", "--", "tool"}, want: ErrInvalidArguments},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1656,7 +1668,7 @@ func TestHelpIsDetailedAndValueFree(t *testing.T) {
 		{
 			name:  "with-session",
 			args:  []string{"with-session", "--help"},
-			wants: []string{"with-session SESSION_ID", "--cwd", "--only", "--allow-mutable-executable", "never printed"},
+			wants: []string{"with-session SESSION_TOKEN", "--cwd", "--only", "--allow-mutable-executable", "never printed"},
 		},
 		{
 			name:  "profile",

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -76,7 +76,7 @@ Safety rules:
   - exec --dry-run --json validates locally without starting the background helper, prompting, resolving values, or spawning the child.
   - exec --reuse-only uses a matching reusable approval or fails without opening a new approval prompt.
 	  - Text file/document refs such as op://Example/GitHub App/key.pem are injected as env values; binary attachments are not supported.
-	  - session create returns an opaque handle only; values stay in background helper memory and are injected only by with-session.
+	  - session create returns a public session id plus a secret session token; values stay in background helper memory and are injected only by with-session.
   - item describe requires approval and prints item metadata only: field labels, types, concealment flags, and refs.
   - agent-secret skill-install links the bundled Agent Secret skill into ~/.agents/skills/agent-secret.
   - Reusable approval is selected only in the approval UI, not by a CLI flag.
@@ -351,19 +351,21 @@ func SessionHelp() string {
 
 	Commands:
 
-	  create   Ask for approval, resolve requested refs, and return an opaque session id.
-	  list     List active sessions without session ids or working directories.
+	  create   Ask for approval, resolve requested refs, and return a session id plus token.
+	  list     List active session ids and non-secret metadata.
 	  destroy  Destroy one session and clear its cached values.
 
 	Examples:
 
 	  agent-secret session create --profile terraform-cloudflare --max-reads 2
-	  agent-secret with-session asess_123 -- terraform plan
-	  agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN,STATE_TOKEN -- terraform apply
-	  agent-secret session destroy asess_123
+	  agent-secret with-session astok_123 -- terraform plan
+	  agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN,STATE_TOKEN -- terraform apply
+	  agent-secret session destroy asid_123
+	  agent-secret session destroy --all
 
 	Values are never printed. Session values live in Agent Secret's background helper memory
-	until TTL, read count exhaustion, destroy, or helper stop.
+	until TTL, read count exhaustion, destroy, or helper stop. Session list shows
+	session ids for management, but never session tokens.
 	`)
 }
 
@@ -373,7 +375,7 @@ func WithSessionHelp() string {
 
 	Usage:
 
-	  agent-secret with-session SESSION_ID [--cwd DIR] [--only ALIAS[,ALIAS...]] -- COMMAND [ARG...]
+	  agent-secret with-session SESSION_TOKEN [--cwd DIR] [--only ALIAS[,ALIAS...]] -- COMMAND [ARG...]
 
 	Flags:
 
@@ -383,7 +385,7 @@ func WithSessionHelp() string {
 	                  Allow a user-owned or writable executable path after showing the approval warning.
 	  -h, --help      Show this help.
 
-	The session id must come from agent-secret session create. Secret values are
+	The session token must come from agent-secret session create. Secret values are
 	injected into the child environment only and are never printed by agent-secret.
 	Without --only, every approved session alias is injected for that command.
 	`)

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -352,7 +352,7 @@ func SessionHelp() string {
 	Commands:
 
 	  create   Ask for approval, resolve requested refs, and return an opaque session id.
-	  list     List active session ids and non-secret metadata.
+	  list     List active sessions without session ids or working directories.
 	  destroy  Destroy one session and clear its cached values.
 
 	Examples:

--- a/internal/cli/request_builder.go
+++ b/internal/cli/request_builder.go
@@ -134,7 +134,7 @@ func buildSessionCreateRequest(opts sessionCreateRequestBuildOptions) (request.S
 }
 
 type sessionResolveRequestBuildOptions struct {
-	sessionID              string
+	sessionToken           string
 	command                []string
 	cwd                    string
 	env                    []string
@@ -143,6 +143,9 @@ type sessionResolveRequestBuildOptions struct {
 }
 
 func buildSessionResolveRequest(opts sessionResolveRequestBuildOptions) (request.SessionResolveRequest, error) {
+	if err := request.ValidateSessionToken(opts.sessionToken); err != nil {
+		return request.SessionResolveRequest{}, err
+	}
 	cwd, err := normalizeCWD(opts.cwd)
 	if err != nil {
 		return request.SessionResolveRequest{}, err
@@ -165,7 +168,7 @@ func buildSessionResolveRequest(opts sessionResolveRequestBuildOptions) (request
 		return request.SessionResolveRequest{}, fmt.Errorf("%w: capture executable identity: %w", request.ErrInvalidCommand, err)
 	}
 	req, err := request.NewSessionResolve(
-		opts.sessionID,
+		opts.sessionToken,
 		command,
 		resolvedExecutable,
 		executableIdentity,

--- a/internal/cli/session_parse.go
+++ b/internal/cli/session_parse.go
@@ -170,7 +170,7 @@ func (p Parser) parseWithSession(args []string) (Command, error) {
 		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
 	}
 	if fs.NArg() != 0 {
-		return Command{}, fmt.Errorf("%w: with-session flags must appear after the session id and before --", ErrInvalidArguments)
+		return Command{}, fmt.Errorf("%w: with-session flags must appear after the session token and before --", ErrInvalidArguments)
 	}
 	env := os.Environ()
 	req, err := buildSessionResolveRequest(sessionResolveRequestBuildOptions{

--- a/internal/cli/session_parse.go
+++ b/internal/cli/session_parse.go
@@ -119,8 +119,15 @@ func parseSessionDestroy(args []string) (Command, error) {
 	fs := flag.NewFlagSet("session destroy", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	jsonOutput := fs.Bool("json", false, "print json")
+	all := fs.Bool("all", false, "destroy all active sessions")
 	if err := fs.Parse(args); err != nil {
 		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
+	}
+	if *all {
+		if fs.NArg() != 0 {
+			return Command{}, fmt.Errorf("%w: session destroy --all does not accept a session id", ErrInvalidArguments)
+		}
+		return Command{Kind: KindSessionDestroy, OutputJSON: *jsonOutput, SessionDestroyRequest: request.NewSessionDestroyAll()}, nil
 	}
 	if fs.NArg() != 1 {
 		return Command{}, fmt.Errorf("%w: session destroy requires one session id", ErrInvalidArguments)
@@ -134,7 +141,7 @@ func parseSessionDestroy(args []string) (Command, error) {
 
 func (p Parser) parseWithSession(args []string) (Command, error) {
 	if len(args) == 0 {
-		return Command{}, fmt.Errorf("%w: with-session requires a session id and -- command", ErrInvalidArguments)
+		return Command{}, fmt.Errorf("%w: with-session requires a session token and -- command", ErrInvalidArguments)
 	}
 	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
 		return Command{Kind: KindHelp, HelpText: WithSessionHelp()}, ErrHelpRequested
@@ -147,7 +154,7 @@ func (p Parser) parseWithSession(args []string) (Command, error) {
 	if len(commandArgs) == 0 {
 		return Command{}, ErrShellStringCommand
 	}
-	sessionID := args[0]
+	sessionToken := args[0]
 	var flags withSessionFlags
 	fs := flag.NewFlagSet("with-session", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -167,7 +174,7 @@ func (p Parser) parseWithSession(args []string) (Command, error) {
 	}
 	env := os.Environ()
 	req, err := buildSessionResolveRequest(sessionResolveRequestBuildOptions{
-		sessionID:              sessionID,
+		sessionToken:           sessionToken,
 		command:                commandArgs,
 		cwd:                    flags.cwd,
 		env:                    env,

--- a/internal/daemon/broker/broker.go
+++ b/internal/daemon/broker/broker.go
@@ -844,9 +844,7 @@ func sessionCreatePayload(summary request.SessionSummary) protocol.SessionCreate
 
 func sessionInfoPayload(summary request.SessionSummary) protocol.SessionInfoPayload {
 	return protocol.SessionInfoPayload{
-		SessionID:      summary.SessionID,
 		Reason:         summary.Reason,
-		CWD:            summary.CWD,
 		SecretAliases:  slices.Clone(summary.SecretAliases),
 		ExpiresAt:      summary.ExpiresAt,
 		MaxReads:       summary.MaxReads,

--- a/internal/daemon/broker/broker.go
+++ b/internal/daemon/broker/broker.go
@@ -215,7 +215,7 @@ func (b *Broker) PrepareSessionResolve(
 	}
 	activeReq := execRequestFromSessionResolve(req, reservation)
 	if err := b.activateExec(correlation, activeReq); err != nil {
-		b.sessions.finishReservation(reservation.SessionID, false)
+		b.sessions.finishReservation(reservation.SessionToken, false)
 		return nil, err
 	}
 	delivery := &SessionResolveDelivery{
@@ -258,6 +258,7 @@ func (d *SessionResolveDelivery) BeforeWrite(ctx context.Context) error {
 		d.req,
 		auditRefsForIdentities(d.reservation.Secrets, uniqueSecretIdentities(d.reservation.Secrets)),
 	)
+	event.SessionID = d.reservation.SessionID
 	event.RemainingReads = &d.reservation.RemainingReads
 	event.MaxReads = &d.reservation.MaxReads
 	if err := recordRequiredAudit(ctx, d.broker.audit, event); err != nil {
@@ -271,14 +272,14 @@ func (d *SessionResolveDelivery) BeforeWrite(ctx context.Context) error {
 
 func (d *SessionResolveDelivery) CommitDelivered() {
 	d.finalizeOnce.Do(func() {
-		d.broker.sessions.finishReservation(d.reservation.SessionID, true)
+		d.broker.sessions.finishReservation(d.reservation.SessionToken, true)
 	})
 }
 
 func (d *SessionResolveDelivery) AbortBeforePayload() {
 	d.finalizeOnce.Do(func() {
 		d.broker.deactivateExec(d.correlation)
-		d.broker.sessions.finishReservation(d.reservation.SessionID, false)
+		d.broker.sessions.finishReservation(d.reservation.SessionToken, false)
 	})
 }
 
@@ -289,6 +290,17 @@ func (b *Broker) HandleSessionDestroy(ctx context.Context, req request.SessionDe
 	if err := preflightRequiredAudit(ctx, b.audit); err != nil {
 		return protocol.SessionDestroyResponsePayload{}, err
 	}
+	if req.All {
+		count := b.sessions.destroyAll()
+		event := audit.Event{
+			Type: audit.EventSessionDestroyed,
+		}
+		if err := recordRequiredAudit(ctx, b.audit, event); err != nil {
+			return protocol.SessionDestroyResponsePayload{}, err
+		}
+		return protocol.SessionDestroyResponsePayload{Destroyed: true, DestroyedCount: count}, nil
+	}
+
 	destroyed := b.sessions.destroy(req.SessionID)
 	event := audit.Event{
 		Type:      audit.EventSessionDestroyed,
@@ -835,6 +847,7 @@ func execRequestFromSessionResolve(req request.SessionResolveRequest, reservatio
 func sessionCreatePayload(summary request.SessionSummary) protocol.SessionCreateResponsePayload {
 	return protocol.SessionCreateResponsePayload{
 		SessionID:      summary.SessionID,
+		SessionToken:   summary.SessionToken,
 		SecretAliases:  slices.Clone(summary.SecretAliases),
 		ExpiresAt:      summary.ExpiresAt,
 		MaxReads:       summary.MaxReads,
@@ -844,7 +857,9 @@ func sessionCreatePayload(summary request.SessionSummary) protocol.SessionCreate
 
 func sessionInfoPayload(summary request.SessionSummary) protocol.SessionInfoPayload {
 	return protocol.SessionInfoPayload{
+		SessionID:      summary.SessionID,
 		Reason:         summary.Reason,
+		CWD:            summary.CWD,
 		SecretAliases:  slices.Clone(summary.SecretAliases),
 		ExpiresAt:      summary.ExpiresAt,
 		MaxReads:       summary.MaxReads,

--- a/internal/daemon/broker/session_store.go
+++ b/internal/daemon/broker/session_store.go
@@ -23,14 +23,16 @@ var (
 )
 
 type sessionStore struct {
-	mu       sync.Mutex
-	now      func() time.Time
-	random   io.Reader
-	sessions map[string]*sessionRecord
+	mu            sync.Mutex
+	now           func() time.Time
+	random        io.Reader
+	sessions      map[string]*sessionRecord
+	sessionTokens map[string]*sessionRecord
 }
 
 type sessionRecord struct {
 	ID            string
+	Token         string
 	Reason        string
 	CWD           string
 	Secrets       []request.Secret
@@ -45,6 +47,7 @@ type sessionRecord struct {
 
 type sessionReservation struct {
 	SessionID      string
+	SessionToken   string
 	Reason         string
 	CWD            string
 	Secrets        []request.Secret
@@ -61,9 +64,10 @@ func newSessionStore(now func() time.Time) *sessionStore {
 		now = time.Now
 	}
 	return &sessionStore{
-		now:      now,
-		random:   rand.Reader,
-		sessions: make(map[string]*sessionRecord),
+		now:           now,
+		random:        rand.Reader,
+		sessions:      make(map[string]*sessionRecord),
+		sessionTokens: make(map[string]*sessionRecord),
 	}
 }
 
@@ -75,8 +79,13 @@ func (s *sessionStore) create(req request.SessionCreateRequest, env map[string]s
 	if err != nil {
 		return request.SessionSummary{}, err
 	}
+	token, err := s.randomToken()
+	if err != nil {
+		return request.SessionSummary{}, err
+	}
 	record := &sessionRecord{
 		ID:            id,
+		Token:         token,
 		Reason:        req.Reason,
 		CWD:           req.CWD,
 		Secrets:       slices.Clone(req.Secrets),
@@ -87,6 +96,7 @@ func (s *sessionStore) create(req request.SessionCreateRequest, env map[string]s
 		OverrideEnv:   req.OverrideEnv,
 	}
 	s.sessions[id] = record
+	s.sessionTokens[token] = record
 	return record.summary(), nil
 }
 
@@ -98,19 +108,19 @@ func (s *sessionStore) reserve(req request.SessionResolveRequest, peer peercred.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record, ok := s.sessions[req.SessionID]
+	record, ok := s.sessionTokens[req.SessionToken]
 	if !ok {
 		return sessionReservation{}, ErrSessionNotFound
 	}
 	if !s.now().Before(record.ExpiresAt) {
-		delete(s.sessions, record.ID)
+		s.deleteRecord(record)
 		return sessionReservation{}, approval.ErrRequestExpired
 	}
 	if record.CWD != req.CWD {
 		return sessionReservation{}, fmt.Errorf("%w: cwd %q != %q", ErrSessionPeerMismatch, req.CWD, record.CWD)
 	}
 	if record.Reads+record.ReservedReads >= record.MaxReads {
-		delete(s.sessions, record.ID)
+		s.deleteRecord(record)
 		return sessionReservation{}, ErrSessionReadExhausted
 	}
 
@@ -121,6 +131,7 @@ func (s *sessionStore) reserve(req request.SessionResolveRequest, peer peercred.
 	record.ReservedReads++
 	return sessionReservation{
 		SessionID:      record.ID,
+		SessionToken:   record.Token,
 		Reason:         record.Reason,
 		CWD:            record.CWD,
 		Secrets:        secrets,
@@ -133,11 +144,11 @@ func (s *sessionStore) reserve(req request.SessionResolveRequest, peer peercred.
 	}, nil
 }
 
-func (s *sessionStore) finishReservation(sessionID string, delivered bool) {
+func (s *sessionStore) finishReservation(sessionToken string, delivered bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record, ok := s.sessions[sessionID]
+	record, ok := s.sessionTokens[sessionToken]
 	if !ok || record.ReservedReads <= 0 {
 		return
 	}
@@ -146,7 +157,7 @@ func (s *sessionStore) finishReservation(sessionID string, delivered bool) {
 		record.Reads++
 	}
 	if record.Reads >= record.MaxReads || !s.now().Before(record.ExpiresAt) {
-		delete(s.sessions, sessionID)
+		s.deleteRecord(record)
 	}
 }
 
@@ -157,8 +168,18 @@ func (s *sessionStore) destroy(sessionID string) bool {
 	if _, ok := s.sessions[sessionID]; !ok {
 		return false
 	}
-	delete(s.sessions, sessionID)
+	s.deleteRecord(s.sessions[sessionID])
 	return true
+}
+
+func (s *sessionStore) destroyAll() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	count := len(s.sessions)
+	s.sessions = make(map[string]*sessionRecord)
+	s.sessionTokens = make(map[string]*sessionRecord)
+	return count
 }
 
 func (s *sessionStore) list() []request.SessionSummary {
@@ -167,9 +188,9 @@ func (s *sessionStore) list() []request.SessionSummary {
 
 	now := s.now()
 	summaries := make([]request.SessionSummary, 0, len(s.sessions))
-	for id, record := range s.sessions {
+	for _, record := range s.sessions {
 		if !now.Before(record.ExpiresAt) || record.Reads+record.ReservedReads >= record.MaxReads {
-			delete(s.sessions, id)
+			s.deleteRecord(record)
 			continue
 		}
 		summaries = append(summaries, record.summary())
@@ -190,15 +211,26 @@ func (s *sessionStore) clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessions = make(map[string]*sessionRecord)
+	s.sessionTokens = make(map[string]*sessionRecord)
 }
 
 func (s *sessionStore) randomID() (string, error) {
-	return randid.Generate(s.random, "asess")
+	return randid.Generate(s.random, "asid")
+}
+
+func (s *sessionStore) randomToken() (string, error) {
+	return randid.Generate(s.random, "astok")
+}
+
+func (s *sessionStore) deleteRecord(record *sessionRecord) {
+	delete(s.sessions, record.ID)
+	delete(s.sessionTokens, record.Token)
 }
 
 func (s sessionRecord) summary() request.SessionSummary {
 	return request.SessionSummary{
 		SessionID:      s.ID,
+		SessionToken:   s.Token,
 		Reason:         s.Reason,
 		CWD:            s.CWD,
 		SecretAliases:  slices.Clone(s.SecretAliases),

--- a/internal/daemon/broker/session_test.go
+++ b/internal/daemon/broker/session_test.go
@@ -34,12 +34,12 @@ func TestBrokerSessionCreateResolveConsumesReadAndAuditsCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HandleSessionCreate returned error: %v", err)
 	}
-	if created.SessionID == "" || created.RemainingReads != 1 {
+	if created.SessionID == "" || created.SessionToken == "" || created.RemainingReads != 1 {
 		t.Fatalf("created session payload = %+v", created)
 	}
 
 	peer := testSessionPeer(t, createReq.CWD)
-	resolveReq := testSessionResolveRequest(t, created.SessionID, createReq.CWD, peer)
+	resolveReq := testSessionResolveRequest(t, created.SessionToken, createReq.CWD, peer)
 	delivery, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), resolveReq, peer)
 	if err != nil {
 		t.Fatalf("PrepareSessionResolve returned error: %v", err)
@@ -109,7 +109,7 @@ func TestBrokerSessionResolveFiltersRequestedAliases(t *testing.T) {
 	}
 
 	peer := testSessionPeer(t, createReq.CWD)
-	missingReq := testSessionResolveRequest(t, created.SessionID, createReq.CWD, peer)
+	missingReq := testSessionResolveRequest(t, created.SessionToken, createReq.CWD, peer)
 	missingReq, err = missingReq.WithRequestedAliases([]string{"MISSING_TOKEN"})
 	if err != nil {
 		t.Fatalf("WithRequestedAliases returned error: %v", err)
@@ -118,7 +118,7 @@ func TestBrokerSessionResolveFiltersRequestedAliases(t *testing.T) {
 		t.Fatalf("missing alias PrepareSessionResolve error = %v, want ErrInvalidAlias", err)
 	}
 
-	resolveReq := testSessionResolveRequest(t, created.SessionID, createReq.CWD, peer)
+	resolveReq := testSessionResolveRequest(t, created.SessionToken, createReq.CWD, peer)
 	resolveReq, err = resolveReq.WithRequestedAliases([]string{"B_TOKEN", "A_TOKEN"})
 	if err != nil {
 		t.Fatalf("WithRequestedAliases returned error: %v", err)
@@ -175,7 +175,7 @@ func TestBrokerSessionResolveAbortRestoresRead(t *testing.T) {
 		t.Fatalf("HandleSessionCreate returned error: %v", err)
 	}
 	peer := testSessionPeer(t, createReq.CWD)
-	resolveReq := testSessionResolveRequest(t, created.SessionID, createReq.CWD, peer)
+	resolveReq := testSessionResolveRequest(t, created.SessionToken, createReq.CWD, peer)
 
 	first, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), resolveReq, peer)
 	if err != nil {
@@ -216,7 +216,10 @@ func TestBrokerSessionListAndDestroy(t *testing.T) {
 	if len(listed.Sessions) != 1 {
 		t.Fatalf("listed sessions = %+v, want one active session", listed.Sessions)
 	}
-	if listed.Sessions[0].RemainingReads != 2 || listed.Sessions[0].SecretAliases[0] != "TOKEN" {
+	if listed.Sessions[0].SessionID != created.SessionID ||
+		listed.Sessions[0].CWD != createReq.CWD ||
+		listed.Sessions[0].RemainingReads != 2 ||
+		listed.Sessions[0].SecretAliases[0] != "TOKEN" {
 		t.Fatalf("listed session metadata = %+v", listed.Sessions[0])
 	}
 
@@ -238,8 +241,29 @@ func TestBrokerSessionListAndDestroy(t *testing.T) {
 		t.Fatalf("second HandleSessionDestroy error = %v, want ErrSessionNotFound", err)
 	}
 
+	createdAgain, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create_again", "nonce_create_again"), createReq)
+	if err != nil {
+		t.Fatalf("second HandleSessionCreate returned error: %v", err)
+	}
+	destroyedAll, err := broker.HandleSessionDestroy(context.Background(), request.NewSessionDestroyAll())
+	if err != nil {
+		t.Fatalf("HandleSessionDestroy --all returned error: %v", err)
+	}
+	if !destroyedAll.Destroyed || destroyedAll.DestroyedCount != 1 {
+		t.Fatalf("destroy all payload = %+v", destroyedAll)
+	}
+	if _, err := broker.HandleSessionDestroy(context.Background(), request.SessionDestroyRequest{SessionID: createdAgain.SessionID}); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("destroy after --all error = %v, want ErrSessionNotFound", err)
+	}
+
 	got := auditEventTypes(aud.Events())
 	want := []audit.EventType{
+		audit.EventApprovalRequested,
+		audit.EventApprovalGranted,
+		audit.EventSecretFetchStarted,
+		audit.EventSessionCreated,
+		audit.EventSessionDestroyed,
+		audit.EventSessionDestroyed,
 		audit.EventApprovalRequested,
 		audit.EventApprovalGranted,
 		audit.EventSecretFetchStarted,
@@ -309,8 +333,9 @@ func TestSessionStoreListPrunesExpiredAndExhaustedSessions(t *testing.T) {
 
 	now := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
 	store := newSessionStore(func() time.Time { return now })
-	store.sessions["asess_live_b"] = &sessionRecord{
-		ID:            "asess_live_b",
+	store.sessions["asid_live_b"] = &sessionRecord{
+		ID:            "asid_live_b",
+		Token:         "astok_live_b",
 		Reason:        "Deploy",
 		CWD:           "/tmp/project",
 		SecretAliases: []string{"TOKEN"},
@@ -318,24 +343,27 @@ func TestSessionStoreListPrunesExpiredAndExhaustedSessions(t *testing.T) {
 		MaxReads:      2,
 		Reads:         1,
 	}
-	store.sessions["asess_live_a"] = &sessionRecord{
-		ID:            "asess_live_a",
+	store.sessions["asid_live_a"] = &sessionRecord{
+		ID:            "asid_live_a",
+		Token:         "astok_live_a",
 		Reason:        "Deploy",
 		CWD:           "/tmp/project",
 		SecretAliases: []string{"TOKEN"},
 		ExpiresAt:     now.Add(time.Minute),
 		MaxReads:      2,
 	}
-	store.sessions["asess_expired"] = &sessionRecord{
-		ID:            "asess_expired",
+	store.sessions["asid_expired"] = &sessionRecord{
+		ID:            "asid_expired",
+		Token:         "astok_expired",
 		Reason:        "Deploy",
 		CWD:           "/tmp/project",
 		SecretAliases: []string{"TOKEN"},
 		ExpiresAt:     now,
 		MaxReads:      2,
 	}
-	store.sessions["asess_exhausted"] = &sessionRecord{
-		ID:            "asess_exhausted",
+	store.sessions["asid_exhausted"] = &sessionRecord{
+		ID:            "asid_exhausted",
+		Token:         "astok_exhausted",
 		Reason:        "Deploy",
 		CWD:           "/tmp/project",
 		SecretAliases: []string{"TOKEN"},
@@ -348,16 +376,16 @@ func TestSessionStoreListPrunesExpiredAndExhaustedSessions(t *testing.T) {
 	if len(summaries) != 2 {
 		t.Fatalf("list returned %d sessions: %+v", len(summaries), summaries)
 	}
-	if summaries[0].SessionID != "asess_live_a" || summaries[1].SessionID != "asess_live_b" {
+	if summaries[0].SessionID != "asid_live_a" || summaries[1].SessionID != "asid_live_b" {
 		t.Fatalf("sessions not sorted by id for equal expiry: %+v", summaries)
 	}
 	if summaries[0].RemainingReads != 2 || summaries[1].RemainingReads != 1 {
 		t.Fatalf("remaining reads mismatch: %+v", summaries)
 	}
-	if _, ok := store.sessions["asess_expired"]; ok {
+	if _, ok := store.sessions["asid_expired"]; ok {
 		t.Fatal("expired session was not pruned")
 	}
-	if _, ok := store.sessions["asess_exhausted"]; ok {
+	if _, ok := store.sessions["asid_exhausted"]; ok {
 		t.Fatal("exhausted session was not pruned")
 	}
 }
@@ -397,7 +425,7 @@ func testSessionCreateRequest(
 
 func testSessionResolveRequest(
 	t *testing.T,
-	sessionID string,
+	sessionToken string,
 	cwd string,
 	peer peercred.Info,
 ) request.SessionResolveRequest {
@@ -408,7 +436,7 @@ func testSessionResolveRequest(
 		t.Fatalf("capture executable identity: %v", err)
 	}
 	req, err := request.NewSessionResolve(
-		sessionID,
+		sessionToken,
 		[]string{exe, "-test.run=TestBrokerSessionCreateResolveConsumesReadAndAuditsCommand", "--", "child"},
 		exe,
 		identity,

--- a/internal/daemon/broker/session_test.go
+++ b/internal/daemon/broker/session_test.go
@@ -213,8 +213,8 @@ func TestBrokerSessionListAndDestroy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HandleSessionList returned error: %v", err)
 	}
-	if len(listed.Sessions) != 1 || listed.Sessions[0].SessionID != created.SessionID {
-		t.Fatalf("listed sessions = %+v, want created session %s", listed.Sessions, created.SessionID)
+	if len(listed.Sessions) != 1 {
+		t.Fatalf("listed sessions = %+v, want one active session", listed.Sessions)
 	}
 	if listed.Sessions[0].RemainingReads != 2 || listed.Sessions[0].SecretAliases[0] != "TOKEN" {
 		t.Fatalf("listed session metadata = %+v", listed.Sessions[0])

--- a/internal/daemon/control/client.go
+++ b/internal/daemon/control/client.go
@@ -194,6 +194,12 @@ func (c *Client) DestroySession(ctx context.Context, req request.SessionDestroyR
 	if err != nil {
 		return protocol.SessionDestroyResponsePayload{}, err
 	}
+	if req.All {
+		if !payload.Destroyed || payload.SessionID != "" {
+			return protocol.SessionDestroyResponsePayload{}, fmt.Errorf("%w: session.destroy --all response does not match request", protocol.ErrMalformedEnvelope)
+		}
+		return payload, nil
+	}
 	if payload.SessionID != req.SessionID || !payload.Destroyed {
 		return protocol.SessionDestroyResponsePayload{}, fmt.Errorf("%w: session.destroy response does not match request", protocol.ErrMalformedEnvelope)
 	}
@@ -355,6 +361,9 @@ func validateExecResponsePayload(payload protocol.ExecResponsePayload, req reque
 func validateSessionCreateResponsePayload(payload protocol.SessionCreateResponsePayload, req request.SessionCreateRequest) error {
 	if err := request.ValidateSessionID(payload.SessionID); err != nil {
 		return fmt.Errorf("%w: invalid session id in session.create response: %w", protocol.ErrMalformedEnvelope, err)
+	}
+	if err := request.ValidateSessionToken(payload.SessionToken); err != nil {
+		return fmt.Errorf("%w: invalid session token in session.create response: %w", protocol.ErrMalformedEnvelope, err)
 	}
 	expectedAliases := request.SecretAliases(req.Secrets)
 	if !slices.Equal(payload.SecretAliases, expectedAliases) {

--- a/internal/daemon/control/client_test.go
+++ b/internal/daemon/control/client_test.go
@@ -728,9 +728,7 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 			requests <- env
 			return okResponseFrame(t, env, protocol.SessionListResponsePayload{
 				Sessions: []protocol.SessionInfoPayload{{
-					SessionID:      "asess_abc123",
 					Reason:         "Deploy workflow",
-					CWD:            "/tmp/project",
 					SecretAliases:  []string{"TOKEN"},
 					ExpiresAt:      time.Now().Add(time.Minute),
 					MaxReads:       2,
@@ -744,7 +742,7 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ListSessions returned error: %v", err)
 		}
-		if len(payload.Sessions) != 1 || payload.Sessions[0].SessionID != "asess_abc123" {
+		if len(payload.Sessions) != 1 || payload.Sessions[0].RemainingReads != 1 {
 			t.Fatalf("unexpected list payload: %+v", payload)
 		}
 		env := receiveStalledRequest(t, requests)

--- a/internal/daemon/control/client_test.go
+++ b/internal/daemon/control/client_test.go
@@ -101,7 +101,7 @@ func testSessionResolveRequest(t *testing.T) request.SessionResolveRequest {
 	t.Helper()
 
 	req, err := request.NewSessionResolve(
-		"asess_abc123",
+		"astok_abc123",
 		[]string{"/opt/homebrew/bin/terraform", "plan"},
 		"/opt/homebrew/bin/terraform",
 		fileidentity.Identity{Device: 2, Inode: 2, Mode: 0o755},
@@ -450,6 +450,7 @@ func TestClientValidatesPayloadOKResponseShape(t *testing.T) {
 
 				return okResponseFrame(t, env, protocol.SessionCreateResponsePayload{
 					SessionID:      "bad",
+					SessionToken:   "astok_abc123",
 					SecretAliases:  []string{"TOKEN"},
 					MaxReads:       sessionCreateReq.MaxReads,
 					RemainingReads: sessionCreateReq.MaxReads,
@@ -462,12 +463,32 @@ func TestClientValidatesPayloadOKResponseShape(t *testing.T) {
 			wantErrMsg: "invalid session id",
 		},
 		{
+			name: "session create token",
+			frame: func(t *testing.T, env protocol.Envelope) []byte {
+				t.Helper()
+
+				return okResponseFrame(t, env, protocol.SessionCreateResponsePayload{
+					SessionID:      "asid_abc123",
+					SessionToken:   "bad",
+					SecretAliases:  []string{"TOKEN"},
+					MaxReads:       sessionCreateReq.MaxReads,
+					RemainingReads: sessionCreateReq.MaxReads,
+				})
+			},
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.CreateSession(ctx, testCorrelation("req_1", "nonce_1"), sessionCreateReq)
+				return err
+			},
+			wantErrMsg: "invalid session token",
+		},
+		{
 			name: "session create aliases",
 			frame: func(t *testing.T, env protocol.Envelope) []byte {
 				t.Helper()
 
 				return okResponseFrame(t, env, protocol.SessionCreateResponsePayload{
-					SessionID:      "asess_abc123",
+					SessionID:      "asid_abc123",
+					SessionToken:   "astok_abc123",
 					SecretAliases:  []string{"OTHER"},
 					MaxReads:       sessionCreateReq.MaxReads,
 					RemainingReads: sessionCreateReq.MaxReads,
@@ -485,7 +506,8 @@ func TestClientValidatesPayloadOKResponseShape(t *testing.T) {
 				t.Helper()
 
 				return okResponseFrame(t, env, protocol.SessionCreateResponsePayload{
-					SessionID:      "asess_abc123",
+					SessionID:      "asid_abc123",
+					SessionToken:   "astok_abc123",
 					SecretAliases:  []string{"TOKEN"},
 					MaxReads:       sessionCreateReq.MaxReads,
 					RemainingReads: 1,
@@ -590,7 +612,7 @@ func TestClientDescribeItemRoundTripsPayload(t *testing.T) {
 	}
 }
 
-func TestClientSessionRoundTripsPayloads(t *testing.T) {
+func TestClientSessionCreateAndResolveRoundTripsPayloads(t *testing.T) {
 	t.Parallel()
 
 	t.Run("create", func(t *testing.T) {
@@ -601,7 +623,8 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 		client, cleanup := startRespondingDaemonClient(t, func(env protocol.Envelope) []byte {
 			requests <- env
 			return okResponseFrame(t, env, protocol.SessionCreateResponsePayload{
-				SessionID:      "asess_abc123",
+				SessionID:      "asid_abc123",
+				SessionToken:   "astok_abc123",
 				SecretAliases:  []string{"TOKEN"},
 				ExpiresAt:      req.ExpiresAt,
 				MaxReads:       2,
@@ -614,7 +637,7 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CreateSession returned error: %v", err)
 		}
-		if payload.SessionID != "asess_abc123" || payload.RemainingReads != 2 {
+		if payload.SessionID != "asid_abc123" || payload.SessionToken != "astok_abc123" || payload.RemainingReads != 2 {
 			t.Fatalf("unexpected create payload: %+v", payload)
 		}
 		env := receiveStalledRequest(t, requests)
@@ -664,7 +687,7 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 		if err != nil {
 			t.Fatalf("decode session resolve request: %v", err)
 		}
-		if got.SessionID != req.SessionID || got.CWD != req.CWD {
+		if got.SessionToken != req.SessionToken || got.CWD != req.CWD {
 			t.Fatalf("unexpected session resolve request: %+v", got)
 		}
 		if len(got.RequestedAliases) != 1 || got.RequestedAliases[0] != "TOKEN" {
@@ -692,16 +715,20 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 			t.Fatalf("ResolveSession error = %v, want ErrMalformedEnvelope", err)
 		}
 	})
+}
+
+func TestClientSessionManagementRoundTripsPayloads(t *testing.T) {
+	t.Parallel()
 
 	t.Run("destroy", func(t *testing.T) {
 		t.Parallel()
 
-		req := request.SessionDestroyRequest{SessionID: "asess_abc123"}
+		req := request.SessionDestroyRequest{SessionID: "asid_abc123"}
 		requests := make(chan protocol.Envelope, 1)
 		client, cleanup := startRespondingDaemonClient(t, func(env protocol.Envelope) []byte {
 			requests <- env
 			return okResponseFrame(t, env, protocol.SessionDestroyResponsePayload{
-				SessionID: "asess_abc123",
+				SessionID: "asid_abc123",
 				Destroyed: true,
 			})
 		})
@@ -720,6 +747,33 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 		}
 	})
 
+	t.Run("destroy all", func(t *testing.T) {
+		t.Parallel()
+
+		req := request.NewSessionDestroyAll()
+		requests := make(chan protocol.Envelope, 1)
+		client, cleanup := startRespondingDaemonClient(t, func(env protocol.Envelope) []byte {
+			requests <- env
+			return okResponseFrame(t, env, protocol.SessionDestroyResponsePayload{
+				Destroyed:      true,
+				DestroyedCount: 2,
+			})
+		})
+		defer cleanup()
+
+		payload, err := client.DestroySession(context.Background(), req)
+		if err != nil {
+			t.Fatalf("DestroySession --all returned error: %v", err)
+		}
+		if !payload.Destroyed || payload.DestroyedCount != 2 {
+			t.Fatalf("unexpected destroy all payload: %+v", payload)
+		}
+		env := receiveStalledRequest(t, requests)
+		if env.Type != protocol.TypeSessionDestroy {
+			t.Fatalf("request type = %s, want %s", env.Type, protocol.TypeSessionDestroy)
+		}
+	})
+
 	t.Run("list", func(t *testing.T) {
 		t.Parallel()
 
@@ -728,7 +782,9 @@ func TestClientSessionRoundTripsPayloads(t *testing.T) {
 			requests <- env
 			return okResponseFrame(t, env, protocol.SessionListResponsePayload{
 				Sessions: []protocol.SessionInfoPayload{{
+					SessionID:      "asid_abc123",
 					Reason:         "Deploy workflow",
+					CWD:            "/tmp/project",
 					SecretAliases:  []string{"TOKEN"},
 					ExpiresAt:      time.Now().Add(time.Minute),
 					MaxReads:       2,

--- a/internal/daemon/protocol/protocol.go
+++ b/internal/daemon/protocol/protocol.go
@@ -106,6 +106,7 @@ type ExecResponsePayload struct {
 
 type SessionCreateResponsePayload struct {
 	SessionID      string    `json:"session_id"`
+	SessionToken   string    `json:"session_token"`
 	SecretAliases  []string  `json:"secret_aliases"`
 	ExpiresAt      time.Time `json:"expires_at"`
 	MaxReads       int       `json:"max_reads"`
@@ -119,8 +120,9 @@ type SessionResolveResponsePayload struct {
 }
 
 type SessionDestroyResponsePayload struct {
-	SessionID string `json:"session_id"`
-	Destroyed bool   `json:"destroyed"`
+	SessionID      string `json:"session_id,omitempty"`
+	Destroyed      bool   `json:"destroyed"`
+	DestroyedCount int    `json:"destroyed_count,omitempty"`
 }
 
 type SessionListResponsePayload struct {
@@ -128,7 +130,9 @@ type SessionListResponsePayload struct {
 }
 
 type SessionInfoPayload struct {
+	SessionID      string    `json:"session_id"`
 	Reason         string    `json:"reason"`
+	CWD            string    `json:"cwd"`
 	SecretAliases  []string  `json:"secret_aliases"`
 	ExpiresAt      time.Time `json:"expires_at"`
 	MaxReads       int       `json:"max_reads"`

--- a/internal/daemon/protocol/protocol.go
+++ b/internal/daemon/protocol/protocol.go
@@ -128,9 +128,7 @@ type SessionListResponsePayload struct {
 }
 
 type SessionInfoPayload struct {
-	SessionID      string    `json:"session_id"`
 	Reason         string    `json:"reason"`
-	CWD            string    `json:"cwd"`
 	SecretAliases  []string  `json:"secret_aliases"`
 	ExpiresAt      time.Time `json:"expires_at"`
 	MaxReads       int       `json:"max_reads"`

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -389,10 +389,10 @@ func TestServerSessionListAndDestroyProtocol(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSessions returned error: %v", err)
 	}
-	if len(listed.Sessions) != 1 || listed.Sessions[0].SessionID != created.SessionID {
-		t.Fatalf("listed sessions = %+v, want %s", listed.Sessions, created.SessionID)
+	if len(listed.Sessions) != 1 {
+		t.Fatalf("listed sessions = %+v, want one active session", listed.Sessions)
 	}
-	if listed.Sessions[0].RemainingReads != 2 || listed.Sessions[0].CWD != cwd {
+	if listed.Sessions[0].RemainingReads != 2 {
 		t.Fatalf("listed session metadata = %+v", listed.Sessions[0])
 	}
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -228,7 +228,7 @@ func TestServerSessionProtocolLifecycle(t *testing.T) {
 	peer := peerInfoForTest(t, os.Getpid(), peerExe)
 	peer.CWD = cwd
 	resolveReq, err := request.NewSessionResolve(
-		created.SessionID,
+		created.SessionToken,
 		[]string{exe, "-test.run=TestServerSessionProtocolLifecycle", "--", "child"},
 		exe,
 		identity,
@@ -315,7 +315,7 @@ func TestServerSessionResolveRejectsUnapprovedAliasProjection(t *testing.T) {
 		t.Fatalf("CreateSession returned error: %v", err)
 	}
 	resolveReq, err := request.NewSessionResolve(
-		created.SessionID,
+		created.SessionToken,
 		[]string{exe, "-test.run=TestServerSessionResolveRejectsUnapprovedAliasProjection", "--", "child"},
 		exe,
 		identity,
@@ -392,7 +392,9 @@ func TestServerSessionListAndDestroyProtocol(t *testing.T) {
 	if len(listed.Sessions) != 1 {
 		t.Fatalf("listed sessions = %+v, want one active session", listed.Sessions)
 	}
-	if listed.Sessions[0].RemainingReads != 2 {
+	if listed.Sessions[0].SessionID != created.SessionID ||
+		listed.Sessions[0].CWD != cwd ||
+		listed.Sessions[0].RemainingReads != 2 {
 		t.Fatalf("listed session metadata = %+v", listed.Sessions[0])
 	}
 

--- a/internal/request/session.go
+++ b/internal/request/session.go
@@ -18,11 +18,15 @@ const (
 )
 
 var (
-	ErrInvalidSessionID   = fmt.Errorf("%w: invalid session id", ErrInvalidRequest)
-	ErrInvalidSessionRead = fmt.Errorf("%w: invalid session read count", ErrInvalidRequest)
+	ErrInvalidSessionID    = fmt.Errorf("%w: invalid session id", ErrInvalidRequest)
+	ErrInvalidSessionToken = fmt.Errorf("%w: invalid session token", ErrInvalidRequest)
+	ErrInvalidSessionRead  = fmt.Errorf("%w: invalid session read count", ErrInvalidRequest)
 )
 
-var sessionIDPattern = regexp.MustCompile(`^asess_[A-Za-z0-9_-]+$`)
+var (
+	sessionIDPattern    = regexp.MustCompile(`^asid_[A-Za-z0-9_-]+$`)
+	sessionTokenPattern = regexp.MustCompile(`^astok_[A-Za-z0-9_-]+$`)
+)
 
 type SessionCreateOptions struct {
 	Reason             string
@@ -52,7 +56,7 @@ type SessionCreateRequest struct {
 }
 
 type SessionResolveRequest struct {
-	SessionID              string                `json:"session_id"`
+	SessionToken           string                `json:"session_token"`
 	Command                []string              `json:"command"`
 	ResolvedExecutable     string                `json:"resolved_executable"`
 	ExecutableIdentity     fileidentity.Identity `json:"executable_identity"`
@@ -63,11 +67,13 @@ type SessionResolveRequest struct {
 }
 
 type SessionDestroyRequest struct {
-	SessionID string `json:"session_id"`
+	SessionID string `json:"session_id,omitempty"`
+	All       bool   `json:"all,omitempty"`
 }
 
 type SessionSummary struct {
 	SessionID      string    `json:"session_id"`
+	SessionToken   string    `json:"session_token,omitempty"`
 	Reason         string    `json:"reason"`
 	CWD            string    `json:"cwd"`
 	SecretAliases  []string  `json:"secret_aliases"`
@@ -177,14 +183,14 @@ func (r SessionCreateRequest) ValidateForDaemon() error {
 }
 
 func NewSessionResolve(
-	sessionID string,
+	sessionToken string,
 	command []string,
 	resolvedExecutable string,
 	executableIdentity fileidentity.Identity,
 	cwd string,
 	environmentFingerprint string,
 ) (SessionResolveRequest, error) {
-	if err := ValidateSessionID(sessionID); err != nil {
+	if err := ValidateSessionToken(sessionToken); err != nil {
 		return SessionResolveRequest{}, err
 	}
 	if len(command) == 0 || command[0] == "" {
@@ -203,7 +209,7 @@ func NewSessionResolve(
 		return SessionResolveRequest{}, err
 	}
 	return SessionResolveRequest{
-		SessionID:              sessionID,
+		SessionToken:           sessionToken,
 		Command:                slices.Clone(command),
 		ResolvedExecutable:     resolvedExecutable,
 		ExecutableIdentity:     executableIdentity,
@@ -227,7 +233,7 @@ func (r SessionResolveRequest) WithRequestedAliases(aliases []string) (SessionRe
 }
 
 func (r SessionResolveRequest) ValidateForDaemon() error {
-	if err := ValidateSessionID(r.SessionID); err != nil {
+	if err := ValidateSessionToken(r.SessionToken); err != nil {
 		return err
 	}
 	if len(r.Command) == 0 || r.Command[0] == "" {
@@ -266,13 +272,30 @@ func NewSessionDestroy(sessionID string) (SessionDestroyRequest, error) {
 	return req, nil
 }
 
+func NewSessionDestroyAll() SessionDestroyRequest {
+	return SessionDestroyRequest{All: true}
+}
+
 func (r SessionDestroyRequest) ValidateForDaemon() error {
+	if r.All {
+		if r.SessionID != "" {
+			return fmt.Errorf("%w: --all cannot be combined with a session id", ErrInvalidRequest)
+		}
+		return nil
+	}
 	return ValidateSessionID(r.SessionID)
 }
 
 func ValidateSessionID(sessionID string) error {
 	if !sessionIDPattern.MatchString(sessionID) {
 		return fmt.Errorf("%w: %q", ErrInvalidSessionID, sessionID)
+	}
+	return nil
+}
+
+func ValidateSessionToken(sessionToken string) error {
+	if !sessionTokenPattern.MatchString(sessionToken) {
+		return fmt.Errorf("%w: %q", ErrInvalidSessionToken, sessionToken)
 	}
 	return nil
 }

--- a/internal/request/session_test.go
+++ b/internal/request/session_test.go
@@ -120,7 +120,7 @@ func TestSessionResolveValidation(t *testing.T) {
 	env := []string{"PATH=" + filepath.Dir(bin), "TOKEN=existing"}
 
 	req, err := NewSessionResolve(
-		"asess_abc123",
+		"astok_abc123",
 		[]string{bin, "plan"},
 		bin,
 		identity,
@@ -159,7 +159,7 @@ func TestSessionResolveRejectsInvalidRequestedAliases(t *testing.T) {
 	dir := testResolvedDir(t)
 	bin, identity := testExecutable(t, dir, "terraform")
 	req, err := NewSessionResolve(
-		"asess_abc123",
+		"astok_abc123",
 		[]string{bin, "plan"},
 		bin,
 		identity,
@@ -195,27 +195,28 @@ func TestSessionResolveRejectsInvalidInputs(t *testing.T) {
 	fingerprint := EnvironmentFingerprint([]string{"PATH=" + filepath.Dir(bin)})
 
 	tests := []struct {
-		name      string
-		sessionID string
-		command   []string
-		exe       string
-		identity  fileidentity.Identity
-		cwd       string
-		env       string
-		want      error
+		name         string
+		sessionToken string
+		command      []string
+		exe          string
+		identity     fileidentity.Identity
+		cwd          string
+		env          string
+		want         error
 	}{
-		{name: "bad session id", sessionID: "session_abc", command: []string{bin}, exe: bin, identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidSessionID},
-		{name: "missing command", sessionID: "asess_abc", command: nil, exe: bin, identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidCommand},
-		{name: "relative cwd", sessionID: "asess_abc", command: []string{bin}, exe: bin, identity: identity, cwd: "deploy", env: fingerprint, want: ErrInvalidRequest},
-		{name: "relative executable", sessionID: "asess_abc", command: []string{bin}, exe: "terraform", identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidRequest},
-		{name: "missing identity", sessionID: "asess_abc", command: []string{bin}, exe: bin, identity: fileidentity.Identity{}, cwd: dir, env: fingerprint, want: ErrInvalidRequest},
-		{name: "bad env fingerprint", sessionID: "asess_abc", command: []string{bin}, exe: bin, identity: identity, cwd: dir, env: "sha256:bad", want: ErrInvalidRequest},
+		{name: "bad session token", sessionToken: "session_abc", command: []string{bin}, exe: bin, identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidSessionToken},
+		{name: "session id is not a token", sessionToken: "asid_abc", command: []string{bin}, exe: bin, identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidSessionToken},
+		{name: "missing command", sessionToken: "astok_abc", command: nil, exe: bin, identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidCommand},
+		{name: "relative cwd", sessionToken: "astok_abc", command: []string{bin}, exe: bin, identity: identity, cwd: "deploy", env: fingerprint, want: ErrInvalidRequest},
+		{name: "relative executable", sessionToken: "astok_abc", command: []string{bin}, exe: "terraform", identity: identity, cwd: dir, env: fingerprint, want: ErrInvalidRequest},
+		{name: "missing identity", sessionToken: "astok_abc", command: []string{bin}, exe: bin, identity: fileidentity.Identity{}, cwd: dir, env: fingerprint, want: ErrInvalidRequest},
+		{name: "bad env fingerprint", sessionToken: "astok_abc", command: []string{bin}, exe: bin, identity: identity, cwd: dir, env: "sha256:bad", want: ErrInvalidRequest},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := NewSessionResolve(tt.sessionID, tt.command, tt.exe, tt.identity, tt.cwd, tt.env)
+			_, err := NewSessionResolve(tt.sessionToken, tt.command, tt.exe, tt.identity, tt.cwd, tt.env)
 			if !errors.Is(err, tt.want) {
 				t.Fatalf("NewSessionResolve error = %v, want %v", err, tt.want)
 			}
@@ -229,7 +230,7 @@ func TestSessionResolveDaemonValidationRejectsMissingPeerMetadata(t *testing.T) 
 	dir := testResolvedDir(t)
 	bin, identity := testExecutable(t, dir, "terraform")
 	req, err := NewSessionResolve(
-		"asess_abc",
+		"astok_abc",
 		[]string{bin},
 		bin,
 		identity,
@@ -248,18 +249,34 @@ func TestSessionResolveDaemonValidationRejectsMissingPeerMetadata(t *testing.T) 
 func TestSessionDestroyValidation(t *testing.T) {
 	t.Parallel()
 
-	req, err := NewSessionDestroy("asess_abc123")
+	req, err := NewSessionDestroy("asid_abc123")
 	if err != nil {
 		t.Fatalf("NewSessionDestroy returned error: %v", err)
 	}
-	if req.SessionID != "asess_abc123" {
+	if req.SessionID != "asid_abc123" {
 		t.Fatalf("session id = %q", req.SessionID)
 	}
 	if err := req.ValidateForDaemon(); err != nil {
 		t.Fatalf("ValidateForDaemon returned error: %v", err)
 	}
-	if err := ValidateSessionID("asess_abc-DEF_123"); err != nil {
+	if err := ValidateSessionID("asid_abc-DEF_123"); err != nil {
 		t.Fatalf("ValidateSessionID returned error: %v", err)
+	}
+	if err := ValidateSessionToken("astok_abc-DEF_123"); err != nil {
+		t.Fatalf("ValidateSessionToken returned error: %v", err)
+	}
+	if err := ValidateSessionID("astok_abc-DEF_123"); !errors.Is(err, ErrInvalidSessionID) {
+		t.Fatalf("ValidateSessionID with token error = %v, want ErrInvalidSessionID", err)
+	}
+	all := NewSessionDestroyAll()
+	if !all.All || all.SessionID != "" {
+		t.Fatalf("destroy all request = %+v", all)
+	}
+	if err := all.ValidateForDaemon(); err != nil {
+		t.Fatalf("destroy all ValidateForDaemon returned error: %v", err)
+	}
+	if err := (SessionDestroyRequest{SessionID: "asid_abc123", All: true}).ValidateForDaemon(); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("destroy all with id error = %v, want ErrInvalidRequest", err)
 	}
 	_, err = NewSessionDestroy("bad")
 	if !errors.Is(err, ErrInvalidSessionID) {

--- a/site/docs.html
+++ b/site/docs.html
@@ -212,24 +212,25 @@ profiles:
             <p>
               Sessions are for short workflows where an agent needs the same
               approved set of references in different combinations. Agent
-              Secret stores values in background helper memory and returns only
-              an opaque session ID.
+              Secret stores values in background helper memory and returns a
+              public session ID for management plus a secret session token for
+              <code>with-session</code>.
             </p>
             <div class="code-panel">
               <pre><code>agent-secret session create --profile terraform-cloudflare --max-reads 3
-agent-secret with-session asess_123 --only CLOUDFLARE_API_TOKEN -- terraform plan
-agent-secret with-session asess_123 \
+agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- terraform plan
+agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
   -- terraform apply
-agent-secret session destroy asess_123</code></pre>
+agent-secret session destroy asid_123</code></pre>
             </div>
             <p>
               <code>session create</code> can combine a project profile, env
               files, and one-off <code>--secret ALIAS=REF</code> flags.
-              Keep the returned handle for later <code>with-session</code> or
-              <code>session destroy</code> calls; <code>session list</code>
-              reports active-session metadata without revealing session IDs or
-              working directories.
+              Keep the returned <code>session_token</code> for
+              <code>with-session</code>; use the listed <code>session_id</code>
+              for inspection and cleanup. <code>session list</code> never
+              reveals session tokens.
               <code>with-session</code> injects every approved alias by default,
               or a per-command subset with <code>--only</code>. Unknown aliases
               fail before the child command starts.

--- a/site/docs.html
+++ b/site/docs.html
@@ -222,15 +222,16 @@ agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- terraform pla
 agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
   -- terraform apply
+agent-secret session list
 agent-secret session destroy asid_123</code></pre>
             </div>
             <p>
               <code>session create</code> can combine a project profile, env
               files, and one-off <code>--secret ALIAS=REF</code> flags.
               Keep the returned <code>session_token</code> for
-              <code>with-session</code>; use the listed <code>session_id</code>
-              for inspection and cleanup. <code>session list</code> never
-              reveals session tokens.
+              <code>with-session</code>; use the returned or listed
+              <code>session_id</code> for inspection and cleanup.
+              <code>session list</code> never reveals session tokens.
               <code>with-session</code> injects every approved alias by default,
               or a per-command subset with <code>--only</code>. Unknown aliases
               fail before the child command starts.

--- a/site/docs.html
+++ b/site/docs.html
@@ -226,6 +226,10 @@ agent-secret session destroy asess_123</code></pre>
             <p>
               <code>session create</code> can combine a project profile, env
               files, and one-off <code>--secret ALIAS=REF</code> flags.
+              Keep the returned handle for later <code>with-session</code> or
+              <code>session destroy</code> calls; <code>session list</code>
+              reports active-session metadata without revealing session IDs or
+              working directories.
               <code>with-session</code> injects every approved alias by default,
               or a per-command subset with <code>--only</code>. Unknown aliases
               fail before the child command starts.

--- a/site/index.html
+++ b/site/index.html
@@ -362,7 +362,7 @@ profiles:
               <li>The background helper fetches only the secrets you approved for the request.</li>
               <li>Audit logs record metadata, never raw secrets.</li>
               <li>Reusable approvals stay bounded by command, cwd, references, account, TTL, and use count.</li>
-              <li>Sessions stay bounded by cwd, aliases, TTL, read count, opaque handles, and the <code>with-session</code> wrapper.</li>
+              <li>Sessions stay bounded by cwd, aliases, TTL, read count, secret tokens, and the <code>with-session</code> wrapper.</li>
             </ul>
           </div>
           <div>

--- a/site/index.html
+++ b/site/index.html
@@ -362,7 +362,7 @@ profiles:
               <li>The background helper fetches only the secrets you approved for the request.</li>
               <li>Audit logs record metadata, never raw secrets.</li>
               <li>Reusable approvals stay bounded by command, cwd, references, account, TTL, and use count.</li>
-              <li>Sessions stay bounded by cwd, aliases, TTL, read count, and the <code>with-session</code> wrapper.</li>
+              <li>Sessions stay bounded by cwd, aliases, TTL, read count, opaque handles, and the <code>with-session</code> wrapper.</li>
             </ul>
           </div>
           <div>


### PR DESCRIPTION
## Summary

Fixes the session authorization issue by splitting bounded sessions into two identifiers:

- `session_id`: public management identifier shown by `session list` and accepted by `session destroy`.
- `session_token`: secret bearer token returned only by `session create` and accepted by `with-session`.

This keeps the session list useful for inspection and cleanup without making it an enumeration surface for active resolve capabilities. `with-session` now rejects public `session_id` values before contacting the daemon.

## Changes

- Generate distinct `asid_...` session IDs and `astok_...` session tokens.
- Store sessions by both ID and token internally; resolve consumes only the token, while list/destroy operate on the ID.
- Restore useful `session list` metadata, including `session_id` and `cwd`, while ensuring list output never includes `session_token`.
- Add `agent-secret session destroy --all` for clearing all active background-helper sessions.
- Update CLI help, agent-context metadata, README, configuration docs, PRD/runbook, threat model, security policy, implementation-plan/security-review docs, site copy, changelog, and bundled Agent Secret skill.
- Add regression coverage for token validation, list non-disclosure, destroy-by-ID, destroy-all, and audit behavior.

## Validation

- `mise exec -- go test ./internal/request ./internal/daemon/broker ./internal/daemon/control ./internal/daemon ./internal/cli ./internal/audit`
- `npx --yes markdownlint-cli CHANGELOG.md README.md docs/configuration.md docs/session-e2e-validation.md docs/threat-model.md docs/prd.md docs/implementation-plan.md .agents/skills/agent-secret/SKILL.md`
- `npx --yes markdownlint-cli SECURITY.md README.md docs/configuration.md docs/implementation-plan.md docs/security-boundary-review-2026-05-05.md .agents/skills/agent-secret/SKILL.md`
- `rg -n "asess_|opaque session|session handle|Session Handles|with-session SESSION_ID|without revealing session IDs|session IDs or working directories|active session handles|resolve handles|return handles|session id and before|unshipped session handles" --glob '!_dist/**' --glob '!tmp/**' .` returned no matches
- `mise exec -- go test ./...`
- `mise exec -- go test ./internal/daemon/control -run 'TestManagerRepairRefreshesRepairableUnexpectedHelper|TestManagerRepairRefusesRepairableUnexpectedHelperWithoutReleaseTeamID' -count=1`
- `mise run lint`
- `mise run build`
- commit hook: gitleaks, gofmt, go vet, golangci-lint, markdownlint
