### PR TITLE
Add shell-friendly session binding

### DIFF
--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -107,7 +107,8 @@ Approve a bounded multi-command session:
 
 ```bash
 session_json="$(agent-secret session create \
-  --json \
+  --json=compact \
+  --bind-parent \
   --profile terraform-cloudflare \
   --max-reads 3)"
 session_id="$(printf '%s' "$session_json" |
@@ -140,13 +141,23 @@ process starts. Use `session destroy SESSION_ID` for one session or
 `session destroy --all` to clear every active session.
 
 Treat `session_token` as a short-lived secret capability bound to the requester
-process tree that created the session. Create and consume a session inside the
-same task shell, wrapper script, or agent process tree. Keep the token in a
-local shell variable only for the duration of the bounded workflow; do not write
-it to repo files, durable agent memory, PR comments, logs, `.env` files, or
-documentation. Keep the public `session_id` separately for cleanup. Prefer
+process tree that created the session. Use `--bind-parent` when the session is
+created inside command substitution and later used from the parent shell. Use
+`--bind-ancestor N` only for deeper wrappers; N must be 1..3 and Agent Secret
+only accepts ancestors of the current `agent-secret` process. Profiles can set:
+
+- `session.bind: parent`
+- `session.bind: auto`
+- `session.bind: { ancestor: N }`
+
+CLI binding flags override profile config. Keep the token in a local shell
+variable only for the duration of the bounded workflow; do not write it to repo
+files, durable agent memory, PR comments, logs, `.env` files, or documentation.
+Keep the public `session_id` separately for cleanup. Prefer
 `session destroy SESSION_ID` or `session destroy --all` when the workflow is
-done.
+done. If `with-session` reports a process mismatch, use the bound/requester
+process names, PIDs, and paths in the error to decide whether the session
+should be recreated with `--bind-parent`.
 
 Use a shell only when the shell is the command you actually want approved:
 
@@ -206,6 +217,8 @@ profiles:
   cloudflare:
     reason: Terraform DNS management
     ttl: 10m
+    session:
+      bind: parent
     secrets:
       CLOUDFLARE_API_TOKEN: op://Example/Cloudflare/token
 
@@ -463,9 +476,11 @@ Before reporting success, prove the migrated path works:
   `--only` wrapper that filters aliases.
 - For session workflows, test `session create`, `session list`, at least one
   full `with-session` invocation, any `with-session --only` subsets, and
-  session exhaustion or `session destroy`. Run session create and session use
-  from the same task shell or wrapper script so the process-tree binding is
-  exercised. For product or release validation, run
+  session exhaustion or `session destroy`. Use `--json=compact` for shell
+  wrappers and verify `session list --json` includes `session_binding` metadata.
+  Run session create and session use from the same task shell or wrapper script
+  so the process-tree binding is exercised. For product or release validation,
+  run
   `docs/session-e2e-validation.md` and confirm the detached process-tree replay
   attempt is rejected before the child command starts.
 - For `--env-file` migrations, test that the real command receives both a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@ version numbers for public releases.
 - GitHub release notes are copied from the matching version section in this
 file before a release is published.
 
+## [0.0.26] - Pending
+
+### Added
+
+- Added `agent-secret session create --bind-parent` and `--bind-ancestor N` so
+  shell wrappers can bind approved sessions to a stable ancestor process instead
+  of the short-lived `agent-secret` process.
+- Added profile config support for session binding with `session.bind: parent`,
+  `session.bind: auto`, and `session.bind: { ancestor: N }`.
+- Added `--json=compact` for session create, list, and destroy output so shell
+  wrappers can safely read one JSON object per line.
+
+### Changed
+
+- Session create/list JSON and approval prompts now include non-secret session
+  binding metadata: binding mode, ancestor depth, bound process, and creator
+  process.
+- Session process mismatch errors now include the bound process and requester
+  process names, PIDs, and paths to make binding failures diagnosable.
+
 ## [0.0.25] - 2026-06-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ file before a release is published.
 - Session create/list JSON and approval prompts now include non-secret session
   binding metadata: binding mode, ancestor depth, bound process, and creator
   process.
+- Session `--max-reads` now accepts up to `100` successful `with-session`
+  commands for longer approved workflows.
 - Session process mismatch errors now include the bound process and requester
   process names, PIDs, and paths to make binding failures diagnosable.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ agent-secret exec --reuse-only --profile terraform-cloudflare -- terraform plan
 Approve a bounded multi-command session and run commands through the wrapper:
 
 ```bash
-agent-secret session create --profile terraform-cloudflare --max-reads 2
+agent-secret session create --profile terraform-cloudflare --bind-parent \
+  --max-reads 2 --json=compact
 agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- terraform plan
 agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
@@ -139,9 +140,11 @@ agent-secret session destroy asid_123
 Keep the `session_token` returned by `session create` for `with-session`.
 Use the `session_id` returned by `session create` or shown by `session list`
 for inspection and cleanup. `session list` never shows session tokens.
-Session tokens are accepted only from the requester process tree that created
-the session, so create and use them inside the same task shell, wrapper script,
-or agent process tree.
+Session tokens are accepted only from the approved requester process tree. Use
+`--bind-parent` when a shell wrapper creates the session inside command
+substitution and later calls `with-session` from the parent shell.
+Advanced wrappers can use `--bind-ancestor N` up to `3`, but only ancestors of
+the current `agent-secret` process are accepted.
 
 Inspect item metadata without revealing values:
 
@@ -186,6 +189,8 @@ profiles:
   terraform-cloudflare:
     reason: Terraform DNS management
     ttl: 10m
+    session:
+      bind: parent
     secrets:
       CLOUDFLARE_API_TOKEN: op://Example/Cloudflare/token
       STATE_TOKEN: op://Example/Terraform State/token
@@ -264,9 +269,9 @@ The launch build is intentionally narrow:
 
 - macOS on Apple Silicon only.
 - 1Password Desktop and Bitwarden Secrets Manager only; no other providers yet.
-- Sessions are bounded by requester process tree, cwd, TTL, read count, aliases,
-  background-helper memory, and `agent-secret with-session`; no long-lived
-  interactive shells.
+- Sessions are bounded by requester process tree or explicit ancestor binding,
+  cwd, TTL, read count, aliases, background-helper memory, and
+  `agent-secret with-session`; no long-lived interactive shells.
 - No writing, updating, or rotating secrets yet.
 - No GCP Secret Manager or GCP token minting support yet.
 - No sandbox guarantee after you approve a child process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ The supported runtime scope is narrow:
 - CLI-supervised `agent-secret exec` with environment injection.
 - Bounded background-helper sessions through `session create`, `session list`,
   `session destroy`, and `with-session`, with token use bound to the requester
-  process tree that created the session.
+  process tree or explicit ancestor binding selected at session creation.
 
 Linux, Windows, credential helpers, automatic updates, and alternative secret
 backends are not supported security surfaces yet.

--- a/approver/Sources/AgentSecretApprover/Models/ApprovalRequest.swift
+++ b/approver/Sources/AgentSecretApprover/Models/ApprovalRequest.swift
@@ -17,6 +17,7 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
         case allowMutableExecutable = "allow_mutable_executable"
         case reusableUses = "reusable_uses"
         case resources
+        case sessionBinding = "session_binding"
     }
 
     /// Default reusable approval count for programmatic requests and out-of-range daemon values.
@@ -38,6 +39,7 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
     public var overrideEnv: Bool
     public var overriddenAliases: [String]
     public var reusableUses: Int
+    public var sessionBinding: SessionBindingInfo?
 
     init(
         requestID: String,
@@ -53,7 +55,8 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
         allowsReusable: Bool = true,
         overrideEnv: Bool = false,
         overriddenAliases: [String] = [],
-        reusableUses: Int = Self.defaultReusableUses
+        reusableUses: Int = Self.defaultReusableUses,
+        sessionBinding: SessionBindingInfo? = nil
     ) {
         self.requestID = requestID
         self.nonce = nonce
@@ -69,6 +72,7 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
         self.overrideEnv = overrideEnv
         self.overriddenAliases = overriddenAliases
         self.reusableUses = Self.boundedReusableUses(reusableUses)
+        self.sessionBinding = sessionBinding
     }
 
     /// Decodes current daemon protocol payloads.
@@ -92,6 +96,7 @@ public struct ApprovalRequest: Codable, Equatable, Sendable {
             forKey: .reusableUses
         )
         reusableUses = Self.boundedReusableUses(decodedReusableUses)
+        sessionBinding = try container.decodeIfPresent(SessionBindingInfo.self, forKey: .sessionBinding)
     }
 
     static func boundedReusableUses(_ uses: Int) -> Int {

--- a/approver/Sources/AgentSecretApprover/Models/SessionBindingInfo.swift
+++ b/approver/Sources/AgentSecretApprover/Models/SessionBindingInfo.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct SessionBindingInfo: Codable, Equatable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case ancestorDepth = "ancestor_depth"
+        case boundProcess = "bound_process"
+        case creatorProcess = "creator_process"
+    }
+
+    public var mode: String
+    public var ancestorDepth: Int?
+    public var boundProcess: SessionBindingProcess
+    public var creatorProcess: SessionBindingProcess
+
+    public init(
+        mode: String,
+        boundProcess: SessionBindingProcess,
+        creatorProcess: SessionBindingProcess,
+        ancestorDepth: Int? = nil
+    ) {
+        self.mode = mode
+        self.ancestorDepth = ancestorDepth
+        self.boundProcess = boundProcess
+        self.creatorProcess = creatorProcess
+    }
+}

--- a/approver/Sources/AgentSecretApprover/Models/SessionBindingProcess.swift
+++ b/approver/Sources/AgentSecretApprover/Models/SessionBindingProcess.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct SessionBindingProcess: Codable, Equatable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case pid
+        case parentPID = "parent_pid"
+        case name
+        case path
+    }
+
+    public var pid: Int
+    public var parentPID: Int?
+    public var name: String
+    public var path: String
+
+    public init(pid: Int, name: String, path: String, parentPID: Int? = nil) {
+        self.pid = pid
+        self.parentPID = parentPID
+        self.name = name
+        self.path = path
+    }
+}

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+Inspection.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+Inspection.swift
@@ -15,6 +15,7 @@ extension ApprovalRequestViewModel {
                 resourceSectionTitle: Self.inspectionResourceSectionTitle(for: operation),
                 resourceRows: resourceRows,
                 scopeSummary: scopeSummary,
+                sessionBindingInspectionText: sessionBindingInspectionText,
                 timeRemaining: timeRemaining
             )
         )
@@ -33,6 +34,7 @@ extension ApprovalRequestViewModel {
         let resourceSectionTitle: String
         let resourceRows: [String]
         let scopeSummary: String
+        let sessionBindingInspectionText: String?
         let timeRemaining: String
     }
 
@@ -66,6 +68,10 @@ extension ApprovalRequestViewModel {
             lines.append(contentsOf: input.overriddenAliases.map { "- \($0)" })
         }
         lines.append("Scope: \(input.scopeSummary)")
+        if let sessionBindingInspectionText: String = input.sessionBindingInspectionText {
+            lines.append("Session binding:")
+            lines.append(sessionBindingInspectionText)
+        }
         lines.append(input.resourceSectionTitle)
         lines.append(contentsOf: input.resourceRows)
         lines.append("Time remaining: \(input.timeRemaining)")

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+SessionBinding.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+SessionBinding.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+extension ApprovalRequestViewModel {
+    static func sessionBindingSummary(_ binding: SessionBindingInfo?) -> String? {
+        guard let binding else {
+            return nil
+        }
+        return processSummary(binding.boundProcess)
+    }
+
+    static func sessionBindingInspectionText(_ binding: SessionBindingInfo?) -> String? {
+        guard let binding else {
+            return nil
+        }
+        var lines = [
+            "Mode: \(sanitizedDisplayText(binding.mode))"
+        ]
+        if let ancestorDepth = binding.ancestorDepth {
+            lines.append("Ancestor depth: \(ancestorDepth)")
+        }
+        lines.append("Bound process: \(processInspectionLine(binding.boundProcess))")
+        lines.append("Creator process: \(processInspectionLine(binding.creatorProcess))")
+        return lines.joined(separator: "\n")
+    }
+
+    private static func processSummary(_ process: SessionBindingProcess) -> String {
+        "\(sanitizedDisplayText(process.name)) pid=\(process.pid)"
+    }
+
+    private static func processInspectionLine(_ process: SessionBindingProcess) -> String {
+        var parts = [
+            "\(sanitizedDisplayText(process.name))",
+            "pid=\(process.pid)"
+        ]
+        if let parentPID = process.parentPID {
+            parts.append("ppid=\(parentPID)")
+        }
+        parts.append("path=\(sanitizedDisplayText(process.path))")
+        return parts.joined(separator: " ")
+    }
+}

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel.swift
@@ -33,6 +33,8 @@ struct ApprovalRequestViewModel: Equatable {
     let reusableUses: Int
     let allowsReusableApproval: Bool
     let scopeSummary: String
+    let sessionBindingSummary: String?
+    let sessionBindingInspectionText: String?
     let allowReusableTitle: String
     let printsEnvironmentWarning: Bool
     let overrideEnv: Bool
@@ -52,6 +54,7 @@ struct ApprovalRequestViewModel: Equatable {
                 commandArgumentRows: commandArguments.map(\.inspectorLine),
                 cwd: cwd,
                 scopeSummary: scopeSummary,
+                sessionBindingSummary: sessionBindingSummary,
                 resolvedExecutable: resolvedExecutable,
                 allowMutableExecutable: allowMutableExecutable,
                 resourceRows: resourceRows,
@@ -94,6 +97,8 @@ struct ApprovalRequestViewModel: Equatable {
             resourcePresentation.count >= Self.highScopeResourceThreshold
         (reusableUses, allowsReusableApproval) = (request.reusableUses, request.allowsReusable)
         (scopeSummary, allowReusableTitle) = (copy.scopeSummary, copy.allowReusableTitle)
+        sessionBindingSummary = Self.sessionBindingSummary(request.sessionBinding)
+        sessionBindingInspectionText = Self.sessionBindingInspectionText(request.sessionBinding)
         let warnings: WarningPresentation = Self.warningPresentation(for: request, highScopeWarning: highScopeWarning)
         (printsEnvironmentWarning, overrideWarning, cautionMessages) = (
             warnings.printsEnvironment,
@@ -172,6 +177,9 @@ struct ApprovalRequestViewModel: Equatable {
             "Working directory: \(viewModel.cwd)",
             "Scope: \(viewModel.scopeSummary)"
         ])
+        if let sessionBindingSummary: String = viewModel.sessionBindingSummary {
+            lines.append("Session binding: \(sessionBindingSummary)")
+        }
         lines.append("Resolved binary: \(viewModel.resolvedExecutable)")
         lines.append("Mutable executable allowed: \(viewModel.allowMutableExecutable ? "yes" : "no")")
         if operation == .itemDescribe {

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModelRenderInput.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModelRenderInput.swift
@@ -5,6 +5,7 @@ struct ApprovalRequestViewModelRenderInput {
     let commandArgumentRows: [String]
     let cwd: String
     let scopeSummary: String
+    let sessionBindingSummary: String?
     let resolvedExecutable: String
     let allowMutableExecutable: Bool
     let resourceRows: [String]

--- a/approver/Sources/AgentSecretApprover/Presentation/Views/Context/ApprovalRequestContextSection.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/Views/Context/ApprovalRequestContextSection.swift
@@ -38,6 +38,19 @@ import Foundation
                     )
                     .frame(maxWidth: .infinity, alignment: .topLeading)
                 }
+                sessionBindingRow
+            }
+        }
+
+        @ViewBuilder private var sessionBindingRow: some View {
+            if let sessionBindingSummary = viewModel.sessionBindingSummary {
+                ApprovalPanelContextRow(
+                    icon: "link",
+                    title: "Session binding",
+                    value: sessionBindingSummary,
+                    inspectAction: requestScopeInspectionAction
+                )
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
         }
 

--- a/approver/Tests/AgentSecretApproverTests/Presentation/ApprovalRequestInspectionTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/Presentation/ApprovalRequestInspectionTests.swift
@@ -28,6 +28,42 @@ final class ApprovalRequestInspectionTests: XCTestCase {
         )
     }
 
+    private static var sessionCreateRequest: ApprovalRequest {
+        ApprovalRequest(
+            requestID: "req_session_create",
+            nonce: "nonce_session_create",
+            reason: "Deploy workflow",
+            command: ["agent-secret", "session", "create", "--profile", "deploy"],
+            cwd: "/tmp/project",
+            expiresAt: Date(timeIntervalSince1970: sampleExpiration),
+            resources: [
+                RequestedResource(
+                    alias: "DEPLOY_TOKEN",
+                    ref: "op://Example Vault/Deploy/token",
+                    account: "Work"
+                )
+            ],
+            resolvedExecutable: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+            operation: .sessionCreate,
+            allowsReusable: false,
+            sessionBinding: SessionBindingInfo(
+                mode: "ancestor",
+                boundProcess: SessionBindingProcess(
+                    pid: 501,
+                    name: "zsh",
+                    path: "/bin/zsh",
+                    parentPID: 1
+                ),
+                creatorProcess: SessionBindingProcess(
+                    pid: 502,
+                    name: "agent-secret",
+                    path: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret"
+                ),
+                ancestorDepth: 1
+            )
+        )
+    }
+
     func testItemMetadataInspectionUsesOperationAwareResourceHeading() {
         let viewModel = ApprovalRequestViewModel(
             request: Self.itemDescribeRequest,
@@ -38,6 +74,24 @@ final class ApprovalRequestInspectionTests: XCTestCase {
         XCTAssertTrue(inspection.contains("Item metadata:"))
         XCTAssertFalse(inspection.contains("Secrets:"))
         XCTAssertTrue(inspection.contains("EXAMPLE_TOKEN [Account: Work] -> op://Example Vault/Example Item/token"))
+        XCTAssertFalse(inspection.contains(Self.canarySecretValue))
+    }
+
+    func testSessionInspectionIncludesBindingProcessMetadata() {
+        let viewModel = ApprovalRequestViewModel(
+            request: Self.sessionCreateRequest,
+            now: Date(timeIntervalSince1970: Self.viewModelNow)
+        )
+        let inspection: String = viewModel.requestInspectionText
+
+        XCTAssertEqual(viewModel.sessionBindingSummary, "zsh pid=501")
+        XCTAssertTrue(inspection.contains("Session binding:"))
+        XCTAssertTrue(inspection.contains("Mode: ancestor"))
+        XCTAssertTrue(inspection.contains("Ancestor depth: 1"))
+        XCTAssertTrue(inspection.contains("Bound process: zsh pid=501 ppid=1 path=/bin/zsh"))
+        let creatorLine = "Creator process: agent-secret pid=502 " +
+            "path=/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret"
+        XCTAssertTrue(inspection.contains(creatorLine))
         XCTAssertFalse(inspection.contains(Self.canarySecretValue))
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -343,7 +343,7 @@ agent-secret session destroy [--json] --all
 
 It also accepts `--max-reads COUNT`, which limits the number of successful
 `with-session` reads. The default is `1`; the allowed range is `1` through
-`20`. `--json=compact` emits one JSON object on a single line for shell
+`100`. `--json=compact` emits one JSON object on a single line for shell
 wrappers. Plain `--json` remains pretty-printed.
 
 By default, Agent Secret binds a session token to a stable requester process in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,8 @@ profiles:
     account: Example Corp
     reason: Terraform DNS management
     ttl: 10m
+    session:
+      bind: parent
     secrets:
       CLOUDFLARE_API_TOKEN: op://Example/Cloudflare/token
       PREVIEW_TOKEN:
@@ -85,6 +87,8 @@ Profile fields:
 - `ttl`: optional approval TTL, such as `90s`, `2m`, or `10m`.
 - `account`: optional 1Password account override for all secrets in a profile.
 - `include`: optional list of profile names to merge before this profile.
+- `session`: optional session-specific policy. Currently supports
+  `bind: auto`, `bind: parent`, or `bind: { ancestor: N }`.
 - `secrets`: map of environment aliases to secret references. Required
   unless `include` contributes at least one secret.
 
@@ -113,8 +117,8 @@ profiles:
 
 Includes are resolved in order. Later included profiles override earlier
 secrets with the same alias, and the selected profile overrides all included
-profiles. `reason` and `ttl` also follow that order: the last included value is
-used unless the selected profile sets its own value.
+profiles. `reason`, `ttl`, and `session.bind` also follow that order: the last
+included value is used unless the selected profile sets its own value.
 
 Each included secret keeps the account chosen by the profile that defined it.
 If the selected profile needs a different account or reference for a secret,
@@ -307,7 +311,7 @@ value and env-var delivery does not support binary attachments with NUL bytes.
 
 Sessions approve one bag of secret references, keep the resolved values in
 Agent Secret's background helper memory, and let later child commands consume
-that bag only through `agent-secret with-session` from the same requester
+that bag only through `agent-secret with-session` from the approved requester
 process tree. Use them for bounded workflows where a user
 approves several secrets once and subsequent commands need those secrets in
 different combinations.
@@ -334,10 +338,41 @@ agent-secret session destroy [--json] --all
 - `--ttl DURATION`
 - `--override-env`
 - `--json`
+- `--bind-parent`
+- `--bind-ancestor N`
 
 It also accepts `--max-reads COUNT`, which limits the number of successful
 `with-session` reads. The default is `1`; the allowed range is `1` through
-`20`.
+`20`. `--json=compact` emits one JSON object on a single line for shell
+wrappers. Plain `--json` remains pretty-printed.
+
+By default, Agent Secret binds a session token to a stable requester process in
+the creator's process tree. `--bind-parent` binds to the direct parent of the
+`agent-secret session create` process, which is usually the right choice when a
+shell wrapper captures the JSON in command substitution and later runs
+`with-session` from the parent shell. `--bind-ancestor N` binds to a deeper
+ancestor, up to `3`. Agent Secret rejects arbitrary PIDs; explicit bindings can
+target only ancestors of the current `agent-secret` process.
+
+The same binding policy can live in a profile:
+
+```yaml
+profiles:
+  deploy:
+    reason: Deploy application
+    session:
+      bind: parent
+    secrets:
+      DEPLOY_TOKEN: op://Example/Deploy/token
+
+  nested-wrapper:
+    include: [deploy]
+    session:
+      bind:
+        ancestor: 2
+```
+
+CLI `--bind-parent` or `--bind-ancestor` overrides profile `session.bind`.
 
 For example, approve a project profile plus a one-off CLI reference, then use
 different aliases for different commands:
@@ -347,7 +382,8 @@ agent-secret session create \
   --profile terraform-cloudflare \
   --secret STATE_TOKEN=op://Example/Terraform\ State/token \
   --max-reads 3 \
-  --json
+  --bind-parent \
+  --json=compact
 
 agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- \
   terraform plan
@@ -362,8 +398,11 @@ agent-secret with-session astok_123 \
 - `session_id`: a management identifier shown by `session list` and accepted by
   `session destroy`.
 - `session_token`: a secret token accepted by `with-session` only from the
-  requester process tree that created the session. It is never shown by
+  requester process tree that created the session or the explicit ancestor tree
+  selected by `--bind-parent` / `--bind-ancestor`. It is never shown by
   `session list`.
+- `session_binding`: non-secret binding metadata including binding mode,
+  ancestor depth, bound process, and creator process.
 
 It does not print secret values. `session list` shows active `session_id` values
 and non-secret metadata for inspection and cleanup. Without `--only`,
@@ -375,8 +414,10 @@ child command.
 `with-session` accepts `--cwd DIR`, `--only ALIAS[,ALIAS...]`, and
 `--allow-mutable-executable`. The `--cwd` value defaults to the caller's current
 directory and must match the session working directory. The caller must also be
-inside the same requester process tree that ran `session create`; keep session
-creation and use inside one task shell, wrapper script, or agent process tree.
+inside the same requester process tree that ran `session create`, or inside the
+explicit ancestor tree selected by `--bind-parent` / `--bind-ancestor`. If
+`with-session` fails with a process mismatch, the error includes the bound
+process and requester process names, PIDs, and paths.
 
 Sessions are background-helper-memory only. They expire when TTL passes, the
 read count is exhausted, `agent-secret session destroy SESSION_ID` or

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -851,7 +851,7 @@ Global options:
 Session option:
 
 ```text
---max-reads integer          Session create only. Default: 1. Max: 20.
+--max-reads integer          Session create only. Default: 1. Max: 100.
 --bind-parent                Session create only. Bind to the parent process.
 --bind-ancestor integer      Session create only. Bind to ancestor depth 1..3.
 --json=compact               Session create/list/destroy. One-line JSON output.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -132,9 +132,9 @@ ansible-playbook site.yml --check
 
 The user approves once for a TTL and max-read count. The broker returns a
 public `session_id` for management plus a secret `session_token` for
-`agent-secret with-session` calls from the approved requester process tree,
-keeps values in Agent Secret's background helper memory, and injects them only
-into wrapped child processes.
+`agent-secret with-session` calls from the approved requester process tree or
+explicit ancestor binding, keeps values in Agent Secret's background helper
+memory, and injects them only into wrapped child processes.
 V1 sessions do not add generic socket reads or credential-helper protocols.
 
 ### Use Case 3: Config-Driven Secret Sync
@@ -681,16 +681,19 @@ Limitations:
 The broker creates a short-lived session and returns a public `session_id` for
 list/destroy operations plus a secret `session_token` instead of values. Values
 stay in Agent Secret's background helper memory and are useful only through
-`agent-secret with-session`, matching requester process tree, peer credentials,
-cwd, remaining read count, and unexpired policy.
+`agent-secret with-session`, matching requester process tree or explicit
+ancestor binding, peer credentials, cwd, remaining read count, and unexpired
+policy.
 
 Unlike same-command reuse, sessions approve a bounded set of references for a
 workflow lifetime and allow those approved references to be injected into
 multiple wrapped commands, subject to TTL, max-read, peer, and destroy policy.
 On macOS, session resolution must fail closed unless the daemon can validate the
-same UID, trusted wrapper peer, requester process tree, cwd, TTL, and read count
-against the approved session. Session values must clear when TTL expires, read
-counts are exhausted, the daemon stops, or the session is destroyed.
+same UID, trusted wrapper peer, requester process tree or configured ancestor
+binding, cwd, TTL, and read count against the approved session. Explicit
+bindings can target only ancestors of the current `agent-secret` process, not
+arbitrary PIDs. Session values must clear when TTL expires, read counts are
+exhausted, the daemon stops, or the session is destroyed.
 
 ### Mode 3: `with-session`
 
@@ -849,6 +852,9 @@ Session option:
 
 ```text
 --max-reads integer          Session create only. Default: 1. Max: 20.
+--bind-parent                Session create only. Bind to the parent process.
+--bind-ancestor integer      Session create only. Bind to ancestor depth 1..3.
+--json=compact               Session create/list/destroy. One-line JSON output.
 ```
 
 V1 commands:
@@ -1190,6 +1196,8 @@ Exit criteria:
 - Session create returns a public session ID and secret session token.
 - Session tokens cannot be resolved after TTL.
 - Session tokens cannot be resolved more than the allowed read count.
+- Session tokens cannot be resolved outside the approved requester process tree
+  or explicit ancestor binding.
 - On macOS, session resolution fails closed if peer UID, PID, executable path, or
   cwd cannot be obtained or does not match the approved session policy.
 - Destroying a session invalidates the session token.

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -86,6 +86,8 @@ profiles:
   session-e2e:
     reason: Agent Secret session E2E multi-secret validation
     ttl: 2m
+    session:
+      bind: parent
     secrets:
       SESSION_E2E_PROFILE_TOKEN: "$profile_ref"
 YAML
@@ -113,7 +115,7 @@ run_with_session() {
 
 SESSION_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
   agent-secret session create \
-    --json \
+    --json=compact \
     --profile session-e2e \
     --secret "SESSION_E2E_CLI_TOKEN=$cli_ref" \
     --max-reads 5)"
@@ -123,7 +125,7 @@ SESSION_TOKEN="$(printf '%s' "$SESSION_JSON" |
   python3 -c 'import json,sys; print(json.load(sys.stdin)["session_token"])')"
 printf 'created mixed config+CLI session: %s\n' "$SESSION_ID"
 
-agent-secret session list --json |
+agent-secret session list --json=compact |
   python3 -c 'import os, json, sys
 session_id = sys.argv[1]
 data = json.load(sys.stdin)
@@ -138,7 +140,12 @@ matches = [
 assert len(matches) >= 1, data
 assert matches[0]["cwd"] == os.getcwd(), matches[0]
 assert "session_token" not in matches[0], matches[0]
-print("session list ok")' "$SESSION_ID"
+binding = matches[0]["session_binding"]
+assert binding["mode"] == "ancestor", binding
+assert binding["ancestor_depth"] == 1, binding
+assert binding["bound_process"]["pid"] > 1, binding
+assert binding["bound_process"]["path"], binding
+print("session list and binding metadata ok")' "$SESSION_ID"
 
 run_with_session "$SESSION_TOKEN" \
   --allow-mutable-executable \
@@ -237,7 +244,7 @@ run_with_session "$SESSION_TOKEN" \
   --allow-mutable-executable \
   -- python3 -c "$check_py" both
 
-agent-secret session list --json |
+agent-secret session list --json=compact |
   python3 -c 'import os, json, sys
 session_id = sys.argv[1]
 data = json.load(sys.stdin)
@@ -274,9 +281,10 @@ SESSION_TOKEN=""
 
 EXHAUST_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
   agent-secret session create \
-    --json \
+    --json=compact \
     --profile session-e2e \
     --secret "SESSION_E2E_CLI_TOKEN=$cli_ref" \
+    --bind-ancestor 1 \
     --max-reads 1)"
 EXHAUST_ID="$(printf '%s' "$EXHAUST_JSON" |
   python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"
@@ -354,7 +362,7 @@ The exact session IDs vary, but a passing run prints these checkpoints:
 
 ```text
 created mixed config+CLI session: asid_...
-session list ok
+session list and binding metadata ok
 full ok
 profile ok
 detached process-tree replay rejected before child spawn
@@ -375,8 +383,13 @@ session E2E ok
 This E2E run proves:
 
 - `session create` accepts secrets from a project config profile and CLI args.
+- `session create` accepts `session.bind: parent` from profile config and
+  explicit `--bind-ancestor 1` from CLI flags.
+- `session create`, `session list`, and JSON parsing work with
+  `--json=compact`.
 - `session list` shows public session IDs and working directories for active
-  sessions without values or session tokens.
+  sessions without values or session tokens, and includes non-secret binding
+  metadata.
 - `with-session` injects the full approved bag when `--only` is omitted.
 - `with-session --only` injects config-only, CLI-only, and combined subsets.
 - `with-session` accepts session tokens from the same requester process tree

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -2,7 +2,7 @@
 
 Status: living review contract.
 
-Last reviewed: 2026-06-07.
+Last reviewed: 2026-06-16.
 
 ## Purpose
 
@@ -108,7 +108,9 @@ Agent Secret must meet these goals:
   cached raw values when exhausted, expired, or rolled back.
 - Bounded session tokens are returned only at `session create` time, are not
   enumerable through session listing, and are usable only from the requester
-  process tree that created the session.
+  process tree selected at session creation. Explicit parent or ancestor
+  bindings can target only ancestors of the current `agent-secret` process, not
+  arbitrary PIDs.
 - The daemon accepts exec and stop requests only from trusted Agent Secret CLI
   executables.
 - The CLI accepts secret-bearing responses only from a trusted Agent Secret

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -215,7 +215,7 @@ func agentContextCommands() map[string]commandContext {
 						{Name: "--config", Type: "path", Description: "Profile config path."},
 						{Name: "--cwd", Type: "path", Description: "Session working directory."},
 						{Name: "--ttl", Type: "duration", Default: request.DefaultSessionTTL.String(), Description: "Session TTL.", Values: []string{request.MinRequestTTL.String() + ".." + request.MaxRequestTTL.String()}},
-						{Name: "--max-reads", Type: "int", Default: "1", Values: []string{"1..20"}, Description: "Maximum with-session resolves before the session is exhausted."},
+						{Name: "--max-reads", Type: "int", Default: "1", Values: []string{"1..100"}, Description: "Maximum with-session resolves before the session is exhausted."},
 						{Name: "--override-env", Type: "bool", Description: "Allow with-session to replace existing child env vars with approved aliases."},
 						{Name: "--bind-parent", Type: "bool", Description: "Bind the session to the parent of this agent-secret process."},
 						{Name: "--bind-ancestor", Type: "int", Values: []string{"1..3"}, Description: "Bind the session to an ancestor process depth; only ancestors are accepted."},

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -106,7 +106,7 @@ func (a App) runAgentContext(command Command) int {
 				"secret values are never printed by agent-secret",
 				"exec passes child stdin/stdout/stderr through unchanged",
 				"item describe returns metadata only",
-				"session create returns a public session id and secret session token bound to the requester process tree; with-session never prints values",
+				"session create returns a public session id and secret session token bound to the approved requester process tree; with-session never prints values",
 			},
 			MutationBoundary: []string{
 				"exec --dry-run validates without prompting or spawning",
@@ -217,22 +217,24 @@ func agentContextCommands() map[string]commandContext {
 						{Name: "--ttl", Type: "duration", Default: request.DefaultSessionTTL.String(), Description: "Session TTL.", Values: []string{request.MinRequestTTL.String() + ".." + request.MaxRequestTTL.String()}},
 						{Name: "--max-reads", Type: "int", Default: "1", Values: []string{"1..20"}, Description: "Maximum with-session resolves before the session is exhausted."},
 						{Name: "--override-env", Type: "bool", Description: "Allow with-session to replace existing child env vars with approved aliases."},
-						{Name: "--json", Type: "bool", Description: "Print session metadata as JSON."},
+						{Name: "--bind-parent", Type: "bool", Description: "Bind the session to the parent of this agent-secret process."},
+						{Name: "--bind-ancestor", Type: "int", Values: []string{"1..3"}, Description: "Bind the session to an ancestor process depth; only ancestors are accepted."},
+						{Name: "--json", Type: "enum", Values: []string{"true", "pretty", "compact"}, Description: "Print session metadata as JSON; compact emits one line."},
 					},
-					Outputs: []string{"text", "json"},
-					Notes:   []string{"returns a public session id for management and a secret session token bound to the requester process tree for with-session", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
+					Outputs: []string{"text", "json", "compact json"},
+					Notes:   []string{"returns a public session id for management and a secret session token bound to the requester process tree for with-session", "use --bind-parent for shell command substitution wrappers that later call with-session from the parent shell", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
 				},
 				"list": {
 					Summary: "List active session ids and non-secret metadata.",
-					Flags:   jsonFlag(),
-					Outputs: []string{"text", "json"},
+					Flags:   sessionJSONFlag(),
+					Outputs: []string{"text", "json", "compact json"},
 				},
 				"destroy": {
 					Summary: "Destroy one session and clear its cached values.",
 					Flags: append([]flagContext{
 						{Name: "--all", Type: "bool", Description: "Destroy all active sessions."},
-					}, jsonFlag()...),
-					Outputs: []string{"text", "json"},
+					}, sessionJSONFlag()...),
+					Outputs: []string{"text", "json", "compact json"},
 				},
 			},
 		},
@@ -243,7 +245,7 @@ func agentContextCommands() map[string]commandContext {
 				{Name: "--allow-mutable-executable", Type: "bool", Description: "Allow a user-owned or writable executable path after surfacing the approval warning."},
 			},
 			Outputs: []string{"child passthrough"},
-			Notes:   []string{"usage: agent-secret with-session SESSION_TOKEN -- COMMAND [ARG...]", "caller must be in the requester process tree that created the session", "session values are injected into the child environment and never printed"},
+			Notes:   []string{"usage: agent-secret with-session SESSION_TOKEN -- COMMAND [ARG...]", "caller must be in the requester process tree that created the session or in the ancestor tree selected with session create --bind-parent/--bind-ancestor", "session values are injected into the child environment and never printed"},
 		},
 		"bitwarden": {
 			Summary: "Manage local Bitwarden Secrets Manager token aliases.",
@@ -327,4 +329,8 @@ func agentContextCommands() map[string]commandContext {
 
 func jsonFlag() []flagContext {
 	return []flagContext{{Name: "--json", Type: "bool", Description: "Print JSON output."}}
+}
+
+func sessionJSONFlag() []flagContext {
+	return []flagContext{{Name: "--json", Type: "enum", Values: []string{"true", "pretty", "compact"}, Description: "Print JSON output; compact emits one line."}}
 }

--- a/internal/cli/app_output.go
+++ b/internal/cli/app_output.go
@@ -6,8 +6,14 @@ import (
 )
 
 func (a App) writeJSON(value any) error {
+	return a.writeJSONMode(value, jsonOutputPretty)
+}
+
+func (a App) writeJSONMode(value any, mode jsonOutputMode) error {
 	encoder := json.NewEncoder(a.Stdout)
-	encoder.SetIndent("", "  ")
+	if mode != jsonOutputCompact {
+		encoder.SetIndent("", "  ")
+	}
 	return encoder.Encode(value)
 }
 

--- a/internal/cli/app_profile.go
+++ b/internal/cli/app_profile.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/kovyrin/agent-secret/internal/profileconfig"
+	"github.com/kovyrin/agent-secret/internal/request"
 )
 
 type profileListOutput struct {
@@ -130,6 +131,11 @@ func (a App) runProfileShow(command Command) int {
 			return a.profileWriteError(err)
 		}
 	}
+	if profile.Session != nil && profile.Session.Bind != nil {
+		if _, err := fmt.Fprintf(writer, "session_bind:\t%s\n", sessionBindingPolicyText(*profile.Session.Bind)); err != nil {
+			return a.profileWriteError(err)
+		}
+	}
 	if _, err := fmt.Fprintln(writer, "secrets:"); err != nil {
 		return a.profileWriteError(err)
 	}
@@ -177,6 +183,20 @@ func joinComma(values []string) string {
 		out.WriteString(value)
 	}
 	return out.String()
+}
+
+func sessionBindingPolicyText(policy request.SessionBindingPolicy) string {
+	switch policy.Mode {
+	case request.SessionBindingModeAuto, "":
+		return "auto"
+	case request.SessionBindingModeAncestor:
+		if policy.AncestorDepth == 1 {
+			return "parent"
+		}
+		return fmt.Sprintf("ancestor:%d", policy.AncestorDepth)
+	default:
+		return string(policy.Mode)
+	}
 }
 
 func (a App) profileError(jsonOutput bool, context string, err error) int {

--- a/internal/cli/app_session.go
+++ b/internal/cli/app_session.go
@@ -15,13 +15,14 @@ import (
 )
 
 type sessionCreateOutput struct {
-	SchemaVersion  string    `json:"schema_version"`
-	SessionID      string    `json:"session_id"`
-	SessionToken   string    `json:"session_token"`
-	SecretAliases  []string  `json:"secret_aliases"`
-	ExpiresAt      time.Time `json:"expires_at"`
-	MaxReads       int       `json:"max_reads"`
-	RemainingReads int       `json:"remaining_reads"`
+	SchemaVersion  string                     `json:"schema_version"`
+	SessionID      string                     `json:"session_id"`
+	SessionToken   string                     `json:"session_token"`
+	SecretAliases  []string                   `json:"secret_aliases"`
+	ExpiresAt      time.Time                  `json:"expires_at"`
+	MaxReads       int                        `json:"max_reads"`
+	RemainingReads int                        `json:"remaining_reads"`
+	Binding        request.SessionBindingInfo `json:"session_binding"`
 }
 
 type sessionListOutput struct {
@@ -58,9 +59,10 @@ func (a App) runSessionCreate(ctx context.Context, command Command) int {
 		ExpiresAt:      payload.ExpiresAt,
 		MaxReads:       payload.MaxReads,
 		RemainingReads: payload.RemainingReads,
+		Binding:        payload.Binding,
 	}
 	if command.OutputJSON {
-		if err := a.writeJSON(output); err != nil {
+		if err := a.writeJSONMode(output, command.jsonOutputMode()); err != nil {
 			a.stderrf("agent-secret: write session create json: %v\n", err)
 			return 1
 		}
@@ -71,6 +73,9 @@ func (a App) runSessionCreate(ctx context.Context, command Command) int {
 	a.stdoutf("expires: %s\n", payload.ExpiresAt.Format(time.RFC3339))
 	a.stdoutf("reads: %d/%d remaining\n", payload.RemainingReads, payload.MaxReads)
 	a.stdoutf("secrets: %s\n", strings.Join(payload.SecretAliases, ", "))
+	if payload.Binding.BoundProcess.PID != 0 || payload.Binding.BoundProcess.Name != "" {
+		a.stdoutf("bound process: %s pid=%d path=%s\n", payload.Binding.BoundProcess.Name, payload.Binding.BoundProcess.PID, payload.Binding.BoundProcess.Path)
+	}
 	return 0
 }
 
@@ -93,7 +98,7 @@ func (a App) runSessionList(ctx context.Context, command Command) int {
 	}
 	defer func() { _ = client.Close() }()
 	if command.OutputJSON {
-		if err := a.writeJSON(sessionListOutput{SchemaVersion: "1", Sessions: payload.Sessions}); err != nil {
+		if err := a.writeJSONMode(sessionListOutput{SchemaVersion: "1", Sessions: payload.Sessions}, command.jsonOutputMode()); err != nil {
 			a.stderrf("agent-secret: write session list json: %v\n", err)
 			return 1
 		}
@@ -114,6 +119,14 @@ func (a App) runSessionList(ctx context.Context, command Command) int {
 			strings.Join(session.SecretAliases, ","),
 			session.Reason,
 		)
+		if session.Binding.BoundProcess.PID != 0 || session.Binding.BoundProcess.Name != "" {
+			a.stdoutf(
+				"  bound=%s pid=%d path=%s\n",
+				session.Binding.BoundProcess.Name,
+				session.Binding.BoundProcess.PID,
+				session.Binding.BoundProcess.Path,
+			)
+		}
 	}
 	return 0
 }
@@ -137,7 +150,7 @@ func (a App) runSessionDestroy(ctx context.Context, command Command) int {
 	}
 	defer func() { _ = client.Close() }()
 	if command.OutputJSON {
-		if err := a.writeJSON(payload); err != nil {
+		if err := a.writeJSONMode(payload, command.jsonOutputMode()); err != nil {
 			a.stderrf("agent-secret: write session destroy json: %v\n", err)
 			return 1
 		}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -46,6 +46,24 @@ func newTestAppWithDaemonManager(manager daemonManager, stdout io.Writer, stderr
 	return app
 }
 
+func testSessionBindingInfo() request.SessionBindingInfo {
+	return request.SessionBindingInfo{
+		Mode:          request.SessionBindingModeAncestor,
+		AncestorDepth: 1,
+		BoundProcess: request.SessionBindingProcess{
+			PID:       501,
+			ParentPID: 1,
+			Name:      "zsh",
+			Path:      "/bin/zsh",
+		},
+		CreatorProcess: request.SessionBindingProcess{
+			PID:  502,
+			Name: "agent-secret",
+			Path: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		},
+	}
+}
+
 func runConfigProfileExec(
 	t *testing.T,
 	app App,
@@ -185,6 +203,7 @@ profiles:
 			ExpiresAt:      expiresAt,
 			MaxReads:       2,
 			RemainingReads: 2,
+			Binding:        testSessionBindingInfo(),
 		},
 	}
 	manager := &appFakeDaemonManager{
@@ -201,7 +220,7 @@ profiles:
 		"create",
 		"--account", "Work",
 		"--max-reads", "2",
-		"--json",
+		"--json=compact",
 	})
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
@@ -223,6 +242,12 @@ profiles:
 	if got.SessionID != "asid_test" || got.SessionToken != "astok_test" || got.RemainingReads != 2 || got.MaxReads != 2 {
 		t.Fatalf("session create json = %+v", got)
 	}
+	if got.Binding.BoundProcess.Name != "zsh" || got.Binding.BoundProcess.PID != 501 {
+		t.Fatalf("session create binding = %+v", got.Binding)
+	}
+	if strings.Count(stdout.String(), "\n") != 1 {
+		t.Fatalf("compact json should be one line, stdout=%q", stdout.String())
+	}
 	if strings.Contains(stdout.String(), "synthetic-secret-value") || strings.Contains(stderr.String(), "synthetic-secret-value") {
 		t.Fatalf("session create leaked secret: stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
@@ -240,6 +265,7 @@ func TestAppSessionCreatePrintsText(t *testing.T) {
 			ExpiresAt:      expiresAt,
 			MaxReads:       1,
 			RemainingReads: 1,
+			Binding:        testSessionBindingInfo(),
 		},
 	}
 	manager := &appFakeDaemonManager{
@@ -261,7 +287,7 @@ func TestAppSessionCreatePrintsText(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"session id: asid_text", "session token: astok_text", "reads: 1/1 remaining", "secrets: TOKEN"} {
+	for _, want := range []string{"session id: asid_text", "session token: astok_text", "reads: 1/1 remaining", "secrets: TOKEN", "bound process: zsh pid=501"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("session create stdout = %q, want %q", stdout.String(), want)
 		}
@@ -285,6 +311,7 @@ func TestAppSessionList(t *testing.T) {
 					ExpiresAt:      expiresAt,
 					MaxReads:       2,
 					RemainingReads: 1,
+					Binding:        testSessionBindingInfo(),
 				}},
 			},
 		}
@@ -304,7 +331,7 @@ func TestAppSessionList(t *testing.T) {
 		if client.sessionListCalls != 1 || client.closeCalls != 1 {
 			t.Fatalf("client calls: list=%d close=%d", client.sessionListCalls, client.closeCalls)
 		}
-		for _, want := range []string{"asid_test", "reads=1/2", "cwd=/tmp/project", "secrets=TOKEN", "reason=Deploy workflow"} {
+		for _, want := range []string{"asid_test", "reads=1/2", "cwd=/tmp/project", "secrets=TOKEN", "reason=Deploy workflow", "bound=zsh pid=501"} {
 			if !strings.Contains(stdout.String(), want) {
 				t.Fatalf("session list stdout = %q, want %q", stdout.String(), want)
 			}
@@ -329,6 +356,7 @@ func TestAppSessionList(t *testing.T) {
 					ExpiresAt:      expiresAt,
 					MaxReads:       2,
 					RemainingReads: 1,
+					Binding:        testSessionBindingInfo(),
 				}},
 			},
 		}
@@ -352,7 +380,8 @@ func TestAppSessionList(t *testing.T) {
 		if len(got.Sessions) != 1 ||
 			got.Sessions[0].SessionID != "asid_test" ||
 			got.Sessions[0].CWD != "/tmp/project" ||
-			got.Sessions[0].RemainingReads != 1 {
+			got.Sessions[0].RemainingReads != 1 ||
+			got.Sessions[0].Binding.BoundProcess.Name != "zsh" {
 			t.Fatalf("session list json = %+v", got)
 		}
 		if strings.Contains(stdout.String(), "session_token") || strings.Contains(stdout.String(), "astok_") {
@@ -3282,7 +3311,10 @@ func (appAllowPeer) Validate(_ *net.UnixConn) error {
 
 type appSessionPeerAuthorizer struct{}
 
-func (appSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (daemonbroker.SessionPeerBinding, error) {
+func (appSessionPeerAuthorizer) BindSessionPeer(
+	peer peercred.Info,
+	policy request.SessionBindingPolicy,
+) (daemonbroker.SessionPeerBinding, error) {
 	return daemonbroker.SessionPeerBinding{
 		CreatorPeer: peer,
 		Anchor: peercred.ProcessIdentity{
@@ -3292,6 +3324,7 @@ func (appSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (daemonbroke
 			ExecutablePath: peer.ExecutablePath,
 			StartTime:      time.Unix(1, 0).UTC(),
 		},
+		Policy: policy,
 	}, nil
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -45,6 +45,7 @@ const (
 type Command struct {
 	Kind                  Kind
 	OutputJSON            bool
+	OutputJSONCompact     bool
 	ExecRequest           request.ExecRequest
 	ExecEnv               []string
 	ExecDryRun            bool
@@ -62,6 +63,16 @@ type Command struct {
 	InstallSkillOptions   install.SkillOptions
 	HelpText              string
 	VersionText           string
+}
+
+func (c Command) jsonOutputMode() jsonOutputMode {
+	if !c.OutputJSON {
+		return jsonOutputOff
+	}
+	if c.OutputJSONCompact {
+		return jsonOutputCompact
+	}
+	return jsonOutputPretty
 }
 
 type Parser struct {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1487,6 +1487,13 @@ func TestParseSessionListDestroyAndHelp(t *testing.T) {
 	if listCommand.Kind != KindSessionList || !listCommand.OutputJSON {
 		t.Fatalf("session list command = %+v", listCommand)
 	}
+	compactListCommand, err := parser.Parse([]string{"session", "list", "--json=compact"})
+	if err != nil {
+		t.Fatalf("Parse compact session list returned error: %v", err)
+	}
+	if compactListCommand.Kind != KindSessionList || !compactListCommand.OutputJSON || !compactListCommand.OutputJSONCompact {
+		t.Fatalf("compact session list command = %+v", compactListCommand)
+	}
 
 	destroyCommand, err := parser.Parse([]string{"session", "destroy", "--json", "asid_abc123"})
 	if err != nil {
@@ -1531,6 +1538,9 @@ profiles:
     secrets:
       A_TOKEN: op://Example/A/token
       B_TOKEN: op://Example/B/token
+    session:
+      bind:
+        ancestor: 2
 `)
 	t.Chdir(root)
 
@@ -1540,12 +1550,12 @@ profiles:
 		"--profile", "deploy",
 		"--secret", "CLI_TOKEN=op://Example/CLI/token",
 		"--max-reads", "3",
-		"--json",
+		"--json=compact",
 	})
 	if err != nil {
 		t.Fatalf("Parse session create returned error: %v", err)
 	}
-	if command.Kind != KindSessionCreate || !command.OutputJSON {
+	if command.Kind != KindSessionCreate || !command.OutputJSON || !command.OutputJSONCompact {
 		t.Fatalf("command = %+v, want session create json", command)
 	}
 	req := command.SessionCreateRequest
@@ -1561,6 +1571,53 @@ profiles:
 	}
 	if strings.Join(aliases, ",") != "A_TOKEN,B_TOKEN,CLI_TOKEN" {
 		t.Fatalf("secret aliases = %v", aliases)
+	}
+	if req.Binding.Mode != request.SessionBindingModeAncestor || req.Binding.AncestorDepth != 2 {
+		t.Fatalf("session binding = %+v, want profile ancestor 2", req.Binding)
+	}
+}
+
+func TestParseSessionCreateBindingFlagsOverrideProfile(t *testing.T) {
+	root := t.TempDir()
+	writeProfileConfig(t, root, `
+version: 1
+profiles:
+  deploy:
+    reason: Deploy workflow
+    session:
+      bind:
+        ancestor: 3
+    secrets:
+      TOKEN: op://Example/Item/token
+`)
+	t.Chdir(root)
+
+	command, err := NewParser().Parse([]string{
+		"session",
+		"create",
+		"--profile", "deploy",
+		"--bind-parent",
+	})
+	if err != nil {
+		t.Fatalf("Parse session create returned error: %v", err)
+	}
+	if command.SessionCreateRequest.Binding.Mode != request.SessionBindingModeAncestor ||
+		command.SessionCreateRequest.Binding.AncestorDepth != 1 {
+		t.Fatalf("binding = %+v, want --bind-parent override", command.SessionCreateRequest.Binding)
+	}
+
+	command, err = NewParser().Parse([]string{
+		"session",
+		"create",
+		"--profile", "deploy",
+		"--bind-ancestor", "2",
+	})
+	if err != nil {
+		t.Fatalf("Parse session create with ancestor returned error: %v", err)
+	}
+	if command.SessionCreateRequest.Binding.Mode != request.SessionBindingModeAncestor ||
+		command.SessionCreateRequest.Binding.AncestorDepth != 2 {
+		t.Fatalf("binding = %+v, want --bind-ancestor 2 override", command.SessionCreateRequest.Binding)
 	}
 }
 
@@ -1609,6 +1666,9 @@ func TestParseSessionRejectsInvalidForms(t *testing.T) {
 		{name: "destroy missing id", args: []string{"session", "destroy"}, want: ErrInvalidArguments},
 		{name: "destroy bad id", args: []string{"session", "destroy", "bad"}, want: request.ErrInvalidSessionID},
 		{name: "destroy all with id", args: []string{"session", "destroy", "--all", "asid_abc"}, want: ErrInvalidArguments},
+		{name: "create conflicting bind flags", args: []string{"session", "create", "--bind-parent", "--bind-ancestor", "2", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
+		{name: "create bad bind depth", args: []string{"session", "create", "--bind-ancestor", "4", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: request.ErrInvalidSessionBind},
+		{name: "create bad json mode", args: []string{"session", "create", "--json=ndjson", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
 		{name: "with-session public id", args: []string{"with-session", "asid_abc", "--", "tool"}, want: request.ErrInvalidSessionToken},
 		{name: "with-session missing boundary", args: []string{"with-session", "astok_abc", "tool"}, want: ErrShellStringCommand},
 		{name: "with-session missing command", args: []string{"with-session", "astok_abc", "--"}, want: ErrShellStringCommand},

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1581,6 +1581,7 @@ func TestParseSessionCreateBindingFlagsOverrideProfile(t *testing.T) {
 	root := t.TempDir()
 	writeProfileConfig(t, root, `
 version: 1
+account: Example
 profiles:
   deploy:
     reason: Deploy workflow

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -37,10 +37,12 @@ type execFlags struct {
 }
 
 type execInputs struct {
-	reason  string
-	ttl     time.Duration
-	env     []string
-	secrets []request.SecretSpec
+	reason                string
+	ttl                   time.Duration
+	env                   []string
+	secrets               []request.SecretSpec
+	sessionBinding        request.SessionBindingPolicy
+	sessionBindingProfile bool
 }
 
 type execInputSources struct {
@@ -155,11 +157,20 @@ func (p Parser) resolveExecInputs(flags execFlags) (execInputs, error) {
 	}
 
 	return execInputs{
-		reason:  sources.reason,
-		ttl:     sources.ttl,
-		env:     sources.env,
-		secrets: secrets,
+		reason:                sources.reason,
+		ttl:                   sources.ttl,
+		env:                   sources.env,
+		secrets:               secrets,
+		sessionBinding:        sessionBindingFromProfile(sources.profile),
+		sessionBindingProfile: sources.loadedProfile && sources.profile.SessionBinding != nil,
 	}, nil
+}
+
+func sessionBindingFromProfile(profile profileconfig.Profile) request.SessionBindingPolicy {
+	if profile.SessionBinding == nil {
+		return request.DefaultSessionBindingPolicy()
+	}
+	return *profile.SessionBinding
 }
 
 func loadExecInputSources(flags execFlags) (execInputSources, error) {

--- a/internal/cli/flag_values.go
+++ b/internal/cli/flag_values.go
@@ -1,11 +1,57 @@
 package cli
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 
 	"github.com/kovyrin/agent-secret/internal/request"
 )
+
+type jsonOutputMode string
+
+const (
+	jsonOutputOff     jsonOutputMode = ""
+	jsonOutputPretty  jsonOutputMode = "pretty"
+	jsonOutputCompact jsonOutputMode = "compact"
+)
+
+func (m jsonOutputMode) enabled() bool {
+	return m == jsonOutputPretty || m == jsonOutputCompact
+}
+
+type jsonOutputFlag struct {
+	mode *jsonOutputMode
+}
+
+func registerJSONOutputFlag(fs *flag.FlagSet, mode *jsonOutputMode, usage string) {
+	fs.Var(jsonOutputFlag{mode: mode}, "json", usage)
+}
+
+func (f jsonOutputFlag) IsBoolFlag() bool {
+	return true
+}
+
+func (f jsonOutputFlag) String() string {
+	if f.mode == nil {
+		return string(jsonOutputOff)
+	}
+	return string(*f.mode)
+}
+
+func (f jsonOutputFlag) Set(value string) error {
+	switch strings.TrimSpace(value) {
+	case "", "true", "pretty":
+		*f.mode = jsonOutputPretty
+	case "compact":
+		*f.mode = jsonOutputCompact
+	case "false":
+		*f.mode = jsonOutputOff
+	default:
+		return fmt.Errorf("%w: --json accepts true, false, pretty, or compact", ErrInvalidArguments)
+	}
+	return nil
+}
 
 type secretFlags struct {
 	specs []request.SecretSpec

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -76,7 +76,7 @@ Safety rules:
   - exec --dry-run --json validates locally without starting the background helper, prompting, resolving values, or spawning the child.
   - exec --reuse-only uses a matching reusable approval or fails without opening a new approval prompt.
 	  - Text file/document refs such as op://Example/GitHub App/key.pem are injected as env values; binary attachments are not supported.
-	  - session create returns a public session id plus a secret session token bound to the requester process tree; values stay in background helper memory and are injected only by with-session.
+	  - session create returns a public session id plus a secret session token bound to the approved requester process tree; values stay in background helper memory and are injected only by with-session.
   - item describe requires approval and prints item metadata only: field labels, types, concealment flags, and refs.
   - agent-secret skill-install links the bundled Agent Secret skill into ~/.agents/skills/agent-secret.
   - Reusable approval is selected only in the approval UI, not by a CLI flag.
@@ -357,7 +357,7 @@ func SessionHelp() string {
 
 	Examples:
 
-	  agent-secret session create --profile terraform-cloudflare --max-reads 2
+	  agent-secret session create --profile terraform-cloudflare --bind-parent --max-reads 2 --json=compact
 	  agent-secret with-session astok_123 -- terraform plan
 	  agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN,STATE_TOKEN -- terraform apply
 	  agent-secret session destroy asid_123
@@ -367,6 +367,12 @@ func SessionHelp() string {
 	until TTL, read count exhaustion, destroy, or helper stop. Session list shows
 	session ids for management, but never session tokens. Session tokens are accepted
 	only from the requester process tree that created the session.
+
+	Use --bind-parent when a wrapper creates a session in command substitution and
+	then calls with-session from the parent shell. Use --bind-ancestor N for deeper
+	wrappers; N must be 1..3 and can only target ancestors of the current
+	agent-secret process. session create, list, and destroy accept --json=compact
+	for one-line JSON suitable for shell wrappers.
 	`)
 }
 
@@ -389,7 +395,8 @@ func WithSessionHelp() string {
 	The session token must come from agent-secret session create. Secret values are
 	injected into the child environment only and are never printed by agent-secret.
 	Without --only, every approved session alias is injected for that command.
-	The caller must be in the same requester process tree that created the session.
+	The caller must be in the approved requester process tree selected when the
+	session was created.
 	`)
 }
 

--- a/internal/cli/request_builder.go
+++ b/internal/cli/request_builder.go
@@ -98,6 +98,7 @@ type sessionCreateRequestBuildOptions struct {
 	ttl                time.Duration
 	maxReads           int
 	overrideEnv        bool
+	binding            request.SessionBindingPolicy
 }
 
 func buildSessionCreateRequest(opts sessionCreateRequestBuildOptions) (request.SessionCreateRequest, error) {
@@ -130,6 +131,7 @@ func buildSessionCreateRequest(opts sessionCreateRequestBuildOptions) (request.S
 		TTL:                opts.ttl,
 		MaxReads:           opts.maxReads,
 		OverrideEnv:        opts.overrideEnv,
+		Binding:            opts.binding,
 	})
 }
 

--- a/internal/cli/session_parse.go
+++ b/internal/cli/session_parse.go
@@ -11,18 +11,20 @@ import (
 )
 
 type sessionCreateFlags struct {
-	reason      string
-	cwd         string
-	ttl         time.Duration
-	maxReads    int
-	profileName string
-	configPath  string
-	account     string
-	overrideEnv bool
-	json        bool
-	secrets     secretFlags
-	only        onlyFlags
-	envFiles    envFileFlags
+	reason       string
+	cwd          string
+	ttl          time.Duration
+	maxReads     int
+	profileName  string
+	configPath   string
+	account      string
+	overrideEnv  bool
+	bindParent   bool
+	bindAncestor int
+	jsonMode     jsonOutputMode
+	secrets      secretFlags
+	only         onlyFlags
+	envFiles     envFileFlags
 }
 
 type withSessionFlags struct {
@@ -61,7 +63,9 @@ func (p Parser) parseSessionCreate(args []string) (Command, error) {
 	fs.StringVar(&flags.configPath, "config", "", "profile config path")
 	fs.StringVar(&flags.account, "account", "", "1Password account")
 	fs.BoolVar(&flags.overrideEnv, "override-env", false, "allow with-session to override existing env aliases")
-	fs.BoolVar(&flags.json, "json", false, "print json")
+	fs.BoolVar(&flags.bindParent, "bind-parent", false, "bind session to the parent of this agent-secret process")
+	fs.IntVar(&flags.bindAncestor, "bind-ancestor", 0, "bind session to an ancestor process depth 1..3")
+	registerJSONOutputFlag(fs, &flags.jsonMode, "print json; use --json=compact for one-line output")
 	fs.Var(&flags.secrets, "secret", "secret mapping")
 	fs.Var(&flags.only, "only", "profile alias filter")
 	fs.Var(&flags.envFiles, "env-file", "dotenv env file")
@@ -70,6 +74,16 @@ func (p Parser) parseSessionCreate(args []string) (Command, error) {
 	}
 	if fs.NArg() != 0 {
 		return Command{}, fmt.Errorf("%w: session create does not accept a child command", ErrInvalidArguments)
+	}
+	bindAncestorSet := false
+	fs.Visit(func(flag *flag.Flag) {
+		if flag.Name == "bind-ancestor" {
+			bindAncestorSet = true
+		}
+	})
+	binding, err := sessionCreateBinding(flags, bindAncestorSet)
+	if err != nil {
+		return Command{}, err
 	}
 
 	inputs, err := p.resolveExecInputs(execFlags{
@@ -87,6 +101,9 @@ func (p Parser) parseSessionCreate(args []string) (Command, error) {
 	if err != nil {
 		return Command{}, err
 	}
+	if !bindAncestorSet && !flags.bindParent && inputs.sessionBindingProfile {
+		binding = inputs.sessionBinding
+	}
 	req, err := buildSessionCreateRequest(sessionCreateRequestBuildOptions{
 		reason:      inputs.reason,
 		command:     []string{"agent-secret", "session", "create"},
@@ -95,30 +112,38 @@ func (p Parser) parseSessionCreate(args []string) (Command, error) {
 		ttl:         inputs.ttl,
 		maxReads:    flags.maxReads,
 		overrideEnv: flags.overrideEnv,
+		binding:     binding,
 	})
 	if err != nil {
 		return Command{}, fmt.Errorf("build session create request: %w", err)
 	}
-	return Command{Kind: KindSessionCreate, OutputJSON: flags.json, SessionCreateRequest: req}, nil
+	return Command{
+		Kind:                 KindSessionCreate,
+		OutputJSON:           flags.jsonMode.enabled(),
+		OutputJSONCompact:    flags.jsonMode == jsonOutputCompact,
+		SessionCreateRequest: req,
+	}, nil
 }
 
 func parseSessionList(args []string) (Command, error) {
 	fs := flag.NewFlagSet("session list", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	jsonOutput := fs.Bool("json", false, "print json")
+	var jsonMode jsonOutputMode
+	registerJSONOutputFlag(fs, &jsonMode, "print json; use --json=compact for one-line output")
 	if err := fs.Parse(args); err != nil {
 		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
 	}
 	if fs.NArg() != 0 {
 		return Command{}, fmt.Errorf("%w: session list does not accept arguments", ErrInvalidArguments)
 	}
-	return Command{Kind: KindSessionList, OutputJSON: *jsonOutput}, nil
+	return Command{Kind: KindSessionList, OutputJSON: jsonMode.enabled(), OutputJSONCompact: jsonMode == jsonOutputCompact}, nil
 }
 
 func parseSessionDestroy(args []string) (Command, error) {
 	fs := flag.NewFlagSet("session destroy", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	jsonOutput := fs.Bool("json", false, "print json")
+	var jsonMode jsonOutputMode
+	registerJSONOutputFlag(fs, &jsonMode, "print json; use --json=compact for one-line output")
 	all := fs.Bool("all", false, "destroy all active sessions")
 	if err := fs.Parse(args); err != nil {
 		return Command{}, fmt.Errorf("%w: %w", ErrInvalidArguments, err)
@@ -127,7 +152,12 @@ func parseSessionDestroy(args []string) (Command, error) {
 		if fs.NArg() != 0 {
 			return Command{}, fmt.Errorf("%w: session destroy --all does not accept a session id", ErrInvalidArguments)
 		}
-		return Command{Kind: KindSessionDestroy, OutputJSON: *jsonOutput, SessionDestroyRequest: request.NewSessionDestroyAll()}, nil
+		return Command{
+			Kind:                  KindSessionDestroy,
+			OutputJSON:            jsonMode.enabled(),
+			OutputJSONCompact:     jsonMode == jsonOutputCompact,
+			SessionDestroyRequest: request.NewSessionDestroyAll(),
+		}, nil
 	}
 	if fs.NArg() != 1 {
 		return Command{}, fmt.Errorf("%w: session destroy requires one session id", ErrInvalidArguments)
@@ -136,7 +166,33 @@ func parseSessionDestroy(args []string) (Command, error) {
 	if err != nil {
 		return Command{}, err
 	}
-	return Command{Kind: KindSessionDestroy, OutputJSON: *jsonOutput, SessionDestroyRequest: req}, nil
+	return Command{
+		Kind:                  KindSessionDestroy,
+		OutputJSON:            jsonMode.enabled(),
+		OutputJSONCompact:     jsonMode == jsonOutputCompact,
+		SessionDestroyRequest: req,
+	}, nil
+}
+
+func sessionCreateBinding(flags sessionCreateFlags, bindAncestorSet bool) (request.SessionBindingPolicy, error) {
+	if flags.bindParent && bindAncestorSet {
+		return request.SessionBindingPolicy{}, fmt.Errorf("%w: use either --bind-parent or --bind-ancestor", ErrInvalidArguments)
+	}
+	if flags.bindParent {
+		policy, err := request.NewSessionAncestorBinding(1)
+		if err != nil {
+			return request.SessionBindingPolicy{}, err
+		}
+		return policy, nil
+	}
+	if bindAncestorSet {
+		policy, err := request.NewSessionAncestorBinding(flags.bindAncestor)
+		if err != nil {
+			return request.SessionBindingPolicy{}, err
+		}
+		return policy, nil
+	}
+	return request.DefaultSessionBindingPolicy(), nil
 }
 
 func (p Parser) parseWithSession(args []string) (Command, error) {

--- a/internal/daemon/approval/approval_protocol.go
+++ b/internal/daemon/approval/approval_protocol.go
@@ -151,8 +151,15 @@ func NewSessionCreatePayload(
 		OverrideEnv:            req.OverrideEnv,
 		OverriddenAliases:      []string{},
 		ReusableUses:           1,
-		SessionBinding:         &binding,
+		SessionBinding:         sessionBindingPointer(binding),
 	}
+}
+
+func sessionBindingPointer(binding request.SessionBindingInfo) *request.SessionBindingInfo {
+	if binding.Mode == "" && binding.BoundProcess.PID == 0 && binding.CreatorProcess.PID == 0 {
+		return nil
+	}
+	return &binding
 }
 
 func ValidateDecision(decision ApprovalDecisionPayload, expectedReusableUses int, allowsReusable bool) error {

--- a/internal/daemon/approval/approval_protocol.go
+++ b/internal/daemon/approval/approval_protocol.go
@@ -24,6 +24,7 @@ type ApprovalRequestPayload struct {
 	OverrideEnv            bool                        `json:"override_env"`
 	OverriddenAliases      []string                    `json:"overridden_aliases"`
 	ReusableUses           int                         `json:"reusable_uses"`
+	SessionBinding         *request.SessionBindingInfo `json:"session_binding,omitempty"`
 }
 
 type ApprovalOperation string
@@ -120,7 +121,11 @@ func NewItemDescribePayload(
 	}
 }
 
-func NewSessionCreatePayload(correlation protocol.Correlation, req request.SessionCreateRequest) ApprovalRequestPayload {
+func NewSessionCreatePayload(
+	correlation protocol.Correlation,
+	req request.SessionCreateRequest,
+	binding request.SessionBindingInfo,
+) ApprovalRequestPayload {
 	resources := make([]ApprovalRequestedResource, 0, len(req.Secrets))
 	for _, secret := range req.Secrets {
 		resources = append(resources, ApprovalRequestedResource{
@@ -146,6 +151,7 @@ func NewSessionCreatePayload(correlation protocol.Correlation, req request.Sessi
 		OverrideEnv:            req.OverrideEnv,
 		OverriddenAliases:      []string{},
 		ReusableUses:           1,
+		SessionBinding:         &binding,
 	}
 }
 

--- a/internal/daemon/approval/approval_protocol_test.go
+++ b/internal/daemon/approval/approval_protocol_test.go
@@ -127,6 +127,20 @@ func TestNewSessionCreatePayloadIncludesBindingMetadata(t *testing.T) {
 	}
 }
 
+func TestNewSessionCreatePayloadOmitsZeroBindingMetadata(t *testing.T) {
+	t.Parallel()
+
+	payload := NewSessionCreatePayload(
+		protocol.Correlation{RequestID: "req_1", Nonce: "nonce_1"},
+		request.SessionCreateRequest{Reason: "deploy"},
+		request.SessionBindingInfo{},
+	)
+
+	if payload.SessionBinding != nil {
+		t.Fatalf("SessionBinding = %+v, want nil for zero-value metadata", payload.SessionBinding)
+	}
+}
+
 func TestValidateDecisionReusableUses(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/approval/approval_protocol_test.go
+++ b/internal/daemon/approval/approval_protocol_test.go
@@ -78,6 +78,55 @@ func TestNewExecPayloadUsesEmptyOverriddenAliasesSlice(t *testing.T) {
 	}
 }
 
+func TestNewSessionCreatePayloadIncludesBindingMetadata(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Now().Add(time.Minute).UTC()
+	req := request.SessionCreateRequest{
+		Reason:             "deploy",
+		Command:            []string{"agent-secret", "session", "create"},
+		CWD:                "/tmp/project",
+		ResolvedExecutable: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		ExpiresAt:          expiresAt,
+		Secrets: []request.Secret{
+			{
+				Alias: "TOKEN",
+				Ref: request.SecretRef{
+					Raw: "op://Vault/Item/token",
+				},
+			},
+		},
+		MaxReads: 2,
+	}
+	binding := request.SessionBindingInfo{
+		Mode:          request.SessionBindingModeAncestor,
+		AncestorDepth: 1,
+		BoundProcess: request.SessionBindingProcess{
+			PID:       501,
+			ParentPID: 1,
+			Name:      "zsh",
+			Path:      "/bin/zsh",
+		},
+		CreatorProcess: request.SessionBindingProcess{
+			PID:  502,
+			Name: "agent-secret",
+			Path: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret",
+		},
+	}
+
+	payload := NewSessionCreatePayload(protocol.Correlation{RequestID: "req_1", Nonce: "nonce_1"}, req, binding)
+
+	if payload.SessionBinding == nil {
+		t.Fatal("SessionBinding is nil, want binding metadata")
+	}
+	if payload.SessionBinding.BoundProcess.Name != "zsh" || payload.SessionBinding.BoundProcess.PID != 501 {
+		t.Fatalf("session binding = %+v", payload.SessionBinding)
+	}
+	if payload.Operation != ApprovalOperationSessionCreate || payload.AllowsReusable {
+		t.Fatalf("operation/reuse = %s/%v", payload.Operation, payload.AllowsReusable)
+	}
+}
+
 func TestValidateDecisionReusableUses(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/broker/broker.go
+++ b/internal/daemon/broker/broker.go
@@ -152,7 +152,7 @@ func (b *Broker) HandleSessionCreate(
 	if err := preflightRequiredAudit(ctx, b.audit); err != nil {
 		return protocol.SessionCreateResponsePayload{}, err
 	}
-	peerBinding, err := b.sessionPeerAuthorizer.BindSessionPeer(peer)
+	peerBinding, err := b.sessionPeerAuthorizer.BindSessionPeer(peer, req.Binding)
 	if err != nil {
 		return protocol.SessionCreateResponsePayload{}, err
 	}
@@ -165,7 +165,7 @@ func (b *Broker) HandleSessionCreate(
 	if err := recordRequiredAudit(sessionCtx, b.audit, audit.FromSessionCreateRequest(audit.EventApprovalRequested, correlation.RequestID, req)); err != nil {
 		return protocol.SessionCreateResponsePayload{}, err
 	}
-	decision, err := b.approver.Approve(sessionCtx, approval.NewSessionCreatePayload(correlation, req))
+	decision, err := b.approver.Approve(sessionCtx, approval.NewSessionCreatePayload(correlation, req, peerBinding.Info()))
 	if err != nil {
 		if auditErr := b.recordSessionCreateApprovalError(ctx, correlation.RequestID, req, err); auditErr != nil {
 			return protocol.SessionCreateResponsePayload{}, auditErr
@@ -865,6 +865,7 @@ func sessionCreatePayload(summary request.SessionSummary) protocol.SessionCreate
 		ExpiresAt:      summary.ExpiresAt,
 		MaxReads:       summary.MaxReads,
 		RemainingReads: summary.RemainingReads,
+		Binding:        summary.Binding,
 	}
 }
 
@@ -878,5 +879,6 @@ func sessionInfoPayload(summary request.SessionSummary) protocol.SessionInfoPayl
 		MaxReads:       summary.MaxReads,
 		RemainingReads: summary.RemainingReads,
 		OverrideEnv:    summary.OverrideEnv,
+		Binding:        summary.Binding,
 	}
 }

--- a/internal/daemon/broker/broker_test.go
+++ b/internal/daemon/broker/broker_test.go
@@ -183,7 +183,10 @@ type testSessionPeerAuthorizer struct {
 	roots map[int]int
 }
 
-func (a testSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (SessionPeerBinding, error) {
+func (a testSessionPeerAuthorizer) BindSessionPeer(
+	peer peercred.Info,
+	policy request.SessionBindingPolicy,
+) (SessionPeerBinding, error) {
 	return SessionPeerBinding{
 		CreatorPeer: peer,
 		Anchor: peercred.ProcessIdentity{
@@ -193,6 +196,7 @@ func (a testSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (SessionP
 			ExecutablePath: "/test/requester",
 			StartTime:      time.Unix(1, 0).UTC(),
 		},
+		Policy: policy,
 	}, nil
 }
 

--- a/internal/daemon/broker/session_peer_authorizer.go
+++ b/internal/daemon/broker/session_peer_authorizer.go
@@ -5,16 +5,59 @@ import (
 	"path/filepath"
 
 	"github.com/kovyrin/agent-secret/internal/peercred"
+	"github.com/kovyrin/agent-secret/internal/request"
 )
 
 type SessionPeerAuthorizer interface {
-	BindSessionPeer(peer peercred.Info) (SessionPeerBinding, error)
+	BindSessionPeer(peer peercred.Info, policy request.SessionBindingPolicy) (SessionPeerBinding, error)
 	ValidateSessionPeer(binding SessionPeerBinding, peer peercred.Info) error
 }
 
 type SessionPeerBinding struct {
 	CreatorPeer peercred.Info
 	Anchor      peercred.ProcessIdentity
+	Policy      request.SessionBindingPolicy
+}
+
+func (b SessionPeerBinding) Info() request.SessionBindingInfo {
+	return request.SessionBindingInfo{
+		Mode:          b.Policy.Mode,
+		AncestorDepth: b.Policy.AncestorDepth,
+		BoundProcess:  processInfoFromIdentity(b.Anchor),
+		CreatorProcess: request.SessionBindingProcess{
+			PID:  b.CreatorPeer.PID,
+			Name: processName(b.CreatorPeer.ExecutablePath),
+			Path: b.CreatorPeer.ExecutablePath,
+		},
+	}
+}
+
+type SessionPeerMismatchError struct {
+	Bound     request.SessionBindingProcess
+	Requester request.SessionBindingProcess
+	Reason    string
+}
+
+func (e *SessionPeerMismatchError) Error() string {
+	reason := e.Reason
+	if reason == "" {
+		reason = "requester ancestry does not include the approved session binding"
+	}
+	return fmt.Sprintf(
+		"%s: %s; bound_process=%s pid=%d path=%q; requester=%s pid=%d path=%q; recreate the session from the shell or agent process tree that will run with-session, or use --bind-parent / --bind-ancestor N",
+		ErrSessionPeerMismatch,
+		reason,
+		e.Bound.Name,
+		e.Bound.PID,
+		e.Bound.Path,
+		e.Requester.Name,
+		e.Requester.PID,
+		e.Requester.Path,
+	)
+}
+
+func (e *SessionPeerMismatchError) Unwrap() error {
+	return ErrSessionPeerMismatch
 }
 
 type processTreeSessionPeerAuthorizer struct {
@@ -25,18 +68,26 @@ func newProcessTreeSessionPeerAuthorizer() processTreeSessionPeerAuthorizer {
 	return processTreeSessionPeerAuthorizer{processAncestry: peercred.ProcessAncestry}
 }
 
-func (a processTreeSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (SessionPeerBinding, error) {
+func (a processTreeSessionPeerAuthorizer) BindSessionPeer(
+	peer peercred.Info,
+	policy request.SessionBindingPolicy,
+) (SessionPeerBinding, error) {
+	policy, err := request.NormalizeSessionBindingPolicy(policy)
+	if err != nil {
+		return SessionPeerBinding{}, err
+	}
 	ancestry, err := a.processAncestry(peer.PID)
 	if err != nil {
 		return SessionPeerBinding{}, fmt.Errorf("%w: inspect session creator process tree: %w", ErrSessionPeerMismatch, err)
 	}
-	anchor, err := sessionPeerAnchor(peer, ancestry)
+	anchor, err := sessionPeerAnchor(peer, ancestry, policy)
 	if err != nil {
 		return SessionPeerBinding{}, err
 	}
 	return SessionPeerBinding{
 		CreatorPeer: peer,
 		Anchor:      anchor,
+		Policy:      policy,
 	}, nil
 }
 
@@ -54,18 +105,31 @@ func (a processTreeSessionPeerAuthorizer) ValidateSessionPeer(
 	if err != nil {
 		return fmt.Errorf("%w: inspect session caller process tree: %w", ErrSessionPeerMismatch, err)
 	}
-	return fmt.Errorf(
-		"%w: caller pid %d is not in the approved requester process tree rooted at pid %d",
-		ErrSessionPeerMismatch,
-		peer.PID,
-		binding.Anchor.PID,
-	)
+	return &SessionPeerMismatchError{
+		Bound:     processInfoFromIdentity(binding.Anchor),
+		Requester: processInfoFromPeer(peer),
+	}
 }
 
-func sessionPeerAnchor(peer peercred.Info, ancestry []peercred.ProcessIdentity) (peercred.ProcessIdentity, error) {
+func sessionPeerAnchor(
+	peer peercred.Info,
+	ancestry []peercred.ProcessIdentity,
+	policy request.SessionBindingPolicy,
+) (peercred.ProcessIdentity, error) {
 	if len(ancestry) == 0 || ancestry[0].PID != peer.PID {
 		return peercred.ProcessIdentity{}, fmt.Errorf("%w: session creator process tree does not start at pid %d", ErrSessionPeerMismatch, peer.PID)
 	}
+	switch policy.Mode {
+	case request.SessionBindingModeAuto:
+		return automaticSessionPeerAnchor(peer, ancestry)
+	case request.SessionBindingModeAncestor:
+		return ancestorSessionPeerAnchor(peer, ancestry, policy.AncestorDepth)
+	default:
+		return peercred.ProcessIdentity{}, fmt.Errorf("%w: unknown binding mode %q", request.ErrInvalidSessionBind, policy.Mode)
+	}
+}
+
+func automaticSessionPeerAnchor(peer peercred.Info, ancestry []peercred.ProcessIdentity) (peercred.ProcessIdentity, error) {
 	for i := 1; i < len(ancestry); i++ {
 		candidate := ancestry[i]
 		if isEligibleSessionPeerAnchor(peer, candidate) {
@@ -77,6 +141,32 @@ func sessionPeerAnchor(peer peercred.Info, ancestry []peercred.ProcessIdentity) 
 		}
 	}
 	return peercred.ProcessIdentity{}, fmt.Errorf("%w: session creator has no stable requester parent", ErrSessionPeerMismatch)
+}
+
+func ancestorSessionPeerAnchor(
+	peer peercred.Info,
+	ancestry []peercred.ProcessIdentity,
+	depth int,
+) (peercred.ProcessIdentity, error) {
+	if depth < 1 || depth >= len(ancestry) {
+		return peercred.ProcessIdentity{}, fmt.Errorf(
+			"%w: session creator does not have ancestor depth %d",
+			ErrSessionPeerMismatch,
+			depth,
+		)
+	}
+	anchor := ancestry[depth]
+	if !isEligibleSessionPeerAnchor(peer, anchor) {
+		return peercred.ProcessIdentity{}, fmt.Errorf(
+			"%w: ancestor depth %d is not an eligible same-user non-launchd binding target: %s pid=%d path=%q",
+			ErrSessionPeerMismatch,
+			depth,
+			processName(anchor.ExecutablePath),
+			anchor.PID,
+			anchor.ExecutablePath,
+		)
+	}
+	return anchor, nil
 }
 
 func isEligibleSessionPeerAnchor(peer peercred.Info, candidate peercred.ProcessIdentity) bool {
@@ -120,4 +210,32 @@ func sameProcessIdentity(a peercred.ProcessIdentity, b peercred.ProcessIdentity)
 		a.GID == b.GID &&
 		a.StartTime.Equal(b.StartTime) &&
 		a.ExecutablePath == b.ExecutablePath
+}
+
+func processInfoFromIdentity(identity peercred.ProcessIdentity) request.SessionBindingProcess {
+	return request.SessionBindingProcess{
+		PID:       identity.PID,
+		ParentPID: identity.ParentPID,
+		Name:      processName(identity.ExecutablePath),
+		Path:      identity.ExecutablePath,
+	}
+}
+
+func processInfoFromPeer(peer peercred.Info) request.SessionBindingProcess {
+	return request.SessionBindingProcess{
+		PID:  peer.PID,
+		Name: processName(peer.ExecutablePath),
+		Path: peer.ExecutablePath,
+	}
+}
+
+func processName(path string) string {
+	if path == "" {
+		return "unknown"
+	}
+	name := filepath.Base(path)
+	if name == "." || name == string(filepath.Separator) {
+		return path
+	}
+	return name
 }

--- a/internal/daemon/broker/session_peer_authorizer.go
+++ b/internal/daemon/broker/session_peer_authorizer.go
@@ -156,6 +156,8 @@ func ancestorSessionPeerAnchor(
 		)
 	}
 	anchor := ancestry[depth]
+	// Explicit binding means exactly the requested ancestor depth. Unlike auto
+	// mode, it intentionally does not skip same-executable subshells.
 	if !isEligibleSessionPeerAnchor(peer, anchor) {
 		return peercred.ProcessIdentity{}, fmt.Errorf(
 			"%w: ancestor depth %d is not an eligible same-user non-launchd binding target: %s pid=%d path=%q",

--- a/internal/daemon/broker/session_peer_authorizer_test.go
+++ b/internal/daemon/broker/session_peer_authorizer_test.go
@@ -2,10 +2,12 @@ package broker
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/kovyrin/agent-secret/internal/peercred"
+	"github.com/kovyrin/agent-secret/internal/request"
 )
 
 func TestProcessTreeSessionPeerAuthorizerAllowsRequesterTreeSiblings(t *testing.T) {
@@ -28,7 +30,7 @@ func TestProcessTreeSessionPeerAuthorizerAllowsRequesterTreeSiblings(t *testing.
 	}
 	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
 
-	binding, err := authorizer.BindSessionPeer(creator)
+	binding, err := authorizer.BindSessionPeer(creator, request.DefaultSessionBindingPolicy())
 	if err != nil {
 		t.Fatalf("BindSessionPeer returned error: %v", err)
 	}
@@ -62,7 +64,7 @@ func TestProcessTreeSessionPeerAuthorizerSkipsSameExecutableSubshellAnchor(t *te
 	}
 	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
 
-	binding, err := authorizer.BindSessionPeer(creator)
+	binding, err := authorizer.BindSessionPeer(creator, request.DefaultSessionBindingPolicy())
 	if err != nil {
 		t.Fatalf("BindSessionPeer returned error: %v", err)
 	}
@@ -100,7 +102,7 @@ func TestProcessTreeSessionPeerAuthorizerSkipsSameExecutableSubshellAcrossInelig
 	}
 	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
 
-	binding, err := authorizer.BindSessionPeer(creator)
+	binding, err := authorizer.BindSessionPeer(creator, request.DefaultSessionBindingPolicy())
 	if err != nil {
 		t.Fatalf("BindSessionPeer returned error: %v", err)
 	}
@@ -109,6 +111,101 @@ func TestProcessTreeSessionPeerAuthorizerSkipsSameExecutableSubshellAcrossInelig
 	}
 	if err := authorizer.ValidateSessionPeer(binding, caller); err != nil {
 		t.Fatalf("ValidateSessionPeer returned error for task shell sibling: %v", err)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerBindsExplicitParent(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	subShell := testProcessIdentity(501, 500, "/bin/bash")
+	taskShell := testProcessIdentity(500, 1, "/bin/bash")
+	lookup := map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, subShell.PID, creator.ExecutablePath),
+			subShell,
+			taskShell,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	}
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
+	policy, err := request.NewSessionAncestorBinding(1)
+	if err != nil {
+		t.Fatalf("NewSessionAncestorBinding returned error: %v", err)
+	}
+
+	binding, err := authorizer.BindSessionPeer(creator, policy)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if binding.Anchor.PID != subShell.PID {
+		t.Fatalf("binding anchor pid = %d, want explicit parent pid %d", binding.Anchor.PID, subShell.PID)
+	}
+	if binding.Policy != policy {
+		t.Fatalf("binding policy = %+v, want %+v", binding.Policy, policy)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerBindsExplicitAncestor(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	subShell := testProcessIdentity(501, 500, "/bin/zsh")
+	agent := testProcessIdentity(500, 400, "/Applications/Codex.app/Contents/MacOS/Codex")
+	terminal := testProcessIdentity(400, 1, "/Applications/iTerm.app/Contents/MacOS/iTerm2")
+	lookup := map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, subShell.PID, creator.ExecutablePath),
+			subShell,
+			agent,
+			terminal,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	}
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
+	policy, err := request.NewSessionAncestorBinding(2)
+	if err != nil {
+		t.Fatalf("NewSessionAncestorBinding returned error: %v", err)
+	}
+
+	binding, err := authorizer.BindSessionPeer(creator, policy)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if binding.Anchor.PID != agent.PID {
+		t.Fatalf("binding anchor pid = %d, want explicit ancestor pid %d", binding.Anchor.PID, agent.PID)
+	}
+	info := binding.Info()
+	if info.Mode != request.SessionBindingModeAncestor ||
+		info.AncestorDepth != 2 ||
+		info.BoundProcess.PID != agent.PID ||
+		info.BoundProcess.Name != "Codex" ||
+		info.CreatorProcess.PID != creator.PID {
+		t.Fatalf("binding info = %+v", info)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerRejectsIneligibleExplicitAncestor(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	rootParent := testProcessIdentity(500, 1, "/bin/zsh")
+	rootParent.UID = 0
+	rootParent.GID = 0
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, rootParent.PID, creator.ExecutablePath),
+			rootParent,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	})}
+	policy, err := request.NewSessionAncestorBinding(1)
+	if err != nil {
+		t.Fatalf("NewSessionAncestorBinding returned error: %v", err)
+	}
+
+	if _, err := authorizer.BindSessionPeer(creator, policy); !errors.Is(err, ErrSessionPeerMismatch) {
+		t.Fatalf("BindSessionPeer error = %v, want ErrSessionPeerMismatch", err)
 	}
 }
 
@@ -137,7 +234,7 @@ func TestProcessTreeSessionPeerAuthorizerAllowsPartialCallerAncestryWhenAnchorWa
 		}
 	}}
 
-	binding, err := authorizer.BindSessionPeer(creator)
+	binding, err := authorizer.BindSessionPeer(creator, request.DefaultSessionBindingPolicy())
 	if err != nil {
 		t.Fatalf("BindSessionPeer returned error: %v", err)
 	}
@@ -172,12 +269,14 @@ func TestProcessTreeSessionPeerAuthorizerRejectsPartialCallerAncestryWhenAnchorW
 		}
 	}}
 
-	binding, err := authorizer.BindSessionPeer(creator)
+	binding, err := authorizer.BindSessionPeer(creator, request.DefaultSessionBindingPolicy())
 	if err != nil {
 		t.Fatalf("BindSessionPeer returned error: %v", err)
 	}
 	if err := authorizer.ValidateSessionPeer(binding, caller); !errors.Is(err, ErrSessionPeerMismatch) {
 		t.Fatalf("ValidateSessionPeer error = %v, want ErrSessionPeerMismatch", err)
+	} else if !strings.Contains(err.Error(), "process exited while walking ancestry") {
+		t.Fatalf("ValidateSessionPeer error = %q, want caller ancestry inspection failure", err.Error())
 	}
 }
 
@@ -202,7 +301,7 @@ func TestProcessTreeSessionPeerAuthorizerRejectsUnrelatedTree(t *testing.T) {
 	}
 	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
 
-	binding, err := authorizer.BindSessionPeer(creator)
+	binding, err := authorizer.BindSessionPeer(creator, request.DefaultSessionBindingPolicy())
 	if err != nil {
 		t.Fatalf("BindSessionPeer returned error: %v", err)
 	}
@@ -222,7 +321,7 @@ func TestProcessTreeSessionPeerAuthorizerDoesNotUseLaunchdAsAnchor(t *testing.T)
 		},
 	})}
 
-	if _, err := authorizer.BindSessionPeer(creator); !errors.Is(err, ErrSessionPeerMismatch) {
+	if _, err := authorizer.BindSessionPeer(creator, request.DefaultSessionBindingPolicy()); !errors.Is(err, ErrSessionPeerMismatch) {
 		t.Fatalf("BindSessionPeer error = %v, want ErrSessionPeerMismatch", err)
 	}
 }

--- a/internal/daemon/broker/session_store.go
+++ b/internal/daemon/broker/session_store.go
@@ -253,6 +253,7 @@ func (s sessionRecord) summary() request.SessionSummary {
 		MaxReads:       s.MaxReads,
 		RemainingReads: s.remainingReads(),
 		OverrideEnv:    s.OverrideEnv,
+		Binding:        s.PeerBinding.Info(),
 	}
 }
 

--- a/internal/daemon/protocol/protocol.go
+++ b/internal/daemon/protocol/protocol.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kovyrin/agent-secret/internal/itemmetadata"
+	"github.com/kovyrin/agent-secret/internal/request"
 )
 
 const ProtocolVersion = 1
@@ -105,12 +106,13 @@ type ExecResponsePayload struct {
 }
 
 type SessionCreateResponsePayload struct {
-	SessionID      string    `json:"session_id"`
-	SessionToken   string    `json:"session_token"`
-	SecretAliases  []string  `json:"secret_aliases"`
-	ExpiresAt      time.Time `json:"expires_at"`
-	MaxReads       int       `json:"max_reads"`
-	RemainingReads int       `json:"remaining_reads"`
+	SessionID      string                     `json:"session_id"`
+	SessionToken   string                     `json:"session_token"`
+	SecretAliases  []string                   `json:"secret_aliases"`
+	ExpiresAt      time.Time                  `json:"expires_at"`
+	MaxReads       int                        `json:"max_reads"`
+	RemainingReads int                        `json:"remaining_reads"`
+	Binding        request.SessionBindingInfo `json:"session_binding"`
 }
 
 type SessionResolveResponsePayload struct {
@@ -130,14 +132,15 @@ type SessionListResponsePayload struct {
 }
 
 type SessionInfoPayload struct {
-	SessionID      string    `json:"session_id"`
-	Reason         string    `json:"reason"`
-	CWD            string    `json:"cwd"`
-	SecretAliases  []string  `json:"secret_aliases"`
-	ExpiresAt      time.Time `json:"expires_at"`
-	MaxReads       int       `json:"max_reads"`
-	RemainingReads int       `json:"remaining_reads"`
-	OverrideEnv    bool      `json:"override_env"`
+	SessionID      string                     `json:"session_id"`
+	Reason         string                     `json:"reason"`
+	CWD            string                     `json:"cwd"`
+	SecretAliases  []string                   `json:"secret_aliases"`
+	ExpiresAt      time.Time                  `json:"expires_at"`
+	MaxReads       int                        `json:"max_reads"`
+	RemainingReads int                        `json:"remaining_reads"`
+	OverrideEnv    bool                       `json:"override_env"`
+	Binding        request.SessionBindingInfo `json:"session_binding"`
 }
 
 type ItemDescribeResponsePayload struct {

--- a/internal/daemon/test_helpers_test.go
+++ b/internal/daemon/test_helpers_test.go
@@ -273,7 +273,10 @@ func newTestBroker(t *testing.T, opts daemonbroker.Options) *daemonbroker.Broker
 
 type testSessionPeerAuthorizer struct{}
 
-func (testSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (daemonbroker.SessionPeerBinding, error) {
+func (testSessionPeerAuthorizer) BindSessionPeer(
+	peer peercred.Info,
+	policy request.SessionBindingPolicy,
+) (daemonbroker.SessionPeerBinding, error) {
 	return daemonbroker.SessionPeerBinding{
 		CreatorPeer: peer,
 		Anchor: peercred.ProcessIdentity{
@@ -283,6 +286,7 @@ func (testSessionPeerAuthorizer) BindSessionPeer(peer peercred.Info) (daemonbrok
 			ExecutablePath: peer.ExecutablePath,
 			StartTime:      time.Unix(1, 0).UTC(),
 		},
+		Policy: policy,
 	}, nil
 }
 

--- a/internal/profileconfig/profileconfig.go
+++ b/internal/profileconfig/profileconfig.go
@@ -56,17 +56,23 @@ type ProfileInfo struct {
 	Reason  string               `json:"reason,omitempty"`
 	TTL     string               `json:"ttl,omitempty"`
 	Include []string             `json:"include,omitempty"`
+	Session *SessionInfo         `json:"session,omitempty"`
 	Secrets []request.SecretSpec `json:"secrets,omitempty"`
 }
 
 type Profile struct {
-	Name       string
-	SourcePath string
-	Account    string
-	Sources    Sources
-	Reason     string
-	Secrets    []request.SecretSpec
-	TTL        time.Duration
+	Name           string
+	SourcePath     string
+	Account        string
+	Sources        Sources
+	Reason         string
+	Secrets        []request.SecretSpec
+	TTL            time.Duration
+	SessionBinding *request.SessionBindingPolicy
+}
+
+type SessionInfo struct {
+	Bind *request.SessionBindingPolicy `json:"bind,omitempty"`
 }
 
 type configFile struct {
@@ -100,15 +106,17 @@ type profileYAML struct {
 	Account string                `yaml:"account"`
 	Include []string              `yaml:"include"`
 	Reason  string                `yaml:"reason"`
+	Session profileSessionYAML    `yaml:"session"`
 	Secrets map[string]secretYAML `yaml:"secrets"`
 	TTL     string                `yaml:"ttl"`
 }
 
 type resolvedProfile struct {
-	account string
-	reason  string
-	secrets map[string]resolvedSecret
-	ttl     time.Duration
+	account        string
+	reason         string
+	secrets        map[string]resolvedSecret
+	ttl            time.Duration
+	sessionBinding *request.SessionBindingPolicy
 }
 
 type resolvedSecret struct {
@@ -122,6 +130,15 @@ type secretYAML struct {
 	Ref     string
 	Account string
 	Source  string
+}
+
+type profileSessionYAML struct {
+	Bind sessionBindYAML `yaml:"bind"`
+}
+
+type sessionBindYAML struct {
+	policy request.SessionBindingPolicy
+	set    bool
 }
 
 func (s *secretYAML) UnmarshalYAML(value *yaml.Node) error {
@@ -165,6 +182,70 @@ func (s *secretYAML) unmarshalMapping(value *yaml.Node) error {
 	return nil
 }
 
+func (s *sessionBindYAML) policyPointer() *request.SessionBindingPolicy {
+	if !s.set {
+		return nil
+	}
+	policy := s.policy
+	return &policy
+}
+
+func (s *sessionBindYAML) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		var raw string
+		if err := value.Decode(&raw); err != nil {
+			return err
+		}
+		return s.setFromScalar(raw)
+	case yaml.MappingNode:
+		return s.unmarshalMapping(value)
+	case yaml.DocumentNode, yaml.SequenceNode, yaml.AliasNode:
+		return errors.New("session bind must be auto, parent, or a mapping")
+	}
+	return errors.New("session bind must be auto, parent, or a mapping")
+}
+
+func (s *sessionBindYAML) setFromScalar(raw string) error {
+	switch strings.TrimSpace(raw) {
+	case "auto":
+		s.policy = request.DefaultSessionBindingPolicy()
+	case "parent":
+		policy, err := request.NewSessionAncestorBinding(1)
+		if err != nil {
+			return err
+		}
+		s.policy = policy
+	default:
+		return errors.New("session bind must be auto, parent, or a mapping")
+	}
+	s.set = true
+	return nil
+}
+
+func (s *sessionBindYAML) unmarshalMapping(value *yaml.Node) error {
+	var ancestorDepth int
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		item := value.Content[i+1]
+		switch key {
+		case "ancestor":
+			if err := item.Decode(&ancestorDepth); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown session bind field %q", key)
+		}
+	}
+	policy, err := request.NewSessionAncestorBinding(ancestorDepth)
+	if err != nil {
+		return err
+	}
+	s.policy = policy
+	s.set = true
+	return nil
+}
+
 func Load(opts LoadOptions) (Profile, error) {
 	path, doc, err := loadConfigFile(opts)
 	if err != nil {
@@ -196,13 +277,14 @@ func Load(opts LoadOptions) (Profile, error) {
 	}
 
 	return Profile{
-		Name:       profileName,
-		SourcePath: path,
-		Account:    resolved.account,
-		Sources:    sources,
-		Reason:     resolved.reason,
-		Secrets:    secrets,
-		TTL:        resolved.ttl,
+		Name:           profileName,
+		SourcePath:     path,
+		Account:        resolved.account,
+		Sources:        sources,
+		Reason:         resolved.reason,
+		Secrets:        secrets,
+		TTL:            resolved.ttl,
+		SessionBinding: cloneSessionBindingPolicy(resolved.sessionBinding),
 	}, nil
 }
 
@@ -262,6 +344,7 @@ func Inspect(opts LoadOptions) (ConfigInfo, error) {
 			Account: resolved.account,
 			Reason:  resolved.reason,
 			Include: trimmedList(rawProfile.Include),
+			Session: sessionInfo(resolved.sessionBinding),
 			Secrets: secrets,
 		}
 		if resolved.ttl != 0 {
@@ -396,6 +479,9 @@ func (r *profileResolver) resolve(profileName string, stack []string) (resolvedP
 		if included.ttl != 0 {
 			result.ttl = included.ttl
 		}
+		if included.sessionBinding != nil {
+			result.sessionBinding = cloneSessionBindingPolicy(included.sessionBinding)
+		}
 	}
 
 	ttl, err := parseTTL(rawProfile.TTL, r.path, profileName)
@@ -407,6 +493,9 @@ func (r *profileResolver) resolve(profileName string, stack []string) (resolvedP
 	}
 	if ttl != 0 {
 		result.ttl = ttl
+	}
+	if policy := rawProfile.Session.Bind.policyPointer(); policy != nil {
+		result.sessionBinding = policy
 	}
 	if err := mergeSecrets(result.secrets, rawProfile.Secrets, result.account, r.sources, r.path, profileName); err != nil {
 		return resolvedProfile{}, err
@@ -420,11 +509,27 @@ func (r *profileResolver) resolve(profileName string, stack []string) (resolvedP
 
 func cloneResolvedProfile(profile resolvedProfile) resolvedProfile {
 	return resolvedProfile{
-		account: profile.account,
-		reason:  profile.reason,
-		secrets: cloneResolvedSecrets(profile.secrets),
-		ttl:     profile.ttl,
+		account:        profile.account,
+		reason:         profile.reason,
+		secrets:        cloneResolvedSecrets(profile.secrets),
+		ttl:            profile.ttl,
+		sessionBinding: cloneSessionBindingPolicy(profile.sessionBinding),
 	}
+}
+
+func sessionInfo(policy *request.SessionBindingPolicy) *SessionInfo {
+	if policy == nil {
+		return nil
+	}
+	return &SessionInfo{Bind: cloneSessionBindingPolicy(policy)}
+}
+
+func cloneSessionBindingPolicy(policy *request.SessionBindingPolicy) *request.SessionBindingPolicy {
+	if policy == nil {
+		return nil
+	}
+	clone := *policy
+	return &clone
 }
 
 func cloneResolvedSecrets(secrets map[string]resolvedSecret) map[string]resolvedSecret {

--- a/internal/profileconfig/profileconfig_test.go
+++ b/internal/profileconfig/profileconfig_test.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/kovyrin/agent-secret/internal/request"
 )
 
 func TestLoadFindsProfileInParentAndSortsSecrets(t *testing.T) {
@@ -46,6 +48,119 @@ profiles:
 	}
 	if got := profile.Secrets[1].Alias; got != "Z_TOKEN" {
 		t.Fatalf("second alias = %q, want sorted Z_TOKEN", got)
+	}
+}
+
+func TestLoadAppliesSessionBindingFromProfile(t *testing.T) {
+	root := t.TempDir()
+	writeConfig(t, filepath.Join(root, "agent-secret.yml"), `
+version: 1
+profiles:
+  base:
+    reason: Base
+    session:
+      bind: parent
+    secrets:
+      BASE_TOKEN: op://Example/Base/token
+  deploy:
+    include: [base]
+    reason: Deploy
+    session:
+      bind:
+        ancestor: 2
+    secrets:
+      DEPLOY_TOKEN: op://Example/Deploy/token
+`)
+
+	base, err := Load(LoadOptions{Name: "base", StartDir: root})
+	if err != nil {
+		t.Fatalf("Load base returned error: %v", err)
+	}
+	if base.SessionBinding == nil ||
+		base.SessionBinding.Mode != request.SessionBindingModeAncestor ||
+		base.SessionBinding.AncestorDepth != 1 {
+		t.Fatalf("base session binding = %+v", base.SessionBinding)
+	}
+
+	deploy, err := Load(LoadOptions{Name: "deploy", StartDir: root})
+	if err != nil {
+		t.Fatalf("Load deploy returned error: %v", err)
+	}
+	if deploy.SessionBinding == nil ||
+		deploy.SessionBinding.Mode != request.SessionBindingModeAncestor ||
+		deploy.SessionBinding.AncestorDepth != 2 {
+		t.Fatalf("deploy session binding = %+v", deploy.SessionBinding)
+	}
+
+	info, err := Inspect(LoadOptions{StartDir: root})
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+	deployInfo := findProfileInfo(t, info, "deploy")
+	if deployInfo.Session == nil || deployInfo.Session.Bind == nil || deployInfo.Session.Bind.AncestorDepth != 2 {
+		t.Fatalf("inspect deploy session binding = %+v", deployInfo.Session)
+	}
+}
+
+func TestLoadRejectsInvalidSessionBindingConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{
+			name: "unknown scalar",
+			config: `
+version: 1
+profiles:
+  deploy:
+    reason: Deploy
+    session:
+      bind: pid
+    secrets:
+      TOKEN: op://Example/Item/token
+`,
+		},
+		{
+			name: "too deep",
+			config: `
+version: 1
+profiles:
+  deploy:
+    reason: Deploy
+    session:
+      bind:
+        ancestor: 4
+    secrets:
+      TOKEN: op://Example/Item/token
+`,
+		},
+		{
+			name: "unknown mapping key",
+			config: `
+version: 1
+profiles:
+  deploy:
+    reason: Deploy
+    session:
+      bind:
+        pid: 123
+    secrets:
+      TOKEN: op://Example/Item/token
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			writeConfig(t, filepath.Join(root, "agent-secret.yml"), tt.config)
+			_, err := Load(LoadOptions{Name: "deploy", StartDir: root})
+			if !errors.Is(err, ErrInvalidConfig) {
+				t.Fatalf("Load error = %v, want ErrInvalidConfig", err)
+			}
+		})
 	}
 }
 
@@ -860,6 +975,18 @@ profiles:
 	if !errors.Is(err, ErrProfileNotFound) {
 		t.Fatalf("expected ErrProfileNotFound, got %v", err)
 	}
+}
+
+func findProfileInfo(t *testing.T, info ConfigInfo, name string) ProfileInfo {
+	t.Helper()
+
+	for _, profile := range info.Profiles {
+		if profile.Name == name {
+			return profile
+		}
+	}
+	t.Fatalf("profile %q not found in %+v", name, info.Profiles)
+	return ProfileInfo{}
 }
 
 func writeConfig(t *testing.T, path string, contents string) {

--- a/internal/request/session.go
+++ b/internal/request/session.go
@@ -15,12 +15,14 @@ const (
 	DefaultSessionTTL      = 2 * time.Minute
 	DefaultSessionMaxReads = 1
 	MaxSessionReads        = 20
+	MaxSessionBindAncestor = 3
 )
 
 var (
 	ErrInvalidSessionID    = fmt.Errorf("%w: invalid session id", ErrInvalidRequest)
 	ErrInvalidSessionToken = fmt.Errorf("%w: invalid session token", ErrInvalidRequest)
 	ErrInvalidSessionRead  = fmt.Errorf("%w: invalid session read count", ErrInvalidRequest)
+	ErrInvalidSessionBind  = fmt.Errorf("%w: invalid session binding", ErrInvalidRequest)
 )
 
 var (
@@ -39,6 +41,7 @@ type SessionCreateOptions struct {
 	ReceivedAt         time.Time
 	MaxReads           int
 	OverrideEnv        bool
+	Binding            SessionBindingPolicy
 }
 
 type SessionCreateRequest struct {
@@ -53,6 +56,7 @@ type SessionCreateRequest struct {
 	ExpiresAt          time.Time             `json:"expires_at"`
 	MaxReads           int                   `json:"max_reads"`
 	OverrideEnv        bool                  `json:"override_env"`
+	Binding            SessionBindingPolicy  `json:"session_binding"`
 }
 
 type SessionResolveRequest struct {
@@ -72,15 +76,75 @@ type SessionDestroyRequest struct {
 }
 
 type SessionSummary struct {
-	SessionID      string    `json:"session_id"`
-	SessionToken   string    `json:"session_token,omitempty"`
-	Reason         string    `json:"reason"`
-	CWD            string    `json:"cwd"`
-	SecretAliases  []string  `json:"secret_aliases"`
-	ExpiresAt      time.Time `json:"expires_at"`
-	MaxReads       int       `json:"max_reads"`
-	RemainingReads int       `json:"remaining_reads"`
-	OverrideEnv    bool      `json:"override_env"`
+	SessionID      string             `json:"session_id"`
+	SessionToken   string             `json:"session_token,omitempty"`
+	Reason         string             `json:"reason"`
+	CWD            string             `json:"cwd"`
+	SecretAliases  []string           `json:"secret_aliases"`
+	ExpiresAt      time.Time          `json:"expires_at"`
+	MaxReads       int                `json:"max_reads"`
+	RemainingReads int                `json:"remaining_reads"`
+	OverrideEnv    bool               `json:"override_env"`
+	Binding        SessionBindingInfo `json:"session_binding"`
+}
+
+type SessionBindingMode string
+
+const (
+	SessionBindingModeAuto     SessionBindingMode = "auto"
+	SessionBindingModeAncestor SessionBindingMode = "ancestor"
+)
+
+type SessionBindingPolicy struct {
+	Mode          SessionBindingMode `json:"mode,omitempty"`
+	AncestorDepth int                `json:"ancestor_depth,omitempty"`
+}
+
+type SessionBindingInfo struct {
+	Mode           SessionBindingMode    `json:"mode"`
+	AncestorDepth  int                   `json:"ancestor_depth,omitempty"`
+	BoundProcess   SessionBindingProcess `json:"bound_process"`
+	CreatorProcess SessionBindingProcess `json:"creator_process"`
+}
+
+type SessionBindingProcess struct {
+	PID       int    `json:"pid"`
+	ParentPID int    `json:"parent_pid,omitempty"`
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+}
+
+func DefaultSessionBindingPolicy() SessionBindingPolicy {
+	return SessionBindingPolicy{Mode: SessionBindingModeAuto}
+}
+
+func NewSessionAncestorBinding(depth int) (SessionBindingPolicy, error) {
+	policy := SessionBindingPolicy{Mode: SessionBindingModeAncestor, AncestorDepth: depth}
+	return NormalizeSessionBindingPolicy(policy)
+}
+
+func NormalizeSessionBindingPolicy(policy SessionBindingPolicy) (SessionBindingPolicy, error) {
+	if policy.Mode == "" {
+		policy.Mode = SessionBindingModeAuto
+	}
+	switch policy.Mode {
+	case SessionBindingModeAuto:
+		if policy.AncestorDepth != 0 {
+			return SessionBindingPolicy{}, fmt.Errorf("%w: auto binding does not accept ancestor depth", ErrInvalidSessionBind)
+		}
+		return policy, nil
+	case SessionBindingModeAncestor:
+		if policy.AncestorDepth < 1 || policy.AncestorDepth > MaxSessionBindAncestor {
+			return SessionBindingPolicy{}, fmt.Errorf(
+				"%w: ancestor depth must be between 1 and %d",
+				ErrInvalidSessionBind,
+				MaxSessionBindAncestor,
+			)
+		}
+		return policy, nil
+	default:
+		return SessionBindingPolicy{}, fmt.Errorf("%w: unknown binding mode %q", ErrInvalidSessionBind, policy.Mode)
+	}
 }
 
 func NewSessionCreate(opts SessionCreateOptions) (SessionCreateRequest, error) {
@@ -119,6 +183,10 @@ func NewSessionCreate(opts SessionCreateOptions) (SessionCreateRequest, error) {
 	if err != nil {
 		return SessionCreateRequest{}, err
 	}
+	binding, err := NormalizeSessionBindingPolicy(opts.Binding)
+	if err != nil {
+		return SessionCreateRequest{}, err
+	}
 	receivedAt := opts.ReceivedAt
 	expiresAt := time.Time{}
 	if !receivedAt.IsZero() {
@@ -136,6 +204,7 @@ func NewSessionCreate(opts SessionCreateOptions) (SessionCreateRequest, error) {
 		ExpiresAt:          expiresAt,
 		MaxReads:           maxReads,
 		OverrideEnv:        opts.OverrideEnv,
+		Binding:            binding,
 	}, nil
 }
 
@@ -166,6 +235,9 @@ func (r SessionCreateRequest) ValidateForDaemon() error {
 	}
 	if r.ExecutableIdentity.IsZero() {
 		return fmt.Errorf("%w: executable identity is required", ErrInvalidRequest)
+	}
+	if _, err := NormalizeSessionBindingPolicy(r.Binding); err != nil {
+		return err
 	}
 	if err := validateDaemonPreparedPath("cwd", r.CWD, false); err != nil {
 		return err

--- a/internal/request/session.go
+++ b/internal/request/session.go
@@ -14,7 +14,7 @@ import (
 const (
 	DefaultSessionTTL      = 2 * time.Minute
 	DefaultSessionMaxReads = 1
-	MaxSessionReads        = 20
+	MaxSessionReads        = 100
 	MaxSessionBindAncestor = 3
 )
 

--- a/internal/request/session_test.go
+++ b/internal/request/session_test.go
@@ -69,6 +69,31 @@ func TestNewSessionCreateDefaultsAndDaemonValidation(t *testing.T) {
 	}
 }
 
+func TestNewSessionCreateAcceptsMaximumReadLimit(t *testing.T) {
+	t.Parallel()
+
+	dir := testResolvedDir(t)
+	bin, identity := testExecutable(t, dir, "agent-secret")
+
+	req, err := NewSessionCreate(SessionCreateOptions{
+		Reason:             "Run long workflow",
+		Command:            []string{"agent-secret", "session", "create"},
+		ResolvedExecutable: bin,
+		ExecutableIdentity: identity,
+		CWD:                dir,
+		MaxReads:           MaxSessionReads,
+		Secrets: []SecretSpec{
+			{Alias: "TOKEN", Ref: "op://Example Vault/Deploy/token", Account: "Work"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewSessionCreate returned error: %v", err)
+	}
+	if req.MaxReads != MaxSessionReads {
+		t.Fatalf("max reads = %d, want %d", req.MaxReads, MaxSessionReads)
+	}
+}
+
 func TestNewSessionCreateRejectsInvalidInputs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/request/session_test.go
+++ b/internal/request/session_test.go
@@ -44,6 +44,9 @@ func TestNewSessionCreateDefaultsAndDaemonValidation(t *testing.T) {
 	if req.MaxReads != DefaultSessionMaxReads {
 		t.Fatalf("max reads = %d, want %d", req.MaxReads, DefaultSessionMaxReads)
 	}
+	if req.Binding.Mode != SessionBindingModeAuto || req.Binding.AncestorDepth != 0 {
+		t.Fatalf("binding = %+v, want auto", req.Binding)
+	}
 	if !req.ExpiresAt.Equal(receivedAt.Add(DefaultSessionTTL)) {
 		t.Fatalf("expires_at = %s, want %s", req.ExpiresAt, receivedAt.Add(DefaultSessionTTL))
 	}
@@ -95,6 +98,9 @@ func TestNewSessionCreateRejectsInvalidInputs(t *testing.T) {
 		{name: "missing executable identity", mutate: func(o *SessionCreateOptions) { o.ExecutableIdentity = fileidentity.Identity{} }, want: ErrInvalidRequest},
 		{name: "missing command", mutate: func(o *SessionCreateOptions) { o.Command = nil }, want: ErrInvalidCommand},
 		{name: "bad secret", mutate: func(o *SessionCreateOptions) { o.Secrets[0].Alias = "token" }, want: ErrInvalidAlias},
+		{name: "bad bind depth", mutate: func(o *SessionCreateOptions) {
+			o.Binding = SessionBindingPolicy{Mode: SessionBindingModeAncestor, AncestorDepth: MaxSessionBindAncestor + 1}
+		}, want: ErrInvalidSessionBind},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -107,6 +113,37 @@ func TestNewSessionCreateRejectsInvalidInputs(t *testing.T) {
 			_, err := NewSessionCreate(opts)
 			if !errors.Is(err, tt.want) {
 				t.Fatalf("NewSessionCreate error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionBindingPolicyValidation(t *testing.T) {
+	t.Parallel()
+
+	parent, err := NewSessionAncestorBinding(1)
+	if err != nil {
+		t.Fatalf("NewSessionAncestorBinding returned error: %v", err)
+	}
+	if parent.Mode != SessionBindingModeAncestor || parent.AncestorDepth != 1 {
+		t.Fatalf("parent binding = %+v", parent)
+	}
+
+	tests := []struct {
+		name   string
+		policy SessionBindingPolicy
+	}{
+		{name: "zero ancestor", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestor}},
+		{name: "too deep ancestor", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestor, AncestorDepth: MaxSessionBindAncestor + 1}},
+		{name: "auto with depth", policy: SessionBindingPolicy{Mode: SessionBindingModeAuto, AncestorDepth: 1}},
+		{name: "unknown mode", policy: SessionBindingPolicy{Mode: "pid", AncestorDepth: 1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := NormalizeSessionBindingPolicy(tt.policy); !errors.Is(err, ErrInvalidSessionBind) {
+				t.Fatalf("NormalizeSessionBindingPolicy error = %v, want ErrInvalidSessionBind", err)
 			}
 		})
 	}

--- a/site/docs.html
+++ b/site/docs.html
@@ -48,7 +48,7 @@
           Secrets Manager, keep references in project profiles, and validate
           requests without printing secret values.
         </p>
-        <p class="legal-date">Last updated: June 9, 2026</p>
+        <p class="legal-date">Last updated: June 16, 2026</p>
       </section>
 
       <div class="docs-layout">
@@ -192,6 +192,8 @@ profiles:
     account: Example Corp
     reason: Deploy application
     ttl: 10m
+    session:
+      bind: parent
     secrets:
       CLOUDFLARE_API_TOKEN: op://Example/Cloudflare/token
       RELEASE_WEBHOOK:
@@ -218,7 +220,11 @@ profiles:
               tree.
             </p>
             <div class="code-panel">
-              <pre><code>agent-secret session create --profile terraform-cloudflare --max-reads 3
+              <pre><code>agent-secret session create \
+  --profile terraform-cloudflare \
+  --bind-parent \
+  --max-reads 3 \
+  --json=compact
 agent-secret with-session astok_123 --only CLOUDFLARE_API_TOKEN -- terraform plan
 agent-secret with-session astok_123 \
   --only CLOUDFLARE_API_TOKEN,STATE_TOKEN \
@@ -229,6 +235,8 @@ agent-secret session destroy asid_123</code></pre>
             <p>
               <code>session create</code> can combine a project profile, env
               files, and one-off <code>--secret ALIAS=REF</code> flags.
+              Use <code>--json=compact</code> when a shell wrapper needs one
+              JSON object on one line.
               Keep the returned <code>session_token</code> for
               <code>with-session</code>; use the returned or listed
               <code>session_id</code> for inspection and cleanup.
@@ -237,6 +245,20 @@ agent-secret session destroy asid_123</code></pre>
               or a per-command subset with <code>--only</code>. Unknown aliases
               fail before the child command starts. Use sessions inside one
               task shell, wrapper script, or agent process tree.
+            </p>
+            <p>
+              Session tokens are bound to the requester process tree by default.
+              Use <code>--bind-parent</code> when a wrapper creates the session
+              inside command substitution and later calls
+              <code>with-session</code> from the parent shell. Deeper wrappers
+              can use <code>--bind-ancestor N</code> up to <code>3</code>;
+              Agent Secret accepts only ancestors of the current
+              <code>agent-secret</code> process, not arbitrary PIDs. Profiles
+              can set <code>session.bind: parent</code>,
+              <code>session.bind: auto</code>, or
+              <code>session.bind: { ancestor: N }</code>. Session list JSON
+              includes non-secret binding metadata so process mismatch failures
+              are easier to debug.
             </p>
             <p>
               Sessions end when TTL passes, the read count is exhausted,

--- a/site/index.html
+++ b/site/index.html
@@ -178,7 +178,7 @@
             <div class="command-row copyable">
               <div class="command-line">
                 <span class="prompt" aria-hidden="true">$</span>
-                <code data-copy-text>agent-secret session create --profile terraform-cloudflare --max-reads 3</code>
+                <code data-copy-text>agent-secret session create --profile terraform-cloudflare --bind-parent --max-reads 3 --json=compact</code>
               </div>
               <button class="copy-button" type="button" data-copy-button aria-label="Copy session command">
                 <svg class="copy-icon" aria-hidden="true" viewBox="0 0 24 24"><rect x="8" y="8" width="10" height="10" rx="2"></rect><path d="M6 16H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
@@ -241,6 +241,8 @@ profiles:
   terraform-cloudflare:
     reason: Terraform DNS management
     ttl: 10m
+    session:
+      bind: parent
     secrets:
       CLOUDFLARE_API_TOKEN: op://Example/Cloudflare/token</code></pre>
           </div>
@@ -362,7 +364,7 @@ profiles:
               <li>The background helper fetches only the secrets you approved for the request.</li>
               <li>Audit logs record metadata, never raw secrets.</li>
               <li>Reusable approvals stay bounded by command, cwd, references, account, TTL, and use count.</li>
-              <li>Sessions stay bounded by requester process tree, cwd, aliases, TTL, read count, secret tokens, and the <code>with-session</code> wrapper.</li>
+              <li>Sessions stay bounded by requester process tree or an explicit ancestor binding, cwd, aliases, TTL, read count, secret tokens, and the <code>with-session</code> wrapper.</li>
             </ul>
           </div>
           <div>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agent-secret.sh/</loc>
-    <lastmod>2026-06-08</lastmod>
+    <lastmod>2026-06-16</lastmod>
   </url>
   <url>
     <loc>https://agent-secret.sh/docs</loc>
-    <lastmod>2026-06-08</lastmod>
+    <lastmod>2026-06-16</lastmod>
   </url>
   <url>
     <loc>https://agent-secret.sh/privacy</loc>


### PR DESCRIPTION
## Summary

- add explicit session binding with `session create --bind-parent` and `--bind-ancestor N`, capped to ancestor-only targets
- add profile config support for `session.bind` and include binding metadata in session create/list JSON plus approval UI context
- add `--json=compact` for session create/list/destroy to make shell wrappers read one-line JSON reliably
- improve process mismatch diagnostics with bound/requester process names, PIDs, and paths
- update the PRD, docs, bundled skill, website, changelog, and session e2e runbook

## Validation

- `mise exec -- go test ./...`
- `swift test` from `approver/`
- `npx --yes markdownlint-cli README.md CHANGELOG.md SECURITY.md docs/configuration.md docs/session-e2e-validation.md docs/threat-model.md docs/prd.md .agents/skills/agent-secret/SKILL.md`
- `mise run lint`
