### PR TITLE
Bind sessions to requester process trees

### DIFF
--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -465,7 +465,9 @@ Before reporting success, prove the migrated path works:
   full `with-session` invocation, any `with-session --only` subsets, and
   session exhaustion or `session destroy`. Run session create and session use
   from the same task shell or wrapper script so the process-tree binding is
-  exercised.
+  exercised. For product or release validation, run
+  `docs/session-e2e-validation.md` and confirm the detached process-tree replay
+  attempt is rejected before the child command starts.
 - For `--env-file` migrations, test that the real command receives both a
   secret-backed variable and at least one plain env-file variable without
   printing either secret value.

--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -139,14 +139,14 @@ aliases needed by that child command. Unknown aliases fail before the child
 process starts. Use `session destroy SESSION_ID` for one session or
 `session destroy --all` to clear every active session.
 
-Treat `session_token` as a short-lived bearer capability. Keep it in the current
-task context or a local shell variable only for the duration of the bounded
-workflow; do not write it to repo files, durable agent memory, PR comments,
-logs, `.env` files, or documentation. Keep the public `session_id` separately
-for cleanup. If separate processes must share the token, use a private per-user
-temporary file outside the repo with mode `0600`, delete it during cleanup, and
-prefer `session destroy SESSION_ID` or `session destroy --all` when the workflow
-is done.
+Treat `session_token` as a short-lived secret capability bound to the requester
+process tree that created the session. Create and consume a session inside the
+same task shell, wrapper script, or agent process tree. Keep the token in a
+local shell variable only for the duration of the bounded workflow; do not write
+it to repo files, durable agent memory, PR comments, logs, `.env` files, or
+documentation. Keep the public `session_id` separately for cleanup. Prefer
+`session destroy SESSION_ID` or `session destroy --all` when the workflow is
+done.
 
 Use a shell only when the shell is the command you actually want approved:
 
@@ -463,7 +463,9 @@ Before reporting success, prove the migrated path works:
   `--only` wrapper that filters aliases.
 - For session workflows, test `session create`, `session list`, at least one
   full `with-session` invocation, any `with-session --only` subsets, and
-  session exhaustion or `session destroy`.
+  session exhaustion or `session destroy`. Run session create and session use
+  from the same task shell or wrapper script so the process-tree binding is
+  exercised.
 - For `--env-file` migrations, test that the real command receives both a
   secret-backed variable and at least one plain env-file variable without
   printing either secret value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ file before a release is published.
 - Expanded the release session E2E runbook to require multi-secret session
   validation and a detached process-tree replay rejection check before release.
 
+### Fixed
+
+- Reduced false session rejections when requester ancestry changes during
+  validation by accepting a caller once the approved process-tree anchor has
+  already been observed.
+- Kept same-executable subshell anchor skipping intact even when an ineligible
+  intermediate process appears between shell ancestors.
+
 ### Security
 
 - Bound session token use to the process tree that created the approved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ file before a release is published.
 - Added public FAQ guidance comparing Agent Secret's approval-broker model with
   Varlock and fnox.
 
+### Security
+
+- Bound session token use to the process tree that created the approved
+  session, so an unrelated same-user process cannot replay an observed
+  `session_token` from the same working directory.
+
 ## [0.0.24] - 2026-06-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ file before a release is published.
 
 - Added public FAQ guidance comparing Agent Secret's approval-broker model with
   Varlock and fnox.
+- Expanded the release session E2E runbook to require multi-secret session
+  validation and a detached process-tree replay rejection check before release.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ agent-secret session destroy asid_123
 Keep the `session_token` returned by `session create` for `with-session`.
 Use the `session_id` returned by `session create` or shown by `session list`
 for inspection and cleanup. `session list` never shows session tokens.
+Session tokens are accepted only from the requester process tree that created
+the session, so create and use them inside the same task shell, wrapper script,
+or agent process tree.
 
 Inspect item metadata without revealing values:
 
@@ -203,8 +206,9 @@ precedence, env-file migration, and the full schema.
 - `agent-secret session create|list|destroy`: manage bounded background-helper
   sessions.
 - `agent-secret with-session SESSION_TOKEN -- COMMAND [ARG...]`: run one command
-  with secrets from an approved session. Add `--only ALIAS[,ALIAS...]` to inject
-  a per-command subset of the approved session bag.
+  with secrets from an approved session and requester process tree. Add
+  `--only ALIAS[,ALIAS...]` to inject a per-command subset of the approved
+  session bag.
 - `agent-secret item describe REF`: inspect 1Password item fields without
   values.
 - `agent-secret agent-context --json`: print a machine-readable command and
@@ -260,8 +264,9 @@ The launch build is intentionally narrow:
 
 - macOS on Apple Silicon only.
 - 1Password Desktop and Bitwarden Secrets Manager only; no other providers yet.
-- Sessions are bounded, background-helper-memory only, and usable only through
-  `agent-secret with-session`; no long-lived interactive shells.
+- Sessions are bounded by requester process tree, cwd, TTL, read count, aliases,
+  background-helper memory, and `agent-secret with-session`; no long-lived
+  interactive shells.
 - No writing, updating, or rotating secrets yet.
 - No GCP Secret Manager or GCP token minting support yet.
 - No sandbox guarantee after you approve a child process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,8 @@ The supported runtime scope is narrow:
 - 1Password Desktop integration through the official 1Password SDK.
 - CLI-supervised `agent-secret exec` with environment injection.
 - Bounded background-helper sessions through `session create`, `session list`,
-  `session destroy`, and `with-session`.
+  `session destroy`, and `with-session`, with token use bound to the requester
+  process tree that created the session.
 
 Linux, Windows, credential helpers, automatic updates, and alternative secret
 backends are not supported security surfaces yet.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,8 +307,8 @@ value and env-var delivery does not support binary attachments with NUL bytes.
 
 Sessions approve one bag of secret references, keep the resolved values in
 Agent Secret's background helper memory, and let later child commands consume
-that bag only through `agent-secret with-session`. Use them for bounded
-workflows where a user
+that bag only through `agent-secret with-session` from the same requester
+process tree. Use them for bounded workflows where a user
 approves several secrets once and subsequent commands need those secrets in
 different combinations.
 
@@ -361,8 +361,9 @@ agent-secret with-session astok_123 \
 
 - `session_id`: a management identifier shown by `session list` and accepted by
   `session destroy`.
-- `session_token`: a secret bearer token accepted by `with-session` and never
-  shown by `session list`.
+- `session_token`: a secret token accepted by `with-session` only from the
+  requester process tree that created the session. It is never shown by
+  `session list`.
 
 It does not print secret values. `session list` shows active `session_id` values
 and non-secret metadata for inspection and cleanup. Without `--only`,
@@ -373,7 +374,9 @@ child command.
 
 `with-session` accepts `--cwd DIR`, `--only ALIAS[,ALIAS...]`, and
 `--allow-mutable-executable`. The `--cwd` value defaults to the caller's current
-directory and must match the session working directory.
+directory and must match the session working directory. The caller must also be
+inside the same requester process tree that ran `session create`; keep session
+creation and use inside one task shell, wrapper script, or agent process tree.
 
 Sessions are background-helper-memory only. They expire when TTL passes, the
 read count is exhausted, `agent-secret session destroy SESSION_ID` or

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -132,8 +132,9 @@ ansible-playbook site.yml --check
 
 The user approves once for a TTL and max-read count. The broker returns a
 public `session_id` for management plus a secret `session_token` for
-`agent-secret with-session`, keeps values in Agent Secret's background helper
-memory, and injects them only into the approved child process.
+`agent-secret with-session` calls from the approved requester process tree,
+keeps values in Agent Secret's background helper memory, and injects them only
+into wrapped child processes.
 V1 sessions do not add generic socket reads or credential-helper protocols.
 
 ### Use Case 3: Config-Driven Secret Sync
@@ -680,16 +681,16 @@ Limitations:
 The broker creates a short-lived session and returns a public `session_id` for
 list/destroy operations plus a secret `session_token` instead of values. Values
 stay in Agent Secret's background helper memory and are useful only through
-`agent-secret with-session`, matching peer credentials, cwd, remaining read
-count, and unexpired policy.
+`agent-secret with-session`, matching requester process tree, peer credentials,
+cwd, remaining read count, and unexpired policy.
 
 Unlike same-command reuse, sessions approve a bounded set of references for a
 workflow lifetime and allow those approved references to be injected into
 multiple wrapped commands, subject to TTL, max-read, peer, and destroy policy.
 On macOS, session resolution must fail closed unless the daemon can validate the
-same UID, peer PID, executable path, cwd, TTL, and read count against the
-approved session. Session values must clear when TTL expires, read counts are
-exhausted, the daemon stops, or the session is destroyed.
+same UID, trusted wrapper peer, requester process tree, cwd, TTL, and read count
+against the approved session. Session values must clear when TTL expires, read
+counts are exhausted, the daemon stops, or the session is destroyed.
 
 ### Mode 3: `with-session`
 
@@ -942,8 +943,8 @@ MVP requirements:
 - stale socket cleanup on startup
 - request envelopes with protocol version and message type
 - session create/resolve/list/destroy over the daemon command socket, with
-  `session.resolve` restricted to `with-session` wrappers that provide complete
-  expected peer metadata
+  `session.resolve` restricted to `with-session` wrappers from the approved
+  requester process tree that provide complete expected peer metadata
 
 Future raw session socket requirements:
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -61,6 +61,12 @@ lives in `AGENT_SECRET_IN_MISE=1 scripts/release/test-release-notes.sh`.
    mise run build
    ```
 
+1. Run the bounded-session product E2E in
+   `docs/session-e2e-validation.md` before tagging. The run must include
+   multi-secret session creation from config plus CLI args, same-tree
+   `with-session` reuse, and the checkpoint:
+   `detached process-tree replay rejected before child spawn`.
+
 1. Run the mixed-install helper recovery smoke before tagging. This catches the
    common local-operator state where the installed release background helper is
    valid but an ad-hoc development CLI is earlier on `PATH`:
@@ -237,6 +243,11 @@ AGENT_SECRET_IN_MISE=1 scripts/release/test-homebrew-cask.sh
 AGENT_SECRET_IN_MISE=1 scripts/release/test-homebrew-cask-audit.sh
 cd approver && swift run agent-secret-app-smoke
 ```
+
+The live bounded-session product E2E is documented in
+`docs/session-e2e-validation.md`. Run it manually before release tags because
+it requires the real native approver, test-only 1Password refs, and a macOS
+user launchd session for the detached process-tree replay check.
 
 The Homebrew cask should also be checked after every cask bump:
 

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -32,8 +32,9 @@ present.
 ## Run
 
 The script creates a temporary project config with one secret from a profile and
-adds the second secret with a CLI `--secret` flag. Approve the native prompts
-when they appear.
+adds the second secret with a CLI `--secret` flag. It creates and consumes each
+session inside one shell so `with-session` runs from the approved requester
+process tree. Approve the native prompts when they appear.
 
 <!-- markdownlint-disable MD013 -->
 
@@ -300,6 +301,8 @@ This E2E run proves:
   sessions without values or session tokens.
 - `with-session` injects the full approved bag when `--only` is omitted.
 - `with-session --only` injects config-only, CLI-only, and combined subsets.
+- `with-session` accepts session tokens from the same requester process tree
+  that created the session.
 - Unknown aliases fail before the child process starts.
 - `session destroy` prevents further resolution.
 - Read exhaustion prevents further resolution.

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -1,8 +1,8 @@
 # Session E2E Validation
 
-Use this runbook to manually re-test bounded sessions against the real
-CLI, background helper, native approver, provider resolver, audit log, and
-child-process environment injection path.
+Use this runbook to manually re-test bounded sessions against the real CLI,
+background helper, native approver, provider resolver, audit log,
+child-process environment injection path, and requester process-tree binding.
 
 The test uses two test-only secret references. It never prints resolved values.
 The child commands only assert whether expected environment variables are
@@ -29,12 +29,18 @@ present.
    - `op://Agent Secret Integration/Test Secret/password`
    - `op://Agent Secret Integration/Another Test Secret/password`
 
+4. Run from a macOS user session where `launchctl submit` can start a per-user
+   helper job. The detached replay check intentionally launches a requester
+   outside the shell that created the session.
+
 ## Run
 
 The script creates a temporary project config with one secret from a profile and
 adds the second secret with a CLI `--secret` flag. It creates and consumes each
 session inside one shell so `with-session` runs from the approved requester
-process tree. Approve the native prompts when they appear.
+process tree, then submits a launchd helper to prove the same token cannot be
+used from a different requester process tree. Approve the native prompts when
+they appear.
 
 <!-- markdownlint-disable MD013 -->
 
@@ -43,14 +49,20 @@ set -euo pipefail
 
 profile_ref="${AGENT_SECRET_E2E_PROFILE_REF:-op://Agent Secret Integration/Test Secret/password}"
 cli_ref="${AGENT_SECRET_E2E_CLI_REF:-op://Agent Secret Integration/Another Test Secret/password}"
+agent_secret_bin="$(command -v agent-secret)"
 
 workdir="$(mktemp -d "${TMPDIR:-/tmp}/agent-secret-session-e2e.XXXXXX")"
+chmod 700 "$workdir"
 SESSION_ID=""
 SESSION_TOKEN=""
 EXHAUST_ID=""
 EXHAUST_TOKEN=""
+DETACHED_LABEL=""
 
 cleanup() {
+  if [[ -n "${DETACHED_LABEL:-}" ]]; then
+    launchctl remove "$DETACHED_LABEL" >/dev/null 2>&1 || true
+  fi
   if [[ -n "${SESSION_ID:-}" ]]; then
     agent-secret session destroy "$SESSION_ID" >/dev/null 2>&1 || true
   fi
@@ -135,6 +147,71 @@ run_with_session "$SESSION_TOKEN" \
   --only SESSION_E2E_PROFILE_TOKEN \
   --allow-mutable-executable \
   -- python3 -c "$check_py" profile
+
+detached_dir="$workdir/detached-replay"
+mkdir -p "$detached_dir"
+chmod 700 "$detached_dir"
+detached_helper="$detached_dir/replay.sh"
+detached_token_file="$detached_dir/session-token"
+detached_output="$detached_dir/output"
+detached_status="$detached_dir/status"
+printf '%s' "$SESSION_TOKEN" > "$detached_token_file"
+chmod 600 "$detached_token_file"
+cat > "$detached_helper" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+agent_secret_bin="$1"
+workdir="$2"
+token_file="$3"
+output_file="$4"
+status_file="$5"
+
+cd "$workdir"
+token="$(cat "$token_file")"
+set +e
+env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
+  "$agent_secret_bin" with-session "$token" \
+    --only SESSION_E2E_PROFILE_TOKEN \
+    --allow-mutable-executable \
+    -- python3 -c 'print("UNEXPECTED_CHILD_STARTED")' \
+    >"$output_file" 2>&1
+exit_code="$?"
+set -e
+printf '%s\n' "$exit_code" > "$status_file"
+SH
+chmod 700 "$detached_helper"
+
+DETACHED_LABEL="com.kovyrin.agent-secret.session-e2e.$RANDOM.$RANDOM"
+launchctl submit -l "$DETACHED_LABEL" -- \
+  "$detached_helper" \
+  "$agent_secret_bin" \
+  "$workdir" \
+  "$detached_token_file" \
+  "$detached_output" \
+  "$detached_status"
+for _ in {1..150}; do
+  if [[ -f "$detached_status" ]]; then
+    break
+  fi
+  sleep 0.1
+done
+launchctl remove "$DETACHED_LABEL" >/dev/null 2>&1 || true
+DETACHED_LABEL=""
+if [[ ! -f "$detached_status" ]]; then
+  echo 'BUG: detached replay attempt did not finish' >&2
+  exit 1
+fi
+detached_rc="$(tr -d '[:space:]' < "$detached_status")"
+if [[ "$detached_rc" == "0" ]]; then
+  echo 'BUG: detached process-tree replay unexpectedly succeeded' >&2
+  exit 1
+fi
+if grep -q 'UNEXPECTED_CHILD_STARTED' "$detached_output"; then
+  echo 'BUG: detached process-tree replay spawned child' >&2
+  exit 1
+fi
+echo 'detached process-tree replay rejected before child spawn'
 
 missing_output="$workdir/missing-alias.out"
 if run_with_session "$SESSION_TOKEN" \
@@ -280,6 +357,7 @@ created mixed config+CLI session: asid_...
 session list ok
 full ok
 profile ok
+detached process-tree replay rejected before child spawn
 missing alias rejected before child spawn
 cli ok
 both ok
@@ -303,6 +381,8 @@ This E2E run proves:
 - `with-session --only` injects config-only, CLI-only, and combined subsets.
 - `with-session` accepts session tokens from the same requester process tree
   that created the session.
+- The same `session_token` is rejected before child spawn when a detached
+  launchd job from a different requester process tree tries to replay it.
 - Unknown aliases fail before the child process starts.
 - `session destroy` prevents further resolution.
 - Read exhaustion prevents further resolution.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -106,8 +106,9 @@ Agent Secret must meet these goals:
   behavior.
 - Reusable approvals expire at their TTL, consume uses correctly, and clear
   cached raw values when exhausted, expired, or rolled back.
-- Bounded session tokens are returned only at `session create` time and are not
-  enumerable through session listing.
+- Bounded session tokens are returned only at `session create` time, are not
+  enumerable through session listing, and are usable only from the requester
+  process tree that created the session.
 - The daemon accepts exec and stop requests only from trusted Agent Secret CLI
   executables.
 - The CLI accepts secret-bearing responses only from a trusted Agent Secret

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -106,7 +106,7 @@ func (a App) runAgentContext(command Command) int {
 				"secret values are never printed by agent-secret",
 				"exec passes child stdin/stdout/stderr through unchanged",
 				"item describe returns metadata only",
-				"session create returns a public session id and secret session token; with-session never prints values",
+				"session create returns a public session id and secret session token bound to the requester process tree; with-session never prints values",
 			},
 			MutationBoundary: []string{
 				"exec --dry-run validates without prompting or spawning",
@@ -220,7 +220,7 @@ func agentContextCommands() map[string]commandContext {
 						{Name: "--json", Type: "bool", Description: "Print session metadata as JSON."},
 					},
 					Outputs: []string{"text", "json"},
-					Notes:   []string{"returns a public session id for management and a secret session token for with-session", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
+					Notes:   []string{"returns a public session id for management and a secret session token bound to the requester process tree for with-session", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
 				},
 				"list": {
 					Summary: "List active session ids and non-secret metadata.",
@@ -243,7 +243,7 @@ func agentContextCommands() map[string]commandContext {
 				{Name: "--allow-mutable-executable", Type: "bool", Description: "Allow a user-owned or writable executable path after surfacing the approval warning."},
 			},
 			Outputs: []string{"child passthrough"},
-			Notes:   []string{"usage: agent-secret with-session SESSION_TOKEN -- COMMAND [ARG...]", "session values are injected into the child environment and never printed"},
+			Notes:   []string{"usage: agent-secret with-session SESSION_TOKEN -- COMMAND [ARG...]", "caller must be in the requester process tree that created the session", "session values are injected into the child environment and never printed"},
 		},
 		"bitwarden": {
 			Summary: "Manage local Bitwarden Secrets Manager token aliases.",

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -3280,6 +3280,25 @@ func (appAllowPeer) Validate(_ *net.UnixConn) error {
 	return nil
 }
 
+type appSessionPeerAuthorizer struct{}
+
+func (appSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (daemonbroker.SessionPeerBinding, error) {
+	return daemonbroker.SessionPeerBinding{
+		CreatorPeer: peer,
+		Anchor: peercred.ProcessIdentity{
+			UID:            peer.UID,
+			GID:            peer.GID,
+			PID:            peer.PID,
+			ExecutablePath: peer.ExecutablePath,
+			StartTime:      time.Unix(1, 0).UTC(),
+		},
+	}, nil
+}
+
+func (appSessionPeerAuthorizer) ValidateSessionPeer(daemonbroker.SessionPeerBinding, peercred.Info) error {
+	return nil
+}
+
 func startAppTestServer(
 	t *testing.T,
 	opts daemonbroker.Options,
@@ -3295,6 +3314,9 @@ func startAppTestServer(
 	unixsocket.SkipIfBindUnavailable(t, err)
 	if err != nil {
 		t.Fatalf("ListenUnix returned error: %v", err)
+	}
+	if opts.SessionPeerAuthorizer == nil {
+		opts.SessionPeerAuthorizer = appSessionPeerAuthorizer{}
 	}
 	broker, err := daemonbroker.New(opts)
 	if err != nil {

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -76,7 +76,7 @@ Safety rules:
   - exec --dry-run --json validates locally without starting the background helper, prompting, resolving values, or spawning the child.
   - exec --reuse-only uses a matching reusable approval or fails without opening a new approval prompt.
 	  - Text file/document refs such as op://Example/GitHub App/key.pem are injected as env values; binary attachments are not supported.
-	  - session create returns a public session id plus a secret session token; values stay in background helper memory and are injected only by with-session.
+	  - session create returns a public session id plus a secret session token bound to the requester process tree; values stay in background helper memory and are injected only by with-session.
   - item describe requires approval and prints item metadata only: field labels, types, concealment flags, and refs.
   - agent-secret skill-install links the bundled Agent Secret skill into ~/.agents/skills/agent-secret.
   - Reusable approval is selected only in the approval UI, not by a CLI flag.
@@ -365,7 +365,8 @@ func SessionHelp() string {
 
 	Values are never printed. Session values live in Agent Secret's background helper memory
 	until TTL, read count exhaustion, destroy, or helper stop. Session list shows
-	session ids for management, but never session tokens.
+	session ids for management, but never session tokens. Session tokens are accepted
+	only from the requester process tree that created the session.
 	`)
 }
 
@@ -388,6 +389,7 @@ func WithSessionHelp() string {
 	The session token must come from agent-secret session create. Secret values are
 	injected into the child environment only and are never printed by agent-secret.
 	Without --only, every approved session alias is injected for that command.
+	The caller must be in the same requester process tree that created the session.
 	`)
 }
 

--- a/internal/daemon/broker/broker.go
+++ b/internal/daemon/broker/broker.go
@@ -47,16 +47,17 @@ type SecretCache interface {
 }
 
 type Broker struct {
-	mu       sync.Mutex
-	now      func() time.Time
-	grants   *grantIssuer
-	sessions *sessionStore
-	approver approval.Approver
-	resolver Resolver
-	audit    AuditSink
-	active   map[string]*activeExec
-	stopOnce sync.Once
-	stop     chan struct{}
+	mu                    sync.Mutex
+	now                   func() time.Time
+	grants                *grantIssuer
+	sessions              *sessionStore
+	sessionPeerAuthorizer SessionPeerAuthorizer
+	approver              approval.Approver
+	resolver              Resolver
+	audit                 AuditSink
+	active                map[string]*activeExec
+	stopOnce              sync.Once
+	stop                  chan struct{}
 }
 
 type activeExec struct {
@@ -72,13 +73,14 @@ type itemDescribeResult struct {
 }
 
 type Options struct {
-	Now        func() time.Time
-	Store      *policy.Store
-	Cache      SecretCache
-	Approver   approval.Approver
-	Resolver   Resolver
-	Audit      AuditSink
-	FetchLimit int
+	Now                   func() time.Time
+	Store                 *policy.Store
+	Cache                 SecretCache
+	Approver              approval.Approver
+	Resolver              Resolver
+	Audit                 AuditSink
+	FetchLimit            int
+	SessionPeerAuthorizer SessionPeerAuthorizer
 }
 
 func New(opts Options) (*Broker, error) {
@@ -107,15 +109,21 @@ func New(opts Options) (*Broker, error) {
 	if fetchLimit <= 0 {
 		fetchLimit = 4
 	}
-	broker := &Broker{
-		now:      now,
-		approver: opts.Approver,
-		resolver: opts.Resolver,
-		audit:    opts.Audit,
-		active:   make(map[string]*activeExec),
-		stop:     make(chan struct{}),
+	sessionPeerAuthorizer := opts.SessionPeerAuthorizer
+	if sessionPeerAuthorizer == nil {
+		defaultAuthorizer := newProcessTreeSessionPeerAuthorizer()
+		sessionPeerAuthorizer = defaultAuthorizer
 	}
-	broker.sessions = newSessionStore(now)
+	broker := &Broker{
+		now:                   now,
+		sessionPeerAuthorizer: sessionPeerAuthorizer,
+		approver:              opts.Approver,
+		resolver:              opts.Resolver,
+		audit:                 opts.Audit,
+		active:                make(map[string]*activeExec),
+		stop:                  make(chan struct{}),
+	}
+	broker.sessions = newSessionStore(now, sessionPeerAuthorizer)
 	broker.grants = newGrantIssuer(
 		now,
 		store,
@@ -133,6 +141,7 @@ func (b *Broker) HandleSessionCreate(
 	ctx context.Context,
 	correlation protocol.Correlation,
 	req request.SessionCreateRequest,
+	peer peercred.Info,
 ) (protocol.SessionCreateResponsePayload, error) {
 	if correlation.RequestID == "" || correlation.Nonce == "" {
 		return protocol.SessionCreateResponsePayload{}, protocol.ErrInvalidNonce
@@ -141,6 +150,10 @@ func (b *Broker) HandleSessionCreate(
 		return protocol.SessionCreateResponsePayload{}, ErrDaemonStopped
 	}
 	if err := preflightRequiredAudit(ctx, b.audit); err != nil {
+		return protocol.SessionCreateResponsePayload{}, err
+	}
+	peerBinding, err := b.sessionPeerAuthorizer.BindSessionPeer(peer)
+	if err != nil {
 		return protocol.SessionCreateResponsePayload{}, err
 	}
 	if req.Expired(b.now()) {
@@ -179,7 +192,7 @@ func (b *Broker) HandleSessionCreate(
 		return protocol.SessionCreateResponsePayload{}, err
 	}
 	values := fanoutValues(req.Secrets, refValues)
-	summary, err := b.sessions.create(req, values)
+	summary, err := b.sessions.create(req, values, peerBinding)
 	if err != nil {
 		return protocol.SessionCreateResponsePayload{}, err
 	}

--- a/internal/daemon/broker/broker_test.go
+++ b/internal/daemon/broker/broker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kovyrin/agent-secret/internal/daemon/protocol"
 	"github.com/kovyrin/agent-secret/internal/fileidentity"
 	"github.com/kovyrin/agent-secret/internal/itemmetadata"
+	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
 	"github.com/kovyrin/agent-secret/internal/secretcache"
 )
@@ -176,6 +177,40 @@ func (a *afterApprovalApprover) Approve(
 		a.after()
 	}
 	return a.decision, nil
+}
+
+type testSessionPeerAuthorizer struct {
+	roots map[int]int
+}
+
+func (a testSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (SessionPeerBinding, error) {
+	return SessionPeerBinding{
+		CreatorPeer: peer,
+		Anchor: peercred.ProcessIdentity{
+			UID:            peer.UID,
+			GID:            peer.GID,
+			PID:            a.rootFor(peer.PID),
+			ExecutablePath: "/test/requester",
+			StartTime:      time.Unix(1, 0).UTC(),
+		},
+	}, nil
+}
+
+func (a testSessionPeerAuthorizer) ValidateSessionPeer(binding SessionPeerBinding, peer peercred.Info) error {
+	if peer.UID != binding.CreatorPeer.UID || peer.GID != binding.CreatorPeer.GID ||
+		a.rootFor(peer.PID) != binding.Anchor.PID {
+		return ErrSessionPeerMismatch
+	}
+	return nil
+}
+
+func (a testSessionPeerAuthorizer) rootFor(pid int) int {
+	if a.roots != nil {
+		if root, ok := a.roots[pid]; ok {
+			return root
+		}
+	}
+	return pid
 }
 
 type contextExpiringApprover struct {
@@ -534,6 +569,9 @@ func newTestBroker(t *testing.T, opts Options) *Broker {
 	if opts.Now == nil {
 		now := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
 		opts.Now = func() time.Time { return now }
+	}
+	if opts.SessionPeerAuthorizer == nil {
+		opts.SessionPeerAuthorizer = testSessionPeerAuthorizer{}
 	}
 	broker, err := New(opts)
 	if err != nil {

--- a/internal/daemon/broker/session_peer_authorizer.go
+++ b/internal/daemon/broker/session_peer_authorizer.go
@@ -1,0 +1,109 @@
+package broker
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/kovyrin/agent-secret/internal/peercred"
+)
+
+type SessionPeerAuthorizer interface {
+	BindSessionPeer(peer peercred.Info) (SessionPeerBinding, error)
+	ValidateSessionPeer(binding SessionPeerBinding, peer peercred.Info) error
+}
+
+type SessionPeerBinding struct {
+	CreatorPeer peercred.Info
+	Anchor      peercred.ProcessIdentity
+}
+
+type processTreeSessionPeerAuthorizer struct {
+	processAncestry func(int) ([]peercred.ProcessIdentity, error)
+}
+
+func newProcessTreeSessionPeerAuthorizer() processTreeSessionPeerAuthorizer {
+	return processTreeSessionPeerAuthorizer{processAncestry: peercred.ProcessAncestry}
+}
+
+func (a processTreeSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (SessionPeerBinding, error) {
+	ancestry, err := a.processAncestry(peer.PID)
+	if err != nil {
+		return SessionPeerBinding{}, fmt.Errorf("%w: inspect session creator process tree: %w", ErrSessionPeerMismatch, err)
+	}
+	anchor, err := sessionPeerAnchor(peer, ancestry)
+	if err != nil {
+		return SessionPeerBinding{}, err
+	}
+	return SessionPeerBinding{
+		CreatorPeer: peer,
+		Anchor:      anchor,
+	}, nil
+}
+
+func (a processTreeSessionPeerAuthorizer) ValidateSessionPeer(
+	binding SessionPeerBinding,
+	peer peercred.Info,
+) error {
+	if binding.Anchor.PID <= 0 || binding.Anchor.StartTime.IsZero() {
+		return fmt.Errorf("%w: session is missing requester process binding", ErrSessionPeerMismatch)
+	}
+	ancestry, err := a.processAncestry(peer.PID)
+	if err != nil {
+		return fmt.Errorf("%w: inspect session caller process tree: %w", ErrSessionPeerMismatch, err)
+	}
+	if processAncestryContains(ancestry, binding.Anchor) {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: caller pid %d is not in the approved requester process tree rooted at pid %d",
+		ErrSessionPeerMismatch,
+		peer.PID,
+		binding.Anchor.PID,
+	)
+}
+
+func sessionPeerAnchor(peer peercred.Info, ancestry []peercred.ProcessIdentity) (peercred.ProcessIdentity, error) {
+	if len(ancestry) == 0 || ancestry[0].PID != peer.PID {
+		return peercred.ProcessIdentity{}, fmt.Errorf("%w: session creator process tree does not start at pid %d", ErrSessionPeerMismatch, peer.PID)
+	}
+	for i, candidate := range ancestry[1:] {
+		if isEligibleSessionPeerAnchor(peer, candidate) {
+			if i+2 < len(ancestry) && isSameExecutableAncestor(candidate, ancestry[i+2]) {
+				continue
+			}
+			return candidate, nil
+		}
+	}
+	return peercred.ProcessIdentity{}, fmt.Errorf("%w: session creator has no stable requester parent", ErrSessionPeerMismatch)
+}
+
+func isEligibleSessionPeerAnchor(peer peercred.Info, candidate peercred.ProcessIdentity) bool {
+	if candidate.PID <= 1 || candidate.UID != peer.UID || candidate.GID != peer.GID || candidate.StartTime.IsZero() {
+		return false
+	}
+	return filepath.Base(candidate.ExecutablePath) != "launchd"
+}
+
+func isSameExecutableAncestor(candidate peercred.ProcessIdentity, ancestor peercred.ProcessIdentity) bool {
+	return candidate.UID == ancestor.UID &&
+		candidate.GID == ancestor.GID &&
+		candidate.ExecutablePath != "" &&
+		candidate.ExecutablePath == ancestor.ExecutablePath
+}
+
+func processAncestryContains(ancestry []peercred.ProcessIdentity, anchor peercred.ProcessIdentity) bool {
+	for _, candidate := range ancestry {
+		if sameProcessIdentity(candidate, anchor) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameProcessIdentity(a peercred.ProcessIdentity, b peercred.ProcessIdentity) bool {
+	return a.PID == b.PID &&
+		a.UID == b.UID &&
+		a.GID == b.GID &&
+		a.StartTime.Equal(b.StartTime) &&
+		a.ExecutablePath == b.ExecutablePath
+}

--- a/internal/daemon/broker/session_peer_authorizer.go
+++ b/internal/daemon/broker/session_peer_authorizer.go
@@ -48,11 +48,11 @@ func (a processTreeSessionPeerAuthorizer) ValidateSessionPeer(
 		return fmt.Errorf("%w: session is missing requester process binding", ErrSessionPeerMismatch)
 	}
 	ancestry, err := a.processAncestry(peer.PID)
-	if err != nil {
-		return fmt.Errorf("%w: inspect session caller process tree: %w", ErrSessionPeerMismatch, err)
-	}
 	if processAncestryContains(ancestry, binding.Anchor) {
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%w: inspect session caller process tree: %w", ErrSessionPeerMismatch, err)
 	}
 	return fmt.Errorf(
 		"%w: caller pid %d is not in the approved requester process tree rooted at pid %d",
@@ -66,9 +66,11 @@ func sessionPeerAnchor(peer peercred.Info, ancestry []peercred.ProcessIdentity) 
 	if len(ancestry) == 0 || ancestry[0].PID != peer.PID {
 		return peercred.ProcessIdentity{}, fmt.Errorf("%w: session creator process tree does not start at pid %d", ErrSessionPeerMismatch, peer.PID)
 	}
-	for i, candidate := range ancestry[1:] {
+	for i := 1; i < len(ancestry); i++ {
+		candidate := ancestry[i]
 		if isEligibleSessionPeerAnchor(peer, candidate) {
-			if i+2 < len(ancestry) && isSameExecutableAncestor(candidate, ancestry[i+2]) {
+			if next, ok := nextEligibleSessionPeerAnchor(peer, ancestry[i+1:]); ok &&
+				isSameExecutableAncestor(candidate, next) {
 				continue
 			}
 			return candidate, nil
@@ -82,6 +84,18 @@ func isEligibleSessionPeerAnchor(peer peercred.Info, candidate peercred.ProcessI
 		return false
 	}
 	return filepath.Base(candidate.ExecutablePath) != "launchd"
+}
+
+func nextEligibleSessionPeerAnchor(
+	peer peercred.Info,
+	ancestry []peercred.ProcessIdentity,
+) (peercred.ProcessIdentity, bool) {
+	for _, candidate := range ancestry {
+		if isEligibleSessionPeerAnchor(peer, candidate) {
+			return candidate, true
+		}
+	}
+	return peercred.ProcessIdentity{}, false
 }
 
 func isSameExecutableAncestor(candidate peercred.ProcessIdentity, ancestor peercred.ProcessIdentity) bool {

--- a/internal/daemon/broker/session_peer_authorizer_test.go
+++ b/internal/daemon/broker/session_peer_authorizer_test.go
@@ -1,0 +1,152 @@
+package broker
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kovyrin/agent-secret/internal/peercred"
+)
+
+func TestProcessTreeSessionPeerAuthorizerAllowsRequesterTreeSiblings(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	caller := testPeerInfo(1002)
+	requester := testProcessIdentity(500, 1, "/bin/zsh")
+	lookup := map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, requester.PID, creator.ExecutablePath),
+			requester,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+		caller.PID: {
+			testProcessIdentity(caller.PID, requester.PID, caller.ExecutablePath),
+			requester,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	}
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
+
+	binding, err := authorizer.BindSessionPeer(creator)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if binding.Anchor.PID != requester.PID {
+		t.Fatalf("binding anchor pid = %d, want %d", binding.Anchor.PID, requester.PID)
+	}
+	if err := authorizer.ValidateSessionPeer(binding, caller); err != nil {
+		t.Fatalf("ValidateSessionPeer returned error for requester tree sibling: %v", err)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerSkipsSameExecutableSubshellAnchor(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	caller := testPeerInfo(1002)
+	subShell := testProcessIdentity(501, 500, "/bin/bash")
+	taskShell := testProcessIdentity(500, 1, "/bin/bash")
+	lookup := map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, subShell.PID, creator.ExecutablePath),
+			subShell,
+			taskShell,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+		caller.PID: {
+			testProcessIdentity(caller.PID, taskShell.PID, caller.ExecutablePath),
+			taskShell,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	}
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
+
+	binding, err := authorizer.BindSessionPeer(creator)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if binding.Anchor.PID != taskShell.PID {
+		t.Fatalf("binding anchor pid = %d, want task shell pid %d", binding.Anchor.PID, taskShell.PID)
+	}
+	if err := authorizer.ValidateSessionPeer(binding, caller); err != nil {
+		t.Fatalf("ValidateSessionPeer returned error for task shell sibling: %v", err)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerRejectsUnrelatedTree(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	caller := testPeerInfo(2001)
+	creatorRequester := testProcessIdentity(500, 1, "/bin/zsh")
+	callerRequester := testProcessIdentity(600, 1, "/bin/zsh")
+	lookup := map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, creatorRequester.PID, creator.ExecutablePath),
+			creatorRequester,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+		caller.PID: {
+			testProcessIdentity(caller.PID, callerRequester.PID, caller.ExecutablePath),
+			callerRequester,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	}
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
+
+	binding, err := authorizer.BindSessionPeer(creator)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if err := authorizer.ValidateSessionPeer(binding, caller); !errors.Is(err, ErrSessionPeerMismatch) {
+		t.Fatalf("ValidateSessionPeer error = %v, want ErrSessionPeerMismatch", err)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerDoesNotUseLaunchdAsAnchor(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, 1, creator.ExecutablePath),
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	})}
+
+	if _, err := authorizer.BindSessionPeer(creator); !errors.Is(err, ErrSessionPeerMismatch) {
+		t.Fatalf("BindSessionPeer error = %v, want ErrSessionPeerMismatch", err)
+	}
+}
+
+func ancestryLookup(lookup map[int][]peercred.ProcessIdentity) func(int) ([]peercred.ProcessIdentity, error) {
+	return func(pid int) ([]peercred.ProcessIdentity, error) {
+		ancestry, ok := lookup[pid]
+		if !ok {
+			return nil, peercred.ErrMissingMetadata
+		}
+		return ancestry, nil
+	}
+}
+
+func testPeerInfo(pid int) peercred.Info {
+	return peercred.Info{
+		UID:            501,
+		GID:            20,
+		PID:            pid,
+		ExecutablePath: "/Applications/Agent Secret.app/Contents/MacOS/Agent Secret",
+		CWD:            "/Users/example/project",
+	}
+}
+
+func testProcessIdentity(pid int, parentPID int, executable string) peercred.ProcessIdentity {
+	return peercred.ProcessIdentity{
+		UID:            501,
+		GID:            20,
+		PID:            pid,
+		ParentPID:      parentPID,
+		ExecutablePath: executable,
+		StartTime:      time.Unix(int64(pid), 0).UTC(),
+	}
+}

--- a/internal/daemon/broker/session_peer_authorizer_test.go
+++ b/internal/daemon/broker/session_peer_authorizer_test.go
@@ -74,6 +74,113 @@ func TestProcessTreeSessionPeerAuthorizerSkipsSameExecutableSubshellAnchor(t *te
 	}
 }
 
+func TestProcessTreeSessionPeerAuthorizerSkipsSameExecutableSubshellAcrossIneligibleAncestor(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	caller := testPeerInfo(1002)
+	subShell := testProcessIdentity(501, 700, "/bin/bash")
+	ineligibleDaemon := testProcessIdentity(700, 500, "/usr/libexec/example-daemon")
+	ineligibleDaemon.UID = 0
+	ineligibleDaemon.GID = 0
+	taskShell := testProcessIdentity(500, 1, "/bin/bash")
+	lookup := map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, subShell.PID, creator.ExecutablePath),
+			subShell,
+			ineligibleDaemon,
+			taskShell,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+		caller.PID: {
+			testProcessIdentity(caller.PID, taskShell.PID, caller.ExecutablePath),
+			taskShell,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	}
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
+
+	binding, err := authorizer.BindSessionPeer(creator)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if binding.Anchor.PID != taskShell.PID {
+		t.Fatalf("binding anchor pid = %d, want task shell pid %d", binding.Anchor.PID, taskShell.PID)
+	}
+	if err := authorizer.ValidateSessionPeer(binding, caller); err != nil {
+		t.Fatalf("ValidateSessionPeer returned error for task shell sibling: %v", err)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerAllowsPartialCallerAncestryWhenAnchorWasSeen(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	caller := testPeerInfo(1002)
+	requester := testProcessIdentity(500, 1, "/bin/zsh")
+	inspectErr := errors.New("process exited while walking ancestry")
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: func(pid int) ([]peercred.ProcessIdentity, error) {
+		switch pid {
+		case creator.PID:
+			return []peercred.ProcessIdentity{
+				testProcessIdentity(creator.PID, requester.PID, creator.ExecutablePath),
+				requester,
+				testProcessIdentity(1, 0, "/sbin/launchd"),
+			}, nil
+		case caller.PID:
+			return []peercred.ProcessIdentity{
+				testProcessIdentity(caller.PID, requester.PID, caller.ExecutablePath),
+				requester,
+			}, inspectErr
+		default:
+			return nil, peercred.ErrMissingMetadata
+		}
+	}}
+
+	binding, err := authorizer.BindSessionPeer(creator)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if err := authorizer.ValidateSessionPeer(binding, caller); err != nil {
+		t.Fatalf("ValidateSessionPeer returned error with anchor in partial ancestry: %v", err)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerRejectsPartialCallerAncestryWhenAnchorWasNotSeen(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	caller := testPeerInfo(1002)
+	creatorRequester := testProcessIdentity(500, 1, "/bin/zsh")
+	callerRequester := testProcessIdentity(600, 1, "/bin/zsh")
+	inspectErr := errors.New("process exited while walking ancestry")
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: func(pid int) ([]peercred.ProcessIdentity, error) {
+		switch pid {
+		case creator.PID:
+			return []peercred.ProcessIdentity{
+				testProcessIdentity(creator.PID, creatorRequester.PID, creator.ExecutablePath),
+				creatorRequester,
+				testProcessIdentity(1, 0, "/sbin/launchd"),
+			}, nil
+		case caller.PID:
+			return []peercred.ProcessIdentity{
+				testProcessIdentity(caller.PID, callerRequester.PID, caller.ExecutablePath),
+				callerRequester,
+			}, inspectErr
+		default:
+			return nil, peercred.ErrMissingMetadata
+		}
+	}}
+
+	binding, err := authorizer.BindSessionPeer(creator)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if err := authorizer.ValidateSessionPeer(binding, caller); !errors.Is(err, ErrSessionPeerMismatch) {
+		t.Fatalf("ValidateSessionPeer error = %v, want ErrSessionPeerMismatch", err)
+	}
+}
+
 func TestProcessTreeSessionPeerAuthorizerRejectsUnrelatedTree(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/broker/session_store.go
+++ b/internal/daemon/broker/session_store.go
@@ -26,6 +26,7 @@ type sessionStore struct {
 	mu            sync.Mutex
 	now           func() time.Time
 	random        io.Reader
+	authorizer    SessionPeerAuthorizer
 	sessions      map[string]*sessionRecord
 	sessionTokens map[string]*sessionRecord
 }
@@ -40,6 +41,7 @@ type sessionRecord struct {
 	SecretAliases []string
 	ExpiresAt     time.Time
 	MaxReads      int
+	PeerBinding   SessionPeerBinding
 	Reads         int
 	ReservedReads int
 	OverrideEnv   bool
@@ -59,19 +61,28 @@ type sessionReservation struct {
 	OverrideEnv    bool
 }
 
-func newSessionStore(now func() time.Time) *sessionStore {
+func newSessionStore(now func() time.Time, authorizer SessionPeerAuthorizer) *sessionStore {
 	if now == nil {
 		now = time.Now
+	}
+	if authorizer == nil {
+		defaultAuthorizer := newProcessTreeSessionPeerAuthorizer()
+		authorizer = defaultAuthorizer
 	}
 	return &sessionStore{
 		now:           now,
 		random:        rand.Reader,
+		authorizer:    authorizer,
 		sessions:      make(map[string]*sessionRecord),
 		sessionTokens: make(map[string]*sessionRecord),
 	}
 }
 
-func (s *sessionStore) create(req request.SessionCreateRequest, env map[string]string) (request.SessionSummary, error) {
+func (s *sessionStore) create(
+	req request.SessionCreateRequest,
+	env map[string]string,
+	peerBinding SessionPeerBinding,
+) (request.SessionSummary, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -93,6 +104,7 @@ func (s *sessionStore) create(req request.SessionCreateRequest, env map[string]s
 		SecretAliases: request.SecretAliases(req.Secrets),
 		ExpiresAt:     req.ExpiresAt,
 		MaxReads:      req.MaxReads,
+		PeerBinding:   peerBinding,
 		OverrideEnv:   req.OverrideEnv,
 	}
 	s.sessions[id] = record
@@ -118,6 +130,9 @@ func (s *sessionStore) reserve(req request.SessionResolveRequest, peer peercred.
 	}
 	if record.CWD != req.CWD {
 		return sessionReservation{}, fmt.Errorf("%w: cwd %q != %q", ErrSessionPeerMismatch, req.CWD, record.CWD)
+	}
+	if err := s.authorizer.ValidateSessionPeer(record.PeerBinding, peer); err != nil {
+		return sessionReservation{}, err
 	}
 	if record.Reads+record.ReservedReads >= record.MaxReads {
 		s.deleteRecord(record)

--- a/internal/daemon/broker/session_test.go
+++ b/internal/daemon/broker/session_test.go
@@ -30,7 +30,8 @@ func TestBrokerSessionCreateResolveConsumesReadAndAuditsCommand(t *testing.T) {
 	})
 
 	createReq := testSessionCreateRequest(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}}, 1)
-	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	peer := testSessionPeer(t, createReq.CWD)
+	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq, peer)
 	if err != nil {
 		t.Fatalf("HandleSessionCreate returned error: %v", err)
 	}
@@ -38,7 +39,6 @@ func TestBrokerSessionCreateResolveConsumesReadAndAuditsCommand(t *testing.T) {
 		t.Fatalf("created session payload = %+v", created)
 	}
 
-	peer := testSessionPeer(t, createReq.CWD)
 	resolveReq := testSessionResolveRequest(t, created.SessionToken, createReq.CWD, peer)
 	delivery, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), resolveReq, peer)
 	if err != nil {
@@ -100,7 +100,8 @@ func TestBrokerSessionResolveFiltersRequestedAliases(t *testing.T) {
 	})
 
 	createReq := testSessionCreateRequest(t, now, specs, 2)
-	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	peer := testSessionPeer(t, createReq.CWD)
+	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq, peer)
 	if err != nil {
 		t.Fatalf("HandleSessionCreate returned error: %v", err)
 	}
@@ -108,7 +109,6 @@ func TestBrokerSessionResolveFiltersRequestedAliases(t *testing.T) {
 		t.Fatalf("created secret aliases = %v", created.SecretAliases)
 	}
 
-	peer := testSessionPeer(t, createReq.CWD)
 	missingReq := testSessionResolveRequest(t, created.SessionToken, createReq.CWD, peer)
 	missingReq, err = missingReq.WithRequestedAliases([]string{"MISSING_TOKEN"})
 	if err != nil {
@@ -158,6 +158,46 @@ func TestBrokerSessionResolveFiltersRequestedAliases(t *testing.T) {
 	}
 }
 
+func TestBrokerSessionResolveRejectsUnrelatedRequesterTree(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
+	ref := "op://Example/Item/token"
+	broker := newTestBroker(t, Options{
+		Now: func() time.Time { return now },
+		SessionPeerAuthorizer: testSessionPeerAuthorizer{roots: map[int]int{
+			1001: 10,
+			2001: 20,
+		}},
+		Approver: &mockApprover{decision: approval.Decision{Approved: true}},
+		Resolver: &mockResolver{values: map[string]string{resolverCallKey(ref, "Work"): "value"}},
+		Audit:    &memoryAudit{},
+	})
+
+	createReq := testSessionCreateRequest(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}}, 1)
+	creatorPeer := testSessionPeerWithPID(t, createReq.CWD, 1001)
+	created, err := broker.HandleSessionCreate(
+		context.Background(),
+		testCorrelation("req_create", "nonce_create"),
+		createReq,
+		creatorPeer,
+	)
+	if err != nil {
+		t.Fatalf("HandleSessionCreate returned error: %v", err)
+	}
+
+	attackerPeer := testSessionPeerWithPID(t, createReq.CWD, 2001)
+	replayReq := testSessionResolveRequest(t, created.SessionToken, createReq.CWD, attackerPeer)
+	if _, err := broker.PrepareSessionResolve(
+		context.Background(),
+		testCorrelation("req_replay", "nonce_replay"),
+		replayReq,
+		attackerPeer,
+	); !errors.Is(err, ErrSessionPeerMismatch) {
+		t.Fatalf("replay PrepareSessionResolve error = %v, want ErrSessionPeerMismatch", err)
+	}
+}
+
 func TestBrokerSessionResolveAbortRestoresRead(t *testing.T) {
 	t.Parallel()
 
@@ -170,11 +210,11 @@ func TestBrokerSessionResolveAbortRestoresRead(t *testing.T) {
 		Audit:    &memoryAudit{},
 	})
 	createReq := testSessionCreateRequest(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}}, 1)
-	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	peer := testSessionPeer(t, createReq.CWD)
+	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq, peer)
 	if err != nil {
 		t.Fatalf("HandleSessionCreate returned error: %v", err)
 	}
-	peer := testSessionPeer(t, createReq.CWD)
 	resolveReq := testSessionResolveRequest(t, created.SessionToken, createReq.CWD, peer)
 
 	first, err := broker.PrepareSessionResolve(context.Background(), testCorrelation("req_resolve", "nonce_resolve"), resolveReq, peer)
@@ -204,7 +244,8 @@ func TestBrokerSessionListAndDestroy(t *testing.T) {
 	})
 
 	createReq := testSessionCreateRequest(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}}, 2)
-	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+	peer := testSessionPeer(t, createReq.CWD)
+	created, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq, peer)
 	if err != nil {
 		t.Fatalf("HandleSessionCreate returned error: %v", err)
 	}
@@ -241,7 +282,7 @@ func TestBrokerSessionListAndDestroy(t *testing.T) {
 		t.Fatalf("second HandleSessionDestroy error = %v, want ErrSessionNotFound", err)
 	}
 
-	createdAgain, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create_again", "nonce_create_again"), createReq)
+	createdAgain, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create_again", "nonce_create_again"), createReq, peer)
 	if err != nil {
 		t.Fatalf("second HandleSessionCreate returned error: %v", err)
 	}
@@ -311,8 +352,9 @@ func TestBrokerSessionCreateRecordsTerminalApprovalFailures(t *testing.T) {
 				Audit:    aud,
 			})
 			createReq := testSessionCreateRequest(t, now, []request.SecretSpec{{Alias: "TOKEN", Ref: ref, Account: "Work"}}, 1)
+			peer := testSessionPeer(t, createReq.CWD)
 
-			_, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq)
+			_, err := broker.HandleSessionCreate(context.Background(), testCorrelation("req_create", "nonce_create"), createReq, peer)
 			if err == nil {
 				t.Fatal("HandleSessionCreate unexpectedly succeeded")
 			}
@@ -332,7 +374,7 @@ func TestSessionStoreListPrunesExpiredAndExhaustedSessions(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
-	store := newSessionStore(func() time.Time { return now })
+	store := newSessionStore(func() time.Time { return now }, testSessionPeerAuthorizer{})
 	store.sessions["asid_live_b"] = &sessionRecord{
 		ID:            "asid_live_b",
 		Token:         "astok_live_b",
@@ -451,10 +493,15 @@ func testSessionResolveRequest(
 
 func testSessionPeer(t *testing.T, cwd string) peercred.Info {
 	t.Helper()
+	return testSessionPeerWithPID(t, cwd, os.Getpid())
+}
+
+func testSessionPeerWithPID(t *testing.T, cwd string, pid int) peercred.Info {
+	t.Helper()
 	return peercred.Info{
 		UID:            os.Getuid(),
 		GID:            os.Getgid(),
-		PID:            os.Getpid(),
+		PID:            pid,
 		ExecutablePath: currentTestExecutable(t),
 		CWD:            cwd,
 	}

--- a/internal/daemon/control/manager_test.go
+++ b/internal/daemon/control/manager_test.go
@@ -1743,7 +1743,7 @@ func copyCurrentTestBinaryToDaemonBundleAt(t *testing.T, dir string, bundleID st
 
 func waitForRawSocket(t *testing.T, path string) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		conn, err := socket.Dial(context.Background(), path)
 		if err == nil {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -503,7 +503,12 @@ func (s *Server) handleSessionCreate(
 		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodeBadRequest, err)
 		return
 	}
-	payload, err := s.broker.HandleSessionCreate(ctx, env.Correlation(), req)
+	peer, err := s.peerInfo(conn)
+	if err != nil {
+		_ = writeErrorEncoder(encoder, env.Correlation(), protocol.ErrorCodePeerRejected, err)
+		return
+	}
+	payload, err := s.broker.HandleSessionCreate(ctx, env.Correlation(), req, peer)
 	if err != nil {
 		_ = writeErrorEncoder(encoder, env.Correlation(), codeForError(err), err)
 		return

--- a/internal/daemon/test_helpers_test.go
+++ b/internal/daemon/test_helpers_test.go
@@ -261,11 +261,33 @@ func newTestBroker(t *testing.T, opts daemonbroker.Options) *daemonbroker.Broker
 		now := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
 		opts.Now = func() time.Time { return now }
 	}
+	if opts.SessionPeerAuthorizer == nil {
+		opts.SessionPeerAuthorizer = testSessionPeerAuthorizer{}
+	}
 	broker, err := daemonbroker.New(opts)
 	if err != nil {
 		t.Fatalf("broker.New returned error: %v", err)
 	}
 	return broker
+}
+
+type testSessionPeerAuthorizer struct{}
+
+func (testSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (daemonbroker.SessionPeerBinding, error) {
+	return daemonbroker.SessionPeerBinding{
+		CreatorPeer: peer,
+		Anchor: peercred.ProcessIdentity{
+			UID:            peer.UID,
+			GID:            peer.GID,
+			PID:            peer.PID,
+			ExecutablePath: peer.ExecutablePath,
+			StartTime:      time.Unix(1, 0).UTC(),
+		},
+	}, nil
+}
+
+func (testSessionPeerAuthorizer) ValidateSessionPeer(daemonbroker.SessionPeerBinding, peercred.Info) error {
+	return nil
 }
 
 func newSocketApproverForTest(t *testing.T, launcher approval.ApproverLauncher, now func() time.Time) *approval.SocketApprover {

--- a/internal/peercred/peercred.go
+++ b/internal/peercred/peercred.go
@@ -115,6 +115,9 @@ func CurrentExpected() (Expected, error) {
 	return currentExpected(os.Executable, os.Getwd)
 }
 
+// ProcessAncestry returns the process identities observed while walking from
+// pid toward its ancestors. If an ancestor exits mid-walk, the returned slice
+// may be partial and still useful for callers that only need a known anchor.
 func ProcessAncestry(pid int) ([]ProcessIdentity, error) {
 	if pid <= 0 {
 		return nil, fmt.Errorf("%w: invalid pid %d", ErrMissingMetadata, pid)

--- a/internal/peercred/peercred.go
+++ b/internal/peercred/peercred.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/kovyrin/agent-secret/internal/pathresolve"
 )
@@ -29,6 +30,15 @@ type Expected struct {
 	PID            int
 	ExecutablePath string
 	CWD            string
+}
+
+type ProcessIdentity struct {
+	UID            int
+	GID            int
+	PID            int
+	ParentPID      int
+	ExecutablePath string
+	StartTime      time.Time
 }
 
 func Inspect(conn *net.UnixConn) (Info, error) {
@@ -103,6 +113,13 @@ func Validate(info Info, expected Expected) error {
 
 func CurrentExpected() (Expected, error) {
 	return currentExpected(os.Executable, os.Getwd)
+}
+
+func ProcessAncestry(pid int) ([]ProcessIdentity, error) {
+	if pid <= 0 {
+		return nil, fmt.Errorf("%w: invalid pid %d", ErrMissingMetadata, pid)
+	}
+	return processAncestry(pid)
 }
 
 func currentExpected(executable func() (string, error), getwd func() (string, error)) (Expected, error) {

--- a/internal/peercred/peercred_darwin.go
+++ b/internal/peercred/peercred_darwin.go
@@ -61,13 +61,28 @@ static int agentsecret_pidcwd(pid_t pid, char *buf, size_t size) {
 	strlcpy(buf, info.pvi_cdir.vip_path, size);
 	return 0;
 }
+
+static int agentsecret_pidbsdinfo(pid_t pid, struct proc_bsdinfo *info) {
+	int ret = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, info, sizeof(*info));
+	if (ret <= 0) {
+		return -1;
+	}
+	if ((size_t)ret < sizeof(*info)) {
+		errno = EINVAL;
+		return -1;
+	}
+	return ret;
+}
 */
 import "C"
 
 import (
 	"fmt"
+	"time"
 	"unsafe"
 )
+
+const maxProcessAncestryDepth = 64
 
 func inspectFD(fd uintptr) (Info, error) {
 	var uid C.uid_t
@@ -106,5 +121,52 @@ func inspectFD(fd uintptr) (Info, error) {
 		PID:            int(pid),
 		ExecutablePath: C.GoString((*C.char)(unsafe.Pointer(&exe[0]))),
 		CWD:            C.GoString((*C.char)(unsafe.Pointer(&cwd[0]))),
+	}, nil
+}
+
+func processAncestry(pid int) ([]ProcessIdentity, error) {
+	ancestry := make([]ProcessIdentity, 0, 8)
+	seen := make(map[int]struct{}, 8)
+	current := pid
+	for range maxProcessAncestryDepth {
+		if current <= 0 {
+			break
+		}
+		if _, ok := seen[current]; ok {
+			break
+		}
+		seen[current] = struct{}{}
+
+		identity, err := inspectProcess(current)
+		if err != nil {
+			return nil, err
+		}
+		ancestry = append(ancestry, identity)
+		if identity.ParentPID <= 1 || identity.ParentPID == identity.PID {
+			break
+		}
+		current = identity.ParentPID
+	}
+	return ancestry, nil
+}
+
+func inspectProcess(pid int) (ProcessIdentity, error) {
+	var info C.struct_proc_bsdinfo
+	if _, err := C.agentsecret_pidbsdinfo(C.pid_t(pid), &info); err != nil {
+		return ProcessIdentity{}, fmt.Errorf("PROC_PIDTBSDINFO pid %d: %w", pid, err)
+	}
+
+	exe := make([]C.char, int(C.agentsecret_proc_path_size))
+	if _, err := C.agentsecret_pidpath(C.pid_t(pid), (*C.char)(unsafe.Pointer(&exe[0])), C.size_t(len(exe))); err != nil {
+		return ProcessIdentity{}, fmt.Errorf("proc_pidpath pid %d: %w", pid, err)
+	}
+
+	return ProcessIdentity{
+		UID:            int(info.pbi_uid),
+		GID:            int(info.pbi_gid),
+		PID:            pid,
+		ParentPID:      int(info.pbi_ppid),
+		ExecutablePath: C.GoString((*C.char)(unsafe.Pointer(&exe[0]))),
+		StartTime:      time.Unix(int64(info.pbi_start_tvsec), int64(info.pbi_start_tvusec)*1000).UTC(),
 	}, nil
 }

--- a/internal/peercred/peercred_darwin.go
+++ b/internal/peercred/peercred_darwin.go
@@ -139,7 +139,7 @@ func processAncestry(pid int) ([]ProcessIdentity, error) {
 
 		identity, err := inspectProcess(current)
 		if err != nil {
-			return nil, err
+			return ancestry, err
 		}
 		ancestry = append(ancestry, identity)
 		if identity.ParentPID <= 1 || identity.ParentPID == identity.PID {

--- a/internal/peercred/peercred_test.go
+++ b/internal/peercred/peercred_test.go
@@ -196,6 +196,49 @@ func TestCurrentExpectedWrapsOSErrors(t *testing.T) {
 	}
 }
 
+func TestProcessAncestryCapturesCurrentProcess(t *testing.T) {
+	t.Parallel()
+
+	ancestry, err := ProcessAncestry(os.Getpid())
+	if errors.Is(err, ErrUnsupportedOS) {
+		t.Skip(err)
+	}
+	if err != nil {
+		t.Fatalf("ProcessAncestry returned error: %v", err)
+	}
+	if len(ancestry) == 0 {
+		t.Fatal("ProcessAncestry returned empty ancestry")
+	}
+	current := ancestry[0]
+	if current.PID != os.Getpid() {
+		t.Fatalf("current pid = %d, want %d", current.PID, os.Getpid())
+	}
+	if current.UID != os.Getuid() || current.GID != os.Getgid() {
+		t.Fatalf("current uid/gid = %d/%d, want %d/%d", current.UID, current.GID, os.Getuid(), os.Getgid())
+	}
+	if current.ParentPID <= 0 {
+		t.Fatalf("current parent pid = %d, want positive", current.ParentPID)
+	}
+	if current.ExecutablePath == "" {
+		t.Fatal("current executable path is empty")
+	}
+	if current.StartTime.IsZero() {
+		t.Fatal("current start time is zero")
+	}
+	if len(ancestry) > 1 && ancestry[1].PID != current.ParentPID {
+		t.Fatalf("parent ancestry pid = %d, want %d", ancestry[1].PID, current.ParentPID)
+	}
+}
+
+func TestProcessAncestryRejectsInvalidPID(t *testing.T) {
+	t.Parallel()
+
+	_, err := ProcessAncestry(0)
+	if !errors.Is(err, ErrMissingMetadata) {
+		t.Fatalf("ProcessAncestry error = %v, want ErrMissingMetadata", err)
+	}
+}
+
 func withUID(info Info, uid int) Info {
 	info.UID = uid
 	return info

--- a/internal/peercred/peercred_unsupported.go
+++ b/internal/peercred/peercred_unsupported.go
@@ -7,3 +7,7 @@ import "fmt"
 func inspectFD(uintptr) (Info, error) {
 	return Info{}, fmt.Errorf("%w: strict peer metadata is macOS-only in v1", ErrUnsupportedOS)
 }
+
+func processAncestry(int) ([]ProcessIdentity, error) {
+	return nil, fmt.Errorf("%w: process ancestry is macOS-only in v1", ErrUnsupportedOS)
+}

--- a/scripts/release/test-release-docs.sh
+++ b/scripts/release/test-release-docs.sh
@@ -6,6 +6,7 @@ project_root="$(cd -- "$script_dir/../.." && pwd)"
 readme="$project_root/README.md"
 release_process="$project_root/docs/release-process.md"
 macos_distribution_plan="$project_root/docs/macos-distribution-plan.md"
+session_e2e="$project_root/docs/session-e2e-validation.md"
 threat_model="$project_root/docs/threat-model.md"
 
 fail() {
@@ -42,6 +43,14 @@ require_release_process_text() {
 
   if ! grep -F -- "$needle" "$release_process" >/dev/null; then
     fail "docs/release-process.md is missing expected release documentation: $needle"
+  fi
+}
+
+require_session_e2e_text() {
+  local needle="$1"
+
+  if ! grep -F -- "$needle" "$session_e2e" >/dev/null; then
+    fail "docs/session-e2e-validation.md is missing expected release coverage: $needle"
   fi
 }
 
@@ -107,6 +116,8 @@ require_release_process_text "scripts/release/prepare-bootstrap-scripts.sh"
 require_release_process_text ".agents/skills/agent-secret/SKILL.md"
 require_release_process_text "Audit user-facing docs and the bundled coding-agent skill"
 require_release_process_text "AGENT_SECRET_RELEASE_SMOKE_REQUIRE_INSTALLED_CLI=1"
+require_release_process_text "docs/session-e2e-validation.md"
+require_release_process_text "detached process-tree replay rejected before child spawn"
 require_release_process_text "--require-production-signing"
 require_release_process_text "Tag-triggered GitHub releases require production"
 require_release_process_text "Developer ID Application: Oleksiy Kovyrin (B6L7QLWTZW)"
@@ -120,6 +131,12 @@ require_release_process_text "scripts/checks/test-workflow-actions-pinned.sh"
 require_release_process_text "scripts/release/check-homebrew-cask.sh"
 require_release_process_text "brew upgrade --cask agent-secret"
 require_release_process_text "release is not"
+
+require_session_e2e_text "SESSION_E2E_PROFILE_TOKEN"
+require_session_e2e_text "SESSION_E2E_CLI_TOKEN"
+require_session_e2e_text "launchctl submit"
+require_session_e2e_text "detached process-tree replay rejected before child spawn"
+require_session_e2e_text "The same \`session_token\` is rejected before child spawn"
 
 require_threat_model_text "## Review Finding Ledger"
 require_threat_model_text "Current open findings live in GitHub issues named"

--- a/site/docs.html
+++ b/site/docs.html
@@ -214,7 +214,8 @@ profiles:
               approved set of references in different combinations. Agent
               Secret stores values in background helper memory and returns a
               public session ID for management plus a secret session token for
-              <code>with-session</code>.
+              <code>with-session</code> calls from the same requester process
+              tree.
             </p>
             <div class="code-panel">
               <pre><code>agent-secret session create --profile terraform-cloudflare --max-reads 3
@@ -234,7 +235,8 @@ agent-secret session destroy asid_123</code></pre>
               <code>session list</code> never reveals session tokens.
               <code>with-session</code> injects every approved alias by default,
               or a per-command subset with <code>--only</code>. Unknown aliases
-              fail before the child command starts.
+              fail before the child command starts. Use sessions inside one
+              task shell, wrapper script, or agent process tree.
             </p>
             <p>
               Sessions end when TTL passes, the read count is exhausted,

--- a/site/index.html
+++ b/site/index.html
@@ -362,7 +362,7 @@ profiles:
               <li>The background helper fetches only the secrets you approved for the request.</li>
               <li>Audit logs record metadata, never raw secrets.</li>
               <li>Reusable approvals stay bounded by command, cwd, references, account, TTL, and use count.</li>
-              <li>Sessions stay bounded by cwd, aliases, TTL, read count, secret tokens, and the <code>with-session</code> wrapper.</li>
+              <li>Sessions stay bounded by requester process tree, cwd, aliases, TTL, read count, secret tokens, and the <code>with-session</code> wrapper.</li>
             </ul>
           </div>
           <div>


### PR DESCRIPTION
## Summary

- Bind approved sessions to the requester process tree that created them, not just to the session token/cwd/read budget.
- Reject `with-session` resolution when a token is replayed from an unrelated same-user process tree.
- Keep common shell usage working by anchoring through same-executable shell/subshell hops, covering Bash command substitution and zsh shell-variable patterns.
- Harden the process-tree validation path against transient ancestry-walk exits and unusual ineligible intermediate ancestors flagged in review.
- Update CLI help, agent-context, docs, website, bundled skill, PRD, threat model, security policy, and session E2E runbook language.
- Add a pre-release product E2E gate for multi-secret sessions and detached process-tree replay rejection.

## Security Impact

This closes the token-only replay gap for bounded sessions: observing a `session_token` is no longer enough for an unrelated local process to resolve approved aliases, even from the same cwd before TTL/read exhaustion.

## Validation

- `mise exec -- go test ./internal/peercred ./internal/daemon/broker ./internal/daemon ./internal/cli`
- `npx --yes markdownlint-cli CHANGELOG.md README.md SECURITY.md docs/configuration.md docs/threat-model.md docs/session-e2e-validation.md docs/prd.md .agents/skills/agent-secret/SKILL.md`
- `mise exec -- go test -race ./internal/daemon/control -run 'TestManagerRepairRefreshesRepairableUnexpectedHelper|TestManagerRepairRefusesRepairableUnexpectedHelperWithoutReleaseTeamID' -count=1 -v`
- `mise exec -- go test -cover ./internal/peercred`
- `AGENT_SECRET_IN_MISE=1 scripts/release/test-release-docs.sh`
- `mise run lint:shell`
- Session E2E runbook command block parses with `bash -n` and `zsh -n`.
- `mise exec -- go test ./internal/daemon/broker ./internal/peercred`
- `npx --yes markdownlint-cli CHANGELOG.md`
- `mise run lint`
- `mise run build`
- `mise run test`
- GitHub PR checks on `cda1473`: `Lint, Test, Build`, `Smoke Tests`, and `Cloudflare Pages` passed.
- Greptile review threads are resolved.
