### PR TITLE
Add session ancestor name binding

### DIFF
--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -144,11 +144,15 @@ Treat `session_token` as a short-lived secret capability bound to the requester
 process tree that created the session. Use `--bind-parent` when the session is
 created inside command substitution and later used from the parent shell. Use
 `--bind-ancestor N` only for deeper wrappers; N must be 1..3 and Agent Secret
-only accepts ancestors of the current `agent-secret` process. Profiles can set:
+only accepts ancestors of the current `agent-secret` process. Use
+`--bind-ancestor-name NAME` when wrapper depth varies but the desired ancestor
+executable basename is stable; it matches only the current process ancestry and
+does not search arbitrary PIDs. Profiles can set:
 
 - `session.bind: parent`
 - `session.bind: auto`
 - `session.bind: { ancestor: N }`
+- `session.bind: { ancestor_name: NAME }`
 
 CLI binding flags override profile config. Keep the token in a local shell
 variable only for the duration of the bounded workflow; do not write it to repo
@@ -157,7 +161,8 @@ Keep the public `session_id` separately for cleanup. Prefer
 `session destroy SESSION_ID` or `session destroy --all` when the workflow is
 done. If `with-session` reports a process mismatch, use the bound/requester
 process names, PIDs, and paths in the error to decide whether the session
-should be recreated with `--bind-parent`.
+should be recreated with `--bind-parent`, `--bind-ancestor N`, or
+`--bind-ancestor-name NAME`.
 
 Use a shell only when the shell is the command you actually want approved:
 

--- a/.agents/skills/agent-secret/SKILL.md
+++ b/.agents/skills/agent-secret/SKILL.md
@@ -144,15 +144,16 @@ Treat `session_token` as a short-lived secret capability bound to the requester
 process tree that created the session. Use `--bind-parent` when the session is
 created inside command substitution and later used from the parent shell. Use
 `--bind-ancestor N` only for deeper wrappers; N must be 1..3 and Agent Secret
-only accepts ancestors of the current `agent-secret` process. Use
-`--bind-ancestor-name NAME` when wrapper depth varies but the desired ancestor
-executable basename is stable; it matches only the current process ancestry and
-does not search arbitrary PIDs. Profiles can set:
+only accepts ancestors of the current `agent-secret` process. Repeat
+`--bind-ancestor-name NAME` when wrapper depth varies across accepted
+agents; it binds to the nearest matching executable basename in the current
+process ancestry and does not search arbitrary PIDs. Profiles can set:
 
 - `session.bind: parent`
 - `session.bind: auto`
 - `session.bind: { ancestor: N }`
 - `session.bind: { ancestor_name: NAME }`
+- `session.bind: { ancestor_names: [Codex, Claude, Cursor] }`
 
 CLI binding flags override profile config. Keep the token in a local shell
 variable only for the duration of the bounded workflow; do not write it to repo
@@ -162,7 +163,7 @@ Keep the public `session_id` separately for cleanup. Prefer
 done. If `with-session` reports a process mismatch, use the bound/requester
 process names, PIDs, and paths in the error to decide whether the session
 should be recreated with `--bind-parent`, `--bind-ancestor N`, or
-`--bind-ancestor-name NAME`.
+`--bind-ancestor-name NAME` or a repeated-name allowlist.
 
 Use a shell only when the shell is the command you actually want approved:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,16 +27,19 @@ file before a release is published.
 - Added `agent-secret session create --bind-parent` and `--bind-ancestor N` so
   shell wrappers can bind approved sessions to a stable ancestor process instead
   of the short-lived `agent-secret` process.
+- Added `agent-secret session create --bind-ancestor-name NAME` for wrappers
+  where the desired ancestor executable name is stable but the depth can vary.
 - Added profile config support for session binding with `session.bind: parent`,
-  `session.bind: auto`, and `session.bind: { ancestor: N }`.
+  `session.bind: auto`, `session.bind: { ancestor: N }`, and
+  `session.bind: { ancestor_name: NAME }`.
 - Added `--json=compact` for session create, list, and destroy output so shell
   wrappers can safely read one JSON object per line.
 
 ### Changed
 
 - Session create/list JSON and approval prompts now include non-secret session
-  binding metadata: binding mode, ancestor depth, bound process, and creator
-  process.
+  binding metadata: binding mode, requested ancestor name, resolved ancestor
+  depth, bound process, and creator process.
 - Session `--max-reads` now accepts up to `100` successful `with-session`
   commands for longer approved workflows.
 - Session process mismatch errors now include the bound process and requester

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,13 @@ file before a release is published.
 - Added `agent-secret session create --bind-parent` and `--bind-ancestor N` so
   shell wrappers can bind approved sessions to a stable ancestor process instead
   of the short-lived `agent-secret` process.
-- Added `agent-secret session create --bind-ancestor-name NAME` for wrappers
-  where the desired ancestor executable name is stable but the depth can vary.
+- Added repeatable `agent-secret session create --bind-ancestor-name NAME` for
+  wrappers that can run under different agent executables while still binding
+  only to the nearest matching ancestor process.
 - Added profile config support for session binding with `session.bind: parent`,
   `session.bind: auto`, `session.bind: { ancestor: N }`, and
-  `session.bind: { ancestor_name: NAME }`.
+  `session.bind: { ancestor_name: NAME }` or
+  `session.bind: { ancestor_names: [NAME, ...] }`.
 - Added `--json=compact` for session create, list, and destroy output so shell
   wrappers can safely read one JSON object per line.
 

--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ Session tokens are accepted only from the approved requester process tree. Use
 `--bind-parent` when a shell wrapper creates the session inside command
 substitution and later calls `with-session` from the parent shell.
 Advanced wrappers can use `--bind-ancestor N` up to `3`, but only ancestors of
-the current `agent-secret` process are accepted. If wrapper depth varies but
-the target process name is stable, use `--bind-ancestor-name NAME`; it matches
-the nearest eligible ancestor executable basename and does not search arbitrary
-PIDs.
+the current `agent-secret` process are accepted. If wrapper depth varies across
+different agents, repeat `--bind-ancestor-name NAME`; Agent Secret matches the
+nearest eligible ancestor executable basename in the allowed set and does not
+search arbitrary PIDs.
 
 Inspect item metadata without revealing values:
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ Session tokens are accepted only from the approved requester process tree. Use
 `--bind-parent` when a shell wrapper creates the session inside command
 substitution and later calls `with-session` from the parent shell.
 Advanced wrappers can use `--bind-ancestor N` up to `3`, but only ancestors of
-the current `agent-secret` process are accepted.
+the current `agent-secret` process are accepted. If wrapper depth varies but
+the target process name is stable, use `--bind-ancestor-name NAME`; it matches
+the nearest eligible ancestor executable basename and does not search arbitrary
+PIDs.
 
 Inspect item metadata without revealing values:
 
@@ -271,7 +274,9 @@ The launch build is intentionally narrow:
 - 1Password Desktop and Bitwarden Secrets Manager only; no other providers yet.
 - Sessions are bounded by requester process tree or explicit ancestor binding,
   cwd, TTL, read count, aliases, background-helper memory, and
-  `agent-secret with-session`; no long-lived interactive shells.
+  `agent-secret with-session`. Named ancestor binding still matches only the
+  current process ancestry; no arbitrary PID binding or long-lived interactive
+  shells.
 - No writing, updating, or rotating secrets yet.
 - No GCP Secret Manager or GCP token minting support yet.
 - No sandbox guarantee after you approve a child process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,6 +13,8 @@ The supported runtime scope is narrow:
 - Bounded background-helper sessions through `session create`, `session list`,
   `session destroy`, and `with-session`, with token use bound to the requester
   process tree or explicit ancestor binding selected at session creation.
+  Named ancestor binding walks only the current process ancestry and matches an
+  executable basename; it does not allow arbitrary PID binding.
 
 Linux, Windows, credential helpers, automatic updates, and alternative secret
 backends are not supported security surfaces yet.

--- a/approver/Sources/AgentSecretApprover/Models/SessionBindingInfo.swift
+++ b/approver/Sources/AgentSecretApprover/Models/SessionBindingInfo.swift
@@ -5,6 +5,7 @@ public struct SessionBindingInfo: Codable, Equatable, Sendable {
         case mode
         case ancestorDepth = "ancestor_depth"
         case ancestorName = "ancestor_name"
+        case ancestorNames = "ancestor_names"
         case boundProcess = "bound_process"
         case creatorProcess = "creator_process"
     }
@@ -12,6 +13,7 @@ public struct SessionBindingInfo: Codable, Equatable, Sendable {
     public var mode: String
     public var ancestorDepth: Int?
     public var ancestorName: String?
+    public var ancestorNames: [String]
     public var boundProcess: SessionBindingProcess
     public var creatorProcess: SessionBindingProcess
 
@@ -20,12 +22,24 @@ public struct SessionBindingInfo: Codable, Equatable, Sendable {
         boundProcess: SessionBindingProcess,
         creatorProcess: SessionBindingProcess,
         ancestorDepth: Int? = nil,
-        ancestorName: String? = nil
+        ancestorName: String? = nil,
+        ancestorNames: [String] = []
     ) {
         self.mode = mode
         self.ancestorDepth = ancestorDepth
         self.ancestorName = ancestorName
+        self.ancestorNames = ancestorNames
         self.boundProcess = boundProcess
         self.creatorProcess = creatorProcess
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        mode = try container.decode(String.self, forKey: .mode)
+        ancestorDepth = try container.decodeIfPresent(Int.self, forKey: .ancestorDepth)
+        ancestorName = try container.decodeIfPresent(String.self, forKey: .ancestorName)
+        ancestorNames = try container.decodeIfPresent([String].self, forKey: .ancestorNames) ?? []
+        boundProcess = try container.decode(SessionBindingProcess.self, forKey: .boundProcess)
+        creatorProcess = try container.decode(SessionBindingProcess.self, forKey: .creatorProcess)
     }
 }

--- a/approver/Sources/AgentSecretApprover/Models/SessionBindingInfo.swift
+++ b/approver/Sources/AgentSecretApprover/Models/SessionBindingInfo.swift
@@ -4,12 +4,14 @@ public struct SessionBindingInfo: Codable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case mode
         case ancestorDepth = "ancestor_depth"
+        case ancestorName = "ancestor_name"
         case boundProcess = "bound_process"
         case creatorProcess = "creator_process"
     }
 
     public var mode: String
     public var ancestorDepth: Int?
+    public var ancestorName: String?
     public var boundProcess: SessionBindingProcess
     public var creatorProcess: SessionBindingProcess
 
@@ -17,10 +19,12 @@ public struct SessionBindingInfo: Codable, Equatable, Sendable {
         mode: String,
         boundProcess: SessionBindingProcess,
         creatorProcess: SessionBindingProcess,
-        ancestorDepth: Int? = nil
+        ancestorDepth: Int? = nil,
+        ancestorName: String? = nil
     ) {
         self.mode = mode
         self.ancestorDepth = ancestorDepth
+        self.ancestorName = ancestorName
         self.boundProcess = boundProcess
         self.creatorProcess = creatorProcess
     }

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+SessionBinding.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+SessionBinding.swift
@@ -15,8 +15,12 @@ extension ApprovalRequestViewModel {
         var lines = [
             "Mode: \(sanitizedDisplayText(binding.mode))"
         ]
+        if !binding.ancestorNames.isEmpty {
+            let sanitizedNames = binding.ancestorNames.map { sanitizedDisplayText($0) }
+            lines.append("Ancestor names: \(sanitizedNames.joined(separator: ", "))")
+        }
         if let ancestorName = binding.ancestorName {
-            lines.append("Ancestor name: \(sanitizedDisplayText(ancestorName))")
+            lines.append("Matched ancestor name: \(sanitizedDisplayText(ancestorName))")
         }
         if let ancestorDepth = binding.ancestorDepth {
             lines.append("Ancestor depth: \(ancestorDepth)")

--- a/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+SessionBinding.swift
+++ b/approver/Sources/AgentSecretApprover/Presentation/ViewModels/ApprovalRequestViewModel+SessionBinding.swift
@@ -15,6 +15,9 @@ extension ApprovalRequestViewModel {
         var lines = [
             "Mode: \(sanitizedDisplayText(binding.mode))"
         ]
+        if let ancestorName = binding.ancestorName {
+            lines.append("Ancestor name: \(sanitizedDisplayText(ancestorName))")
+        }
         if let ancestorDepth = binding.ancestorDepth {
             lines.append("Ancestor depth: \(ancestorDepth)")
         }

--- a/approver/Tests/AgentSecretApproverTests/Presentation/ApprovalRequestInspectionTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/Presentation/ApprovalRequestInspectionTests.swift
@@ -60,7 +60,8 @@ final class ApprovalRequestInspectionTests: XCTestCase {
                     path: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret"
                 ),
                 ancestorDepth: 1,
-                ancestorName: "zsh"
+                ancestorName: "zsh",
+                ancestorNames: ["Codex", "zsh"]
             )
         )
     }
@@ -88,7 +89,8 @@ final class ApprovalRequestInspectionTests: XCTestCase {
         XCTAssertEqual(viewModel.sessionBindingSummary, "zsh pid=501")
         XCTAssertTrue(inspection.contains("Session binding:"))
         XCTAssertTrue(inspection.contains("Mode: ancestor_name"))
-        XCTAssertTrue(inspection.contains("Ancestor name: zsh"))
+        XCTAssertTrue(inspection.contains("Ancestor names: Codex, zsh"))
+        XCTAssertTrue(inspection.contains("Matched ancestor name: zsh"))
         XCTAssertTrue(inspection.contains("Ancestor depth: 1"))
         XCTAssertTrue(inspection.contains("Bound process: zsh pid=501 ppid=1 path=/bin/zsh"))
         let creatorLine = "Creator process: agent-secret pid=502 " +

--- a/approver/Tests/AgentSecretApproverTests/Presentation/ApprovalRequestInspectionTests.swift
+++ b/approver/Tests/AgentSecretApproverTests/Presentation/ApprovalRequestInspectionTests.swift
@@ -47,7 +47,7 @@ final class ApprovalRequestInspectionTests: XCTestCase {
             operation: .sessionCreate,
             allowsReusable: false,
             sessionBinding: SessionBindingInfo(
-                mode: "ancestor",
+                mode: "ancestor_name",
                 boundProcess: SessionBindingProcess(
                     pid: 501,
                     name: "zsh",
@@ -59,7 +59,8 @@ final class ApprovalRequestInspectionTests: XCTestCase {
                     name: "agent-secret",
                     path: "/Applications/Agent Secret.app/Contents/Resources/bin/agent-secret"
                 ),
-                ancestorDepth: 1
+                ancestorDepth: 1,
+                ancestorName: "zsh"
             )
         )
     }
@@ -86,7 +87,8 @@ final class ApprovalRequestInspectionTests: XCTestCase {
 
         XCTAssertEqual(viewModel.sessionBindingSummary, "zsh pid=501")
         XCTAssertTrue(inspection.contains("Session binding:"))
-        XCTAssertTrue(inspection.contains("Mode: ancestor"))
+        XCTAssertTrue(inspection.contains("Mode: ancestor_name"))
+        XCTAssertTrue(inspection.contains("Ancestor name: zsh"))
         XCTAssertTrue(inspection.contains("Ancestor depth: 1"))
         XCTAssertTrue(inspection.contains("Bound process: zsh pid=501 ppid=1 path=/bin/zsh"))
         let creatorLine = "Creator process: agent-secret pid=502 " +

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,6 +340,7 @@ agent-secret session destroy [--json] --all
 - `--json`
 - `--bind-parent`
 - `--bind-ancestor N`
+- `--bind-ancestor-name NAME`
 
 It also accepts `--max-reads COUNT`, which limits the number of successful
 `with-session` reads. The default is `1`; the allowed range is `1` through
@@ -353,6 +354,9 @@ shell wrapper captures the JSON in command substitution and later runs
 `with-session` from the parent shell. `--bind-ancestor N` binds to a deeper
 ancestor, up to `3`. Agent Secret rejects arbitrary PIDs; explicit bindings can
 target only ancestors of the current `agent-secret` process.
+`--bind-ancestor-name NAME` walks that same ancestry and binds to the nearest
+eligible ancestor whose executable basename exactly matches `NAME`, which is
+useful when wrapper depth varies but the shell or agent process name is stable.
 
 The same binding policy can live in a profile:
 
@@ -370,9 +374,16 @@ profiles:
     session:
       bind:
         ancestor: 2
+
+  codex-wrapper:
+    include: [deploy]
+    session:
+      bind:
+        ancestor_name: Codex
 ```
 
-CLI `--bind-parent` or `--bind-ancestor` overrides profile `session.bind`.
+CLI `--bind-parent`, `--bind-ancestor`, or `--bind-ancestor-name` overrides
+profile `session.bind`.
 
 For example, approve a project profile plus a one-off CLI reference, then use
 different aliases for different commands:
@@ -399,10 +410,11 @@ agent-secret with-session astok_123 \
   `session destroy`.
 - `session_token`: a secret token accepted by `with-session` only from the
   requester process tree that created the session or the explicit ancestor tree
-  selected by `--bind-parent` / `--bind-ancestor`. It is never shown by
-  `session list`.
+  selected by `--bind-parent`, `--bind-ancestor`, or `--bind-ancestor-name`. It
+  is never shown by `session list`.
 - `session_binding`: non-secret binding metadata including binding mode,
-  ancestor depth, bound process, and creator process.
+  requested ancestor name when configured, resolved ancestor depth, bound
+  process, and creator process.
 
 It does not print secret values. `session list` shows active `session_id` values
 and non-secret metadata for inspection and cleanup. Without `--only`,
@@ -415,9 +427,9 @@ child command.
 `--allow-mutable-executable`. The `--cwd` value defaults to the caller's current
 directory and must match the session working directory. The caller must also be
 inside the same requester process tree that ran `session create`, or inside the
-explicit ancestor tree selected by `--bind-parent` / `--bind-ancestor`. If
-`with-session` fails with a process mismatch, the error includes the bound
-process and requester process names, PIDs, and paths.
+explicit ancestor tree selected by `--bind-parent`, `--bind-ancestor`, or
+`--bind-ancestor-name`. If `with-session` fails with a process mismatch, the
+error includes the bound process and requester process names, PIDs, and paths.
 
 Sessions are background-helper-memory only. They expire when TTL passes, the
 read count is exhausted, `agent-secret session destroy SESSION_ID` or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,7 +340,7 @@ agent-secret session destroy [--json] --all
 - `--json`
 - `--bind-parent`
 - `--bind-ancestor N`
-- `--bind-ancestor-name NAME`
+- `--bind-ancestor-name NAME` (repeatable)
 
 It also accepts `--max-reads COUNT`, which limits the number of successful
 `with-session` reads. The default is `1`; the allowed range is `1` through
@@ -354,9 +354,10 @@ shell wrapper captures the JSON in command substitution and later runs
 `with-session` from the parent shell. `--bind-ancestor N` binds to a deeper
 ancestor, up to `3`. Agent Secret rejects arbitrary PIDs; explicit bindings can
 target only ancestors of the current `agent-secret` process.
-`--bind-ancestor-name NAME` walks that same ancestry and binds to the nearest
-eligible ancestor whose executable basename exactly matches `NAME`, which is
-useful when wrapper depth varies but the shell or agent process name is stable.
+Repeated `--bind-ancestor-name NAME` walks that same ancestry and binds to the
+nearest eligible ancestor whose executable basename exactly matches any allowed
+name. This is useful when the same wrapper may run from different agents with
+different process-tree shapes. Name matching is exact and case-sensitive.
 
 The same binding policy can live in a profile:
 
@@ -380,6 +381,15 @@ profiles:
     session:
       bind:
         ancestor_name: Codex
+
+  agent-wrapper:
+    include: [deploy]
+    session:
+      bind:
+        ancestor_names:
+          - Codex
+          - Claude
+          - Cursor
 ```
 
 CLI `--bind-parent`, `--bind-ancestor`, or `--bind-ancestor-name` overrides
@@ -413,8 +423,8 @@ agent-secret with-session astok_123 \
   selected by `--bind-parent`, `--bind-ancestor`, or `--bind-ancestor-name`. It
   is never shown by `session list`.
 - `session_binding`: non-secret binding metadata including binding mode,
-  requested ancestor name when configured, resolved ancestor depth, bound
-  process, and creator process.
+  requested ancestor names when configured, the matched ancestor name, resolved
+  ancestor depth, bound process, and creator process.
 
 It does not print secret values. `session list` shows active `session_id` values
 and non-secret metadata for inspection and cleanup. Without `--only`,

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -854,8 +854,9 @@ Session option:
 --max-reads integer          Session create only. Default: 1. Max: 100.
 --bind-parent                Session create only. Bind to the parent process.
 --bind-ancestor integer      Session create only. Bind to ancestor depth 1..3.
---bind-ancestor-name string  Session create only. Bind to the nearest matching
-                             ancestor executable basename.
+--bind-ancestor-name string  Session create only. Repeatable. Bind to the
+                             nearest ancestor executable basename in the
+                             allowed set.
 --json=compact               Session create/list/destroy. One-line JSON output.
 ```
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -854,6 +854,8 @@ Session option:
 --max-reads integer          Session create only. Default: 1. Max: 100.
 --bind-parent                Session create only. Bind to the parent process.
 --bind-ancestor integer      Session create only. Bind to ancestor depth 1..3.
+--bind-ancestor-name string  Session create only. Bind to the nearest matching
+                             ancestor executable basename.
 --json=compact               Session create/list/destroy. One-line JSON output.
 ```
 

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -284,12 +284,14 @@ if [ -z "$bind_name" ]; then
   echo 'failed to determine current shell process name for bind-ancestor-name' >&2
   exit 1
 fi
+missing_bind_name="agent-secret-e2e-missing-ancestor"
 
 EXHAUST_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
   agent-secret session create \
     --json=compact \
     --profile session-e2e \
     --secret "SESSION_E2E_CLI_TOKEN=$cli_ref" \
+    --bind-ancestor-name "$missing_bind_name" \
     --bind-ancestor-name "$bind_name" \
     --max-reads 1)"
 EXHAUST_ID="$(printf '%s' "$EXHAUST_JSON" |
@@ -307,8 +309,9 @@ assert len(matches) == 1, data
 binding = matches[0]["session_binding"]
 assert binding["mode"] == "ancestor_name", binding
 assert binding["ancestor_name"] == bind_name, binding
+assert binding["ancestor_names"] == [sys.argv[3], bind_name], binding
 assert binding["ancestor_depth"] >= 1, binding
-print("ancestor-name binding metadata ok")' "$EXHAUST_ID" "$bind_name"
+print("ancestor-name binding metadata ok")' "$EXHAUST_ID" "$bind_name" "$missing_bind_name"
 run_with_session "$EXHAUST_TOKEN" \
   --only SESSION_E2E_PROFILE_TOKEN \
   --allow-mutable-executable \
@@ -403,7 +406,7 @@ This E2E run proves:
 
 - `session create` accepts secrets from a project config profile and CLI args.
 - `session create` accepts `session.bind: parent` from profile config and
-  explicit `--bind-ancestor-name NAME` from CLI flags.
+  repeated explicit `--bind-ancestor-name NAME` CLI flags.
 - `session create`, `session list`, and JSON parsing work with
   `--json=compact`.
 - `session list` shows public session IDs and working directories for active

--- a/docs/session-e2e-validation.md
+++ b/docs/session-e2e-validation.md
@@ -38,9 +38,9 @@ present.
 The script creates a temporary project config with one secret from a profile and
 adds the second secret with a CLI `--secret` flag. It creates and consumes each
 session inside one shell so `with-session` runs from the approved requester
-process tree, then submits a launchd helper to prove the same token cannot be
-used from a different requester process tree. Approve the native prompts when
-they appear.
+process tree, uses profile and name-based explicit ancestor binding, then
+submits a launchd helper to prove the same token cannot be used from a different
+requester process tree. Approve the native prompts when they appear.
 
 <!-- markdownlint-disable MD013 -->
 
@@ -279,18 +279,36 @@ echo 'destroyed session rejected before child spawn'
 SESSION_ID=""
 SESSION_TOKEN=""
 
+bind_name="$(basename "$(ps -p "$$" -o comm= | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')")"
+if [ -z "$bind_name" ]; then
+  echo 'failed to determine current shell process name for bind-ancestor-name' >&2
+  exit 1
+fi
+
 EXHAUST_JSON="$(env -u SESSION_E2E_PROFILE_TOKEN -u SESSION_E2E_CLI_TOKEN \
   agent-secret session create \
     --json=compact \
     --profile session-e2e \
     --secret "SESSION_E2E_CLI_TOKEN=$cli_ref" \
-    --bind-ancestor 1 \
+    --bind-ancestor-name "$bind_name" \
     --max-reads 1)"
 EXHAUST_ID="$(printf '%s' "$EXHAUST_JSON" |
   python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"
 EXHAUST_TOKEN="$(printf '%s' "$EXHAUST_JSON" |
   python3 -c 'import json,sys; print(json.load(sys.stdin)["session_token"])')"
 printf 'created one-read session: %s\n' "$EXHAUST_ID"
+agent-secret session list --json=compact |
+  python3 -c 'import json, sys
+session_id = sys.argv[1]
+bind_name = sys.argv[2]
+data = json.load(sys.stdin)
+matches = [s for s in data["sessions"] if s["session_id"] == session_id]
+assert len(matches) == 1, data
+binding = matches[0]["session_binding"]
+assert binding["mode"] == "ancestor_name", binding
+assert binding["ancestor_name"] == bind_name, binding
+assert binding["ancestor_depth"] >= 1, binding
+print("ancestor-name binding metadata ok")' "$EXHAUST_ID" "$bind_name"
 run_with_session "$EXHAUST_TOKEN" \
   --only SESSION_E2E_PROFILE_TOKEN \
   --allow-mutable-executable \
@@ -372,6 +390,7 @@ both ok
 read count after subset runs ok
 destroyed session rejected before child spawn
 created one-read session: asid_...
+ancestor-name binding metadata ok
 profile ok
 read exhaustion rejected before child spawn
 audit metadata ok
@@ -384,12 +403,12 @@ This E2E run proves:
 
 - `session create` accepts secrets from a project config profile and CLI args.
 - `session create` accepts `session.bind: parent` from profile config and
-  explicit `--bind-ancestor 1` from CLI flags.
+  explicit `--bind-ancestor-name NAME` from CLI flags.
 - `session create`, `session list`, and JSON parsing work with
   `--json=compact`.
 - `session list` shows public session IDs and working directories for active
   sessions without values or session tokens, and includes non-secret binding
-  metadata.
+  metadata for both parent and ancestor-name bindings.
 - `with-session` injects the full approved bag when `--only` is omitted.
 - `with-session --only` injects config-only, CLI-only, and combined subsets.
 - `with-session` accepts session tokens from the same requester process tree

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -110,7 +110,8 @@ Agent Secret must meet these goals:
   enumerable through session listing, and are usable only from the requester
   process tree selected at session creation. Explicit parent or ancestor
   bindings can target only ancestors of the current `agent-secret` process, not
-  arbitrary PIDs.
+  arbitrary PIDs. Named ancestor binding still walks only that ancestry and
+  matches the nearest eligible executable basename exactly.
 - The daemon accepts exec and stop requests only from trusted Agent Secret CLI
   executables.
 - The CLI accepts secret-bearing responses only from a trusted Agent Secret

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -219,11 +219,11 @@ func agentContextCommands() map[string]commandContext {
 						{Name: "--override-env", Type: "bool", Description: "Allow with-session to replace existing child env vars with approved aliases."},
 						{Name: "--bind-parent", Type: "bool", Description: "Bind the session to the parent of this agent-secret process."},
 						{Name: "--bind-ancestor", Type: "int", Values: []string{"1..3"}, Description: "Bind the session to an ancestor process depth; only ancestors are accepted."},
-						{Name: "--bind-ancestor-name", Type: "string", Description: "Bind the session to the nearest ancestor with this executable basename."},
+						{Name: "--bind-ancestor-name", Type: "string", Repeatable: true, Description: "Bind the session to the nearest ancestor whose executable basename is in the allowed set."},
 						{Name: "--json", Type: "enum", Values: []string{"true", "pretty", "compact"}, Description: "Print session metadata as JSON; compact emits one line."},
 					},
 					Outputs: []string{"text", "json", "compact json"},
-					Notes:   []string{"returns a public session id for management and a secret session token bound to the requester process tree for with-session", "use --bind-parent for shell command substitution wrappers that later call with-session from the parent shell", "use --bind-ancestor-name NAME when wrapper depth varies but the desired ancestor executable name is stable", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
+					Notes:   []string{"returns a public session id for management and a secret session token bound to the requester process tree for with-session", "use --bind-parent for shell command substitution wrappers that later call with-session from the parent shell", "repeat --bind-ancestor-name NAME when wrapper depth varies across accepted agents; Agent Secret binds the nearest matching ancestor in the current process tree", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
 				},
 				"list": {
 					Summary: "List active session ids and non-secret metadata.",

--- a/internal/cli/app_agent.go
+++ b/internal/cli/app_agent.go
@@ -219,10 +219,11 @@ func agentContextCommands() map[string]commandContext {
 						{Name: "--override-env", Type: "bool", Description: "Allow with-session to replace existing child env vars with approved aliases."},
 						{Name: "--bind-parent", Type: "bool", Description: "Bind the session to the parent of this agent-secret process."},
 						{Name: "--bind-ancestor", Type: "int", Values: []string{"1..3"}, Description: "Bind the session to an ancestor process depth; only ancestors are accepted."},
+						{Name: "--bind-ancestor-name", Type: "string", Description: "Bind the session to the nearest ancestor with this executable basename."},
 						{Name: "--json", Type: "enum", Values: []string{"true", "pretty", "compact"}, Description: "Print session metadata as JSON; compact emits one line."},
 					},
 					Outputs: []string{"text", "json", "compact json"},
-					Notes:   []string{"returns a public session id for management and a secret session token bound to the requester process tree for with-session", "use --bind-parent for shell command substitution wrappers that later call with-session from the parent shell", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
+					Notes:   []string{"returns a public session id for management and a secret session token bound to the requester process tree for with-session", "use --bind-parent for shell command substitution wrappers that later call with-session from the parent shell", "use --bind-ancestor-name NAME when wrapper depth varies but the desired ancestor executable name is stable", "secret values stay in Agent Secret's background helper memory until TTL, max reads, destroy, or helper stop"},
 				},
 				"list": {
 					Summary: "List active session ids and non-secret metadata.",
@@ -245,7 +246,7 @@ func agentContextCommands() map[string]commandContext {
 				{Name: "--allow-mutable-executable", Type: "bool", Description: "Allow a user-owned or writable executable path after surfacing the approval warning."},
 			},
 			Outputs: []string{"child passthrough"},
-			Notes:   []string{"usage: agent-secret with-session SESSION_TOKEN -- COMMAND [ARG...]", "caller must be in the requester process tree that created the session or in the ancestor tree selected with session create --bind-parent/--bind-ancestor", "session values are injected into the child environment and never printed"},
+			Notes:   []string{"usage: agent-secret with-session SESSION_TOKEN -- COMMAND [ARG...]", "caller must be in the requester process tree that created the session or in the ancestor tree selected with session create --bind-parent/--bind-ancestor/--bind-ancestor-name", "session values are injected into the child environment and never printed"},
 		},
 		"bitwarden": {
 			Summary: "Manage local Bitwarden Secrets Manager token aliases.",

--- a/internal/cli/app_profile.go
+++ b/internal/cli/app_profile.go
@@ -195,6 +195,9 @@ func sessionBindingPolicyText(policy request.SessionBindingPolicy) string {
 		}
 		return fmt.Sprintf("ancestor:%d", policy.AncestorDepth)
 	case request.SessionBindingModeAncestorName:
+		if len(policy.AncestorNames) > 1 {
+			return "ancestor_names:" + strings.Join(policy.AncestorNames, ",")
+		}
 		return "ancestor_name:" + policy.AncestorName
 	default:
 		return string(policy.Mode)

--- a/internal/cli/app_profile.go
+++ b/internal/cli/app_profile.go
@@ -194,6 +194,8 @@ func sessionBindingPolicyText(policy request.SessionBindingPolicy) string {
 			return "parent"
 		}
 		return fmt.Sprintf("ancestor:%d", policy.AncestorDepth)
+	case request.SessionBindingModeAncestorName:
+		return "ancestor_name:" + policy.AncestorName
 	default:
 		return string(policy.Mode)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1682,6 +1682,7 @@ func TestParseSessionRejectsInvalidForms(t *testing.T) {
 		{name: "destroy bad id", args: []string{"session", "destroy", "bad"}, want: request.ErrInvalidSessionID},
 		{name: "destroy all with id", args: []string{"session", "destroy", "--all", "asid_abc"}, want: ErrInvalidArguments},
 		{name: "create conflicting bind flags", args: []string{"session", "create", "--bind-parent", "--bind-ancestor", "2", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
+		{name: "create conflicting bind ancestor and name", args: []string{"session", "create", "--bind-ancestor", "2", "--bind-ancestor-name", "zsh", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
 		{name: "create conflicting bind name", args: []string{"session", "create", "--bind-parent", "--bind-ancestor-name", "zsh", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
 		{name: "create bad bind depth", args: []string{"session", "create", "--bind-ancestor", "4", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: request.ErrInvalidSessionBind},
 		{name: "create empty bind name", args: []string{"session", "create", "--bind-ancestor-name", "", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: request.ErrInvalidSessionBind},

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1620,6 +1620,20 @@ profiles:
 		command.SessionCreateRequest.Binding.AncestorDepth != 2 {
 		t.Fatalf("binding = %+v, want --bind-ancestor 2 override", command.SessionCreateRequest.Binding)
 	}
+
+	command, err = NewParser().Parse([]string{
+		"session",
+		"create",
+		"--profile", "deploy",
+		"--bind-ancestor-name", "Codex",
+	})
+	if err != nil {
+		t.Fatalf("Parse session create with ancestor name returned error: %v", err)
+	}
+	if command.SessionCreateRequest.Binding.Mode != request.SessionBindingModeAncestorName ||
+		command.SessionCreateRequest.Binding.AncestorName != "Codex" {
+		t.Fatalf("binding = %+v, want --bind-ancestor-name Codex override", command.SessionCreateRequest.Binding)
+	}
 }
 
 func TestParseWithSessionRecordsRequestedAliases(t *testing.T) {
@@ -1668,7 +1682,10 @@ func TestParseSessionRejectsInvalidForms(t *testing.T) {
 		{name: "destroy bad id", args: []string{"session", "destroy", "bad"}, want: request.ErrInvalidSessionID},
 		{name: "destroy all with id", args: []string{"session", "destroy", "--all", "asid_abc"}, want: ErrInvalidArguments},
 		{name: "create conflicting bind flags", args: []string{"session", "create", "--bind-parent", "--bind-ancestor", "2", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
+		{name: "create conflicting bind name", args: []string{"session", "create", "--bind-parent", "--bind-ancestor-name", "zsh", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
 		{name: "create bad bind depth", args: []string{"session", "create", "--bind-ancestor", "4", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: request.ErrInvalidSessionBind},
+		{name: "create empty bind name", args: []string{"session", "create", "--bind-ancestor-name", "", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: request.ErrInvalidSessionBind},
+		{name: "create path bind name", args: []string{"session", "create", "--bind-ancestor-name", "/bin/zsh", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: request.ErrInvalidSessionBind},
 		{name: "create bad json mode", args: []string{"session", "create", "--json=ndjson", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
 		{name: "with-session public id", args: []string{"with-session", "asid_abc", "--", "tool"}, want: request.ErrInvalidSessionToken},
 		{name: "with-session missing boundary", args: []string{"with-session", "astok_abc", "tool"}, want: ErrShellStringCommand},

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1625,14 +1626,16 @@ profiles:
 		"session",
 		"create",
 		"--profile", "deploy",
+		"--bind-ancestor-name", "Claude",
 		"--bind-ancestor-name", "Codex",
 	})
 	if err != nil {
 		t.Fatalf("Parse session create with ancestor name returned error: %v", err)
 	}
 	if command.SessionCreateRequest.Binding.Mode != request.SessionBindingModeAncestorName ||
-		command.SessionCreateRequest.Binding.AncestorName != "Codex" {
-		t.Fatalf("binding = %+v, want --bind-ancestor-name Codex override", command.SessionCreateRequest.Binding)
+		command.SessionCreateRequest.Binding.AncestorName != "" ||
+		!slices.Equal(command.SessionCreateRequest.Binding.AncestorNames, []string{"Claude", "Codex"}) {
+		t.Fatalf("binding = %+v, want repeated --bind-ancestor-name override", command.SessionCreateRequest.Binding)
 	}
 }
 
@@ -1683,6 +1686,7 @@ func TestParseSessionRejectsInvalidForms(t *testing.T) {
 		{name: "destroy all with id", args: []string{"session", "destroy", "--all", "asid_abc"}, want: ErrInvalidArguments},
 		{name: "create conflicting bind flags", args: []string{"session", "create", "--bind-parent", "--bind-ancestor", "2", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
 		{name: "create conflicting bind ancestor and name", args: []string{"session", "create", "--bind-ancestor", "2", "--bind-ancestor-name", "zsh", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
+		{name: "create conflicting bind ancestor and repeated names", args: []string{"session", "create", "--bind-ancestor", "2", "--bind-ancestor-name", "zsh", "--bind-ancestor-name", "bash", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
 		{name: "create conflicting bind name", args: []string{"session", "create", "--bind-parent", "--bind-ancestor-name", "zsh", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: ErrInvalidArguments},
 		{name: "create bad bind depth", args: []string{"session", "create", "--bind-ancestor", "4", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: request.ErrInvalidSessionBind},
 		{name: "create empty bind name", args: []string{"session", "create", "--bind-ancestor-name", "", "--reason", "Deploy", "--secret", "TOKEN=op://Example/Item/token"}, want: request.ErrInvalidSessionBind},

--- a/internal/cli/flag_values.go
+++ b/internal/cli/flag_values.go
@@ -89,6 +89,19 @@ func (o *onlyFlags) Set(value string) error {
 	return nil
 }
 
+type ancestorNameFlags struct {
+	names []string
+}
+
+func (n *ancestorNameFlags) String() string {
+	return strings.Join(n.names, ",")
+}
+
+func (n *ancestorNameFlags) Set(value string) error {
+	n.names = append(n.names, value)
+	return nil
+}
+
 type envFileFlags struct {
 	paths []string
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -371,8 +371,9 @@ func SessionHelp() string {
 	Use --bind-parent when a wrapper creates a session in command substitution and
 	then calls with-session from the parent shell. Use --bind-ancestor N for deeper
 	wrappers; N must be 1..3 and can only target ancestors of the current
-	agent-secret process. session create, list, and destroy accept --json=compact
-	for one-line JSON suitable for shell wrappers.
+	agent-secret process. Use --bind-ancestor-name NAME when wrapper depth varies
+	but the desired ancestor executable basename is stable. session create, list,
+	and destroy accept --json=compact for one-line JSON suitable for shell wrappers.
 	`)
 }
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -371,9 +371,10 @@ func SessionHelp() string {
 	Use --bind-parent when a wrapper creates a session in command substitution and
 	then calls with-session from the parent shell. Use --bind-ancestor N for deeper
 	wrappers; N must be 1..3 and can only target ancestors of the current
-	agent-secret process. Use --bind-ancestor-name NAME when wrapper depth varies
-	but the desired ancestor executable basename is stable. session create, list,
-	and destroy accept --json=compact for one-line JSON suitable for shell wrappers.
+	agent-secret process. Repeat --bind-ancestor-name NAME when wrapper depth varies
+	across accepted agents; Agent Secret binds the nearest matching executable
+	basename in the current ancestry. session create, list, and destroy accept
+	--json=compact for one-line JSON suitable for shell wrappers.
 	`)
 }
 

--- a/internal/cli/session_parse.go
+++ b/internal/cli/session_parse.go
@@ -21,6 +21,7 @@ type sessionCreateFlags struct {
 	overrideEnv  bool
 	bindParent   bool
 	bindAncestor int
+	bindName     string
 	jsonMode     jsonOutputMode
 	secrets      secretFlags
 	only         onlyFlags
@@ -65,6 +66,7 @@ func (p Parser) parseSessionCreate(args []string) (Command, error) {
 	fs.BoolVar(&flags.overrideEnv, "override-env", false, "allow with-session to override existing env aliases")
 	fs.BoolVar(&flags.bindParent, "bind-parent", false, "bind session to the parent of this agent-secret process")
 	fs.IntVar(&flags.bindAncestor, "bind-ancestor", 0, "bind session to an ancestor process depth 1..3")
+	fs.StringVar(&flags.bindName, "bind-ancestor-name", "", "bind session to the nearest ancestor process with this executable name")
 	registerJSONOutputFlag(fs, &flags.jsonMode, "print json; use --json=compact for one-line output")
 	fs.Var(&flags.secrets, "secret", "secret mapping")
 	fs.Var(&flags.only, "only", "profile alias filter")
@@ -76,12 +78,16 @@ func (p Parser) parseSessionCreate(args []string) (Command, error) {
 		return Command{}, fmt.Errorf("%w: session create does not accept a child command", ErrInvalidArguments)
 	}
 	bindAncestorSet := false
+	bindNameSet := false
 	fs.Visit(func(flag *flag.Flag) {
-		if flag.Name == "bind-ancestor" {
+		switch flag.Name {
+		case "bind-ancestor":
 			bindAncestorSet = true
+		case "bind-ancestor-name":
+			bindNameSet = true
 		}
 	})
-	binding, err := sessionCreateBinding(flags, bindAncestorSet)
+	binding, err := sessionCreateBinding(flags, bindAncestorSet, bindNameSet)
 	if err != nil {
 		return Command{}, err
 	}
@@ -101,7 +107,7 @@ func (p Parser) parseSessionCreate(args []string) (Command, error) {
 	if err != nil {
 		return Command{}, err
 	}
-	if !bindAncestorSet && !flags.bindParent && inputs.sessionBindingProfile {
+	if !bindAncestorSet && !bindNameSet && !flags.bindParent && inputs.sessionBindingProfile {
 		binding = inputs.sessionBinding
 	}
 	req, err := buildSessionCreateRequest(sessionCreateRequestBuildOptions{
@@ -174,9 +180,23 @@ func parseSessionDestroy(args []string) (Command, error) {
 	}, nil
 }
 
-func sessionCreateBinding(flags sessionCreateFlags, bindAncestorSet bool) (request.SessionBindingPolicy, error) {
-	if flags.bindParent && bindAncestorSet {
-		return request.SessionBindingPolicy{}, fmt.Errorf("%w: use either --bind-parent or --bind-ancestor", ErrInvalidArguments)
+func sessionCreateBinding(
+	flags sessionCreateFlags,
+	bindAncestorSet bool,
+	bindNameSet bool,
+) (request.SessionBindingPolicy, error) {
+	bindFlagCount := 0
+	if flags.bindParent {
+		bindFlagCount++
+	}
+	if bindAncestorSet {
+		bindFlagCount++
+	}
+	if bindNameSet {
+		bindFlagCount++
+	}
+	if bindFlagCount > 1 {
+		return request.SessionBindingPolicy{}, fmt.Errorf("%w: use only one session binding flag", ErrInvalidArguments)
 	}
 	if flags.bindParent {
 		policy, err := request.NewSessionAncestorBinding(1)
@@ -187,6 +207,13 @@ func sessionCreateBinding(flags sessionCreateFlags, bindAncestorSet bool) (reque
 	}
 	if bindAncestorSet {
 		policy, err := request.NewSessionAncestorBinding(flags.bindAncestor)
+		if err != nil {
+			return request.SessionBindingPolicy{}, err
+		}
+		return policy, nil
+	}
+	if bindNameSet {
+		policy, err := request.NewSessionAncestorNameBinding(flags.bindName)
 		if err != nil {
 			return request.SessionBindingPolicy{}, err
 		}

--- a/internal/cli/session_parse.go
+++ b/internal/cli/session_parse.go
@@ -21,7 +21,7 @@ type sessionCreateFlags struct {
 	overrideEnv  bool
 	bindParent   bool
 	bindAncestor int
-	bindName     string
+	bindNames    ancestorNameFlags
 	jsonMode     jsonOutputMode
 	secrets      secretFlags
 	only         onlyFlags
@@ -66,7 +66,7 @@ func (p Parser) parseSessionCreate(args []string) (Command, error) {
 	fs.BoolVar(&flags.overrideEnv, "override-env", false, "allow with-session to override existing env aliases")
 	fs.BoolVar(&flags.bindParent, "bind-parent", false, "bind session to the parent of this agent-secret process")
 	fs.IntVar(&flags.bindAncestor, "bind-ancestor", 0, "bind session to an ancestor process depth 1..3")
-	fs.StringVar(&flags.bindName, "bind-ancestor-name", "", "bind session to the nearest ancestor process with this executable name")
+	fs.Var(&flags.bindNames, "bind-ancestor-name", "bind session to the nearest ancestor process with this executable name; repeatable")
 	registerJSONOutputFlag(fs, &flags.jsonMode, "print json; use --json=compact for one-line output")
 	fs.Var(&flags.secrets, "secret", "secret mapping")
 	fs.Var(&flags.only, "only", "profile alias filter")
@@ -213,7 +213,7 @@ func sessionCreateBinding(
 		return policy, nil
 	}
 	if bindNameSet {
-		policy, err := request.NewSessionAncestorNameBinding(flags.bindName)
+		policy, err := request.NewSessionAncestorNamesBinding(flags.bindNames.names)
 		if err != nil {
 			return request.SessionBindingPolicy{}, err
 		}

--- a/internal/daemon/broker/session_peer_authorizer.go
+++ b/internal/daemon/broker/session_peer_authorizer.go
@@ -3,6 +3,8 @@ package broker
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/kovyrin/agent-secret/internal/peercred"
 	"github.com/kovyrin/agent-secret/internal/request"
@@ -24,6 +26,7 @@ func (b SessionPeerBinding) Info() request.SessionBindingInfo {
 		Mode:          b.Policy.Mode,
 		AncestorDepth: b.Policy.AncestorDepth,
 		AncestorName:  b.Policy.AncestorName,
+		AncestorNames: slices.Clone(b.Policy.AncestorNames),
 		BoundProcess:  processInfoFromIdentity(b.Anchor),
 		CreatorProcess: request.SessionBindingProcess{
 			PID:  b.CreatorPeer.PID,
@@ -128,8 +131,9 @@ func sessionPeerAnchor(
 		anchor, err := ancestorSessionPeerAnchor(peer, ancestry, policy.AncestorDepth)
 		return anchor, policy, err
 	case request.SessionBindingModeAncestorName:
-		anchor, depth, err := ancestorNameSessionPeerAnchor(peer, ancestry, policy.AncestorName)
+		anchor, depth, name, err := ancestorNamesSessionPeerAnchor(peer, ancestry, policy.AncestorNames)
 		policy.AncestorDepth = depth
+		policy.AncestorName = name
 		return anchor, policy, err
 	default:
 		return peercred.ProcessIdentity{}, request.SessionBindingPolicy{}, fmt.Errorf("%w: unknown binding mode %q", request.ErrInvalidSessionBind, policy.Mode)
@@ -178,38 +182,54 @@ func ancestorSessionPeerAnchor(
 	return anchor, nil
 }
 
-func ancestorNameSessionPeerAnchor(
+func ancestorNamesSessionPeerAnchor(
 	peer peercred.Info,
 	ancestry []peercred.ProcessIdentity,
-	name string,
-) (peercred.ProcessIdentity, int, error) {
+	names []string,
+) (peercred.ProcessIdentity, int, string, error) {
+	nameSet := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		nameSet[name] = struct{}{}
+	}
 	var ineligible peercred.ProcessIdentity
+	var ineligibleName string
 	matchedIneligible := false
 	for depth := 1; depth < len(ancestry); depth++ {
 		anchor := ancestry[depth]
-		if processName(anchor.ExecutablePath) != name {
+		name := processName(anchor.ExecutablePath)
+		if _, ok := nameSet[name]; !ok {
 			continue
 		}
 		if !isEligibleSessionPeerAnchor(peer, anchor) {
 			if !matchedIneligible {
 				ineligible = anchor
+				ineligibleName = name
 				matchedIneligible = true
 			}
 			continue
 		}
-		return anchor, depth, nil
+		return anchor, depth, name, nil
 	}
+	acceptedNames := formatSessionAncestorNames(names)
 	if matchedIneligible {
-		return peercred.ProcessIdentity{}, 0, fmt.Errorf(
-			"%w: ancestor name %q matched only ineligible binding targets; nearest was %s pid=%d path=%q",
+		return peercred.ProcessIdentity{}, 0, "", fmt.Errorf(
+			"%w: ancestor names %s matched only ineligible binding targets; nearest match was %s pid=%d path=%q",
 			ErrSessionPeerMismatch,
-			name,
-			processName(ineligible.ExecutablePath),
+			acceptedNames,
+			ineligibleName,
 			ineligible.PID,
 			ineligible.ExecutablePath,
 		)
 	}
-	return peercred.ProcessIdentity{}, 0, fmt.Errorf("%w: session creator has no eligible ancestor named %q", ErrSessionPeerMismatch, name)
+	return peercred.ProcessIdentity{}, 0, "", fmt.Errorf("%w: session creator has no eligible ancestor named one of %s", ErrSessionPeerMismatch, acceptedNames)
+}
+
+func formatSessionAncestorNames(names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, name := range names {
+		quoted = append(quoted, fmt.Sprintf("%q", name))
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
 }
 
 func isEligibleSessionPeerAnchor(peer peercred.Info, candidate peercred.ProcessIdentity) bool {

--- a/internal/daemon/broker/session_peer_authorizer.go
+++ b/internal/daemon/broker/session_peer_authorizer.go
@@ -23,6 +23,7 @@ func (b SessionPeerBinding) Info() request.SessionBindingInfo {
 	return request.SessionBindingInfo{
 		Mode:          b.Policy.Mode,
 		AncestorDepth: b.Policy.AncestorDepth,
+		AncestorName:  b.Policy.AncestorName,
 		BoundProcess:  processInfoFromIdentity(b.Anchor),
 		CreatorProcess: request.SessionBindingProcess{
 			PID:  b.CreatorPeer.PID,
@@ -44,7 +45,7 @@ func (e *SessionPeerMismatchError) Error() string {
 		reason = "requester ancestry does not include the approved session binding"
 	}
 	return fmt.Sprintf(
-		"%s: %s; bound_process=%s pid=%d path=%q; requester=%s pid=%d path=%q; recreate the session from the shell or agent process tree that will run with-session, or use --bind-parent / --bind-ancestor N",
+		"%s: %s; bound_process=%s pid=%d path=%q; requester=%s pid=%d path=%q; recreate the session from the shell or agent process tree that will run with-session, or use --bind-parent / --bind-ancestor N / --bind-ancestor-name NAME",
 		ErrSessionPeerMismatch,
 		reason,
 		e.Bound.Name,
@@ -80,7 +81,7 @@ func (a processTreeSessionPeerAuthorizer) BindSessionPeer(
 	if err != nil {
 		return SessionPeerBinding{}, fmt.Errorf("%w: inspect session creator process tree: %w", ErrSessionPeerMismatch, err)
 	}
-	anchor, err := sessionPeerAnchor(peer, ancestry, policy)
+	anchor, policy, err := sessionPeerAnchor(peer, ancestry, policy)
 	if err != nil {
 		return SessionPeerBinding{}, err
 	}
@@ -115,17 +116,23 @@ func sessionPeerAnchor(
 	peer peercred.Info,
 	ancestry []peercred.ProcessIdentity,
 	policy request.SessionBindingPolicy,
-) (peercred.ProcessIdentity, error) {
+) (peercred.ProcessIdentity, request.SessionBindingPolicy, error) {
 	if len(ancestry) == 0 || ancestry[0].PID != peer.PID {
-		return peercred.ProcessIdentity{}, fmt.Errorf("%w: session creator process tree does not start at pid %d", ErrSessionPeerMismatch, peer.PID)
+		return peercred.ProcessIdentity{}, request.SessionBindingPolicy{}, fmt.Errorf("%w: session creator process tree does not start at pid %d", ErrSessionPeerMismatch, peer.PID)
 	}
 	switch policy.Mode {
 	case request.SessionBindingModeAuto:
-		return automaticSessionPeerAnchor(peer, ancestry)
+		anchor, err := automaticSessionPeerAnchor(peer, ancestry)
+		return anchor, policy, err
 	case request.SessionBindingModeAncestor:
-		return ancestorSessionPeerAnchor(peer, ancestry, policy.AncestorDepth)
+		anchor, err := ancestorSessionPeerAnchor(peer, ancestry, policy.AncestorDepth)
+		return anchor, policy, err
+	case request.SessionBindingModeAncestorName:
+		anchor, depth, err := ancestorNameSessionPeerAnchor(peer, ancestry, policy.AncestorName)
+		policy.AncestorDepth = depth
+		return anchor, policy, err
 	default:
-		return peercred.ProcessIdentity{}, fmt.Errorf("%w: unknown binding mode %q", request.ErrInvalidSessionBind, policy.Mode)
+		return peercred.ProcessIdentity{}, request.SessionBindingPolicy{}, fmt.Errorf("%w: unknown binding mode %q", request.ErrInvalidSessionBind, policy.Mode)
 	}
 }
 
@@ -169,6 +176,40 @@ func ancestorSessionPeerAnchor(
 		)
 	}
 	return anchor, nil
+}
+
+func ancestorNameSessionPeerAnchor(
+	peer peercred.Info,
+	ancestry []peercred.ProcessIdentity,
+	name string,
+) (peercred.ProcessIdentity, int, error) {
+	var ineligible peercred.ProcessIdentity
+	matchedIneligible := false
+	for depth := 1; depth < len(ancestry); depth++ {
+		anchor := ancestry[depth]
+		if processName(anchor.ExecutablePath) != name {
+			continue
+		}
+		if !isEligibleSessionPeerAnchor(peer, anchor) {
+			if !matchedIneligible {
+				ineligible = anchor
+				matchedIneligible = true
+			}
+			continue
+		}
+		return anchor, depth, nil
+	}
+	if matchedIneligible {
+		return peercred.ProcessIdentity{}, 0, fmt.Errorf(
+			"%w: ancestor name %q matched only ineligible binding targets; nearest was %s pid=%d path=%q",
+			ErrSessionPeerMismatch,
+			name,
+			processName(ineligible.ExecutablePath),
+			ineligible.PID,
+			ineligible.ExecutablePath,
+		)
+	}
+	return peercred.ProcessIdentity{}, 0, fmt.Errorf("%w: session creator has no eligible ancestor named %q", ErrSessionPeerMismatch, name)
 }
 
 func isEligibleSessionPeerAnchor(peer peercred.Info, candidate peercred.ProcessIdentity) bool {

--- a/internal/daemon/broker/session_peer_authorizer_test.go
+++ b/internal/daemon/broker/session_peer_authorizer_test.go
@@ -185,6 +185,156 @@ func TestProcessTreeSessionPeerAuthorizerBindsExplicitAncestor(t *testing.T) {
 	}
 }
 
+func TestProcessTreeSessionPeerAuthorizerBindsNearestNamedAncestor(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	subShell := testProcessIdentity(501, 500, "/bin/zsh")
+	agentShim := testProcessIdentity(500, 400, "/Applications/Codex.app/Contents/Resources/codex")
+	agentApp := testProcessIdentity(400, 300, "/Applications/Codex.app/Contents/MacOS/Codex")
+	terminal := testProcessIdentity(300, 1, "/Applications/iTerm.app/Contents/MacOS/iTerm2")
+	lookup := map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, subShell.PID, creator.ExecutablePath),
+			subShell,
+			agentShim,
+			agentApp,
+			terminal,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	}
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(lookup)}
+	policy, err := request.NewSessionAncestorNameBinding("Codex")
+	if err != nil {
+		t.Fatalf("NewSessionAncestorNameBinding returned error: %v", err)
+	}
+
+	binding, err := authorizer.BindSessionPeer(creator, policy)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if binding.Anchor.PID != agentApp.PID {
+		t.Fatalf("binding anchor pid = %d, want named ancestor pid %d", binding.Anchor.PID, agentApp.PID)
+	}
+	info := binding.Info()
+	if info.Mode != request.SessionBindingModeAncestorName ||
+		info.AncestorName != "Codex" ||
+		info.AncestorDepth != 3 ||
+		info.BoundProcess.Name != "Codex" ||
+		info.BoundProcess.PID != agentApp.PID {
+		t.Fatalf("binding info = %+v", info)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerUsesExactAncestorName(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	subShell := testProcessIdentity(501, 500, "/bin/zsh")
+	agentShim := testProcessIdentity(500, 400, "/Applications/Codex.app/Contents/Resources/codex")
+	agentApp := testProcessIdentity(400, 1, "/Applications/Codex.app/Contents/MacOS/Codex")
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, subShell.PID, creator.ExecutablePath),
+			subShell,
+			agentShim,
+			agentApp,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	})}
+	policy, err := request.NewSessionAncestorNameBinding("codex")
+	if err != nil {
+		t.Fatalf("NewSessionAncestorNameBinding returned error: %v", err)
+	}
+
+	binding, err := authorizer.BindSessionPeer(creator, policy)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if binding.Anchor.PID != agentShim.PID || binding.Policy.AncestorDepth != 2 {
+		t.Fatalf("binding = %+v, want exact lowercase shim at depth 2", binding)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerSkipsIneligibleNamedAncestor(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	nearestCodex := testProcessIdentity(501, 500, "/Applications/Codex.app/Contents/MacOS/Codex")
+	nearestCodex.UID = 0
+	nearestCodex.GID = 0
+	eligibleCodex := testProcessIdentity(500, 1, "/Users/example/Applications/Codex.app/Contents/MacOS/Codex")
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, nearestCodex.PID, creator.ExecutablePath),
+			nearestCodex,
+			eligibleCodex,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	})}
+	policy, err := request.NewSessionAncestorNameBinding("Codex")
+	if err != nil {
+		t.Fatalf("NewSessionAncestorNameBinding returned error: %v", err)
+	}
+
+	binding, err := authorizer.BindSessionPeer(creator, policy)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if binding.Anchor.PID != eligibleCodex.PID || binding.Policy.AncestorDepth != 2 {
+		t.Fatalf("binding = %+v, want eligible named ancestor at depth 2", binding)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerRejectsIneligibleNamedAncestor(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	rootParent := testProcessIdentity(500, 1, "/bin/zsh")
+	rootParent.UID = 0
+	rootParent.GID = 0
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, rootParent.PID, creator.ExecutablePath),
+			rootParent,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	})}
+	policy, err := request.NewSessionAncestorNameBinding("zsh")
+	if err != nil {
+		t.Fatalf("NewSessionAncestorNameBinding returned error: %v", err)
+	}
+
+	if _, err := authorizer.BindSessionPeer(creator, policy); !errors.Is(err, ErrSessionPeerMismatch) {
+		t.Fatalf("BindSessionPeer error = %v, want ErrSessionPeerMismatch", err)
+	} else if !strings.Contains(err.Error(), "matched only ineligible binding targets") {
+		t.Fatalf("BindSessionPeer error = %q, want ineligible target detail", err.Error())
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerRejectsMissingNamedAncestor(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, 500, creator.ExecutablePath),
+			testProcessIdentity(500, 1, "/bin/zsh"),
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	})}
+	policy, err := request.NewSessionAncestorNameBinding("Codex")
+	if err != nil {
+		t.Fatalf("NewSessionAncestorNameBinding returned error: %v", err)
+	}
+
+	if _, err := authorizer.BindSessionPeer(creator, policy); !errors.Is(err, ErrSessionPeerMismatch) {
+		t.Fatalf("BindSessionPeer error = %v, want ErrSessionPeerMismatch", err)
+	} else if !strings.Contains(err.Error(), "no eligible ancestor named") {
+		t.Fatalf("BindSessionPeer error = %q, want missing ancestor detail", err.Error())
+	}
+}
+
 func TestProcessTreeSessionPeerAuthorizerRejectsIneligibleExplicitAncestor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/broker/session_peer_authorizer_test.go
+++ b/internal/daemon/broker/session_peer_authorizer_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -141,7 +142,10 @@ func TestProcessTreeSessionPeerAuthorizerBindsExplicitParent(t *testing.T) {
 	if binding.Anchor.PID != subShell.PID {
 		t.Fatalf("binding anchor pid = %d, want explicit parent pid %d", binding.Anchor.PID, subShell.PID)
 	}
-	if binding.Policy != policy {
+	if binding.Policy.Mode != policy.Mode ||
+		binding.Policy.AncestorDepth != policy.AncestorDepth ||
+		binding.Policy.AncestorName != policy.AncestorName ||
+		!slices.Equal(binding.Policy.AncestorNames, policy.AncestorNames) {
 		t.Fatalf("binding policy = %+v, want %+v", binding.Policy, policy)
 	}
 }
@@ -219,10 +223,44 @@ func TestProcessTreeSessionPeerAuthorizerBindsNearestNamedAncestor(t *testing.T)
 	info := binding.Info()
 	if info.Mode != request.SessionBindingModeAncestorName ||
 		info.AncestorName != "Codex" ||
+		!slices.Equal(info.AncestorNames, []string{"Codex"}) ||
 		info.AncestorDepth != 3 ||
 		info.BoundProcess.Name != "Codex" ||
 		info.BoundProcess.PID != agentApp.PID {
 		t.Fatalf("binding info = %+v", info)
+	}
+}
+
+func TestProcessTreeSessionPeerAuthorizerUsesNearestAllowedAncestorName(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	nearestAgent := testProcessIdentity(501, 500, "/Applications/Claude.app/Contents/MacOS/Claude")
+	fartherAgent := testProcessIdentity(500, 1, "/Applications/Codex.app/Contents/MacOS/Codex")
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, nearestAgent.PID, creator.ExecutablePath),
+			nearestAgent,
+			fartherAgent,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	})}
+	policy, err := request.NewSessionAncestorNamesBinding([]string{"Codex", "Claude"})
+	if err != nil {
+		t.Fatalf("NewSessionAncestorNamesBinding returned error: %v", err)
+	}
+
+	binding, err := authorizer.BindSessionPeer(creator, policy)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	info := binding.Info()
+	if binding.Anchor.PID != nearestAgent.PID ||
+		binding.Policy.AncestorName != "Claude" ||
+		binding.Policy.AncestorDepth != 1 ||
+		info.AncestorName != "Claude" ||
+		!slices.Equal(info.AncestorNames, []string{"Codex", "Claude"}) {
+		t.Fatalf("binding = %+v info=%+v, want nearest matching ancestor with original allowlist", binding, info)
 	}
 }
 
@@ -286,6 +324,36 @@ func TestProcessTreeSessionPeerAuthorizerSkipsIneligibleNamedAncestor(t *testing
 	}
 }
 
+func TestProcessTreeSessionPeerAuthorizerSkipsIneligibleAllowedAncestorName(t *testing.T) {
+	t.Parallel()
+
+	creator := testPeerInfo(1001)
+	nearestClaude := testProcessIdentity(501, 500, "/Applications/Claude.app/Contents/MacOS/Claude")
+	nearestClaude.UID = 0
+	nearestClaude.GID = 0
+	eligibleCodex := testProcessIdentity(500, 1, "/Applications/Codex.app/Contents/MacOS/Codex")
+	authorizer := processTreeSessionPeerAuthorizer{processAncestry: ancestryLookup(map[int][]peercred.ProcessIdentity{
+		creator.PID: {
+			testProcessIdentity(creator.PID, nearestClaude.PID, creator.ExecutablePath),
+			nearestClaude,
+			eligibleCodex,
+			testProcessIdentity(1, 0, "/sbin/launchd"),
+		},
+	})}
+	policy, err := request.NewSessionAncestorNamesBinding([]string{"Claude", "Codex"})
+	if err != nil {
+		t.Fatalf("NewSessionAncestorNamesBinding returned error: %v", err)
+	}
+
+	binding, err := authorizer.BindSessionPeer(creator, policy)
+	if err != nil {
+		t.Fatalf("BindSessionPeer returned error: %v", err)
+	}
+	if binding.Anchor.PID != eligibleCodex.PID || binding.Policy.AncestorName != "Codex" || binding.Policy.AncestorDepth != 2 {
+		t.Fatalf("binding = %+v, want eligible allowed ancestor at depth 2", binding)
+	}
+}
+
 func TestProcessTreeSessionPeerAuthorizerRejectsIneligibleNamedAncestor(t *testing.T) {
 	t.Parallel()
 
@@ -307,7 +375,7 @@ func TestProcessTreeSessionPeerAuthorizerRejectsIneligibleNamedAncestor(t *testi
 
 	if _, err := authorizer.BindSessionPeer(creator, policy); !errors.Is(err, ErrSessionPeerMismatch) {
 		t.Fatalf("BindSessionPeer error = %v, want ErrSessionPeerMismatch", err)
-	} else if !strings.Contains(err.Error(), "matched only ineligible binding targets") {
+	} else if !strings.Contains(err.Error(), "ancestor names [\"zsh\"] matched only ineligible binding targets") {
 		t.Fatalf("BindSessionPeer error = %q, want ineligible target detail", err.Error())
 	}
 }
@@ -330,7 +398,7 @@ func TestProcessTreeSessionPeerAuthorizerRejectsMissingNamedAncestor(t *testing.
 
 	if _, err := authorizer.BindSessionPeer(creator, policy); !errors.Is(err, ErrSessionPeerMismatch) {
 		t.Fatalf("BindSessionPeer error = %v, want ErrSessionPeerMismatch", err)
-	} else if !strings.Contains(err.Error(), "no eligible ancestor named") {
+	} else if !strings.Contains(err.Error(), "no eligible ancestor named one of [\"Codex\"]") {
 		t.Fatalf("BindSessionPeer error = %q, want missing ancestor detail", err.Error())
 	}
 }

--- a/internal/profileconfig/profileconfig.go
+++ b/internal/profileconfig/profileconfig.go
@@ -225,19 +225,39 @@ func (s *sessionBindYAML) setFromScalar(raw string) error {
 
 func (s *sessionBindYAML) unmarshalMapping(value *yaml.Node) error {
 	var ancestorDepth int
+	var ancestorName string
+	ancestorDepthSet := false
+	ancestorNameSet := false
 	for i := 0; i < len(value.Content); i += 2 {
 		key := value.Content[i].Value
 		item := value.Content[i+1]
 		switch key {
 		case "ancestor":
+			ancestorDepthSet = true
 			if err := item.Decode(&ancestorDepth); err != nil {
+				return err
+			}
+		case "ancestor_name":
+			ancestorNameSet = true
+			if err := item.Decode(&ancestorName); err != nil {
 				return err
 			}
 		default:
 			return fmt.Errorf("unknown session bind field %q", key)
 		}
 	}
-	policy, err := request.NewSessionAncestorBinding(ancestorDepth)
+	if ancestorDepthSet == ancestorNameSet {
+		return errors.New("session bind mapping must set exactly one of ancestor or ancestor_name")
+	}
+	var (
+		policy request.SessionBindingPolicy
+		err    error
+	)
+	if ancestorDepthSet {
+		policy, err = request.NewSessionAncestorBinding(ancestorDepth)
+	} else {
+		policy, err = request.NewSessionAncestorNameBinding(ancestorName)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/profileconfig/profileconfig.go
+++ b/internal/profileconfig/profileconfig.go
@@ -226,8 +226,10 @@ func (s *sessionBindYAML) setFromScalar(raw string) error {
 func (s *sessionBindYAML) unmarshalMapping(value *yaml.Node) error {
 	var ancestorDepth int
 	var ancestorName string
+	var ancestorNames []string
 	ancestorDepthSet := false
 	ancestorNameSet := false
+	ancestorNamesSet := false
 	for i := 0; i < len(value.Content); i += 2 {
 		key := value.Content[i].Value
 		item := value.Content[i+1]
@@ -242,21 +244,35 @@ func (s *sessionBindYAML) unmarshalMapping(value *yaml.Node) error {
 			if err := item.Decode(&ancestorName); err != nil {
 				return err
 			}
+		case "ancestor_names":
+			ancestorNamesSet = true
+			if err := item.Decode(&ancestorNames); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("unknown session bind field %q", key)
 		}
 	}
-	if ancestorDepthSet == ancestorNameSet {
-		return errors.New("session bind mapping must set exactly one of ancestor or ancestor_name")
+	setCount := 0
+	for _, set := range []bool{ancestorDepthSet, ancestorNameSet, ancestorNamesSet} {
+		if set {
+			setCount++
+		}
+	}
+	if setCount != 1 {
+		return errors.New("session bind mapping must set exactly one of ancestor, ancestor_name, or ancestor_names")
 	}
 	var (
 		policy request.SessionBindingPolicy
 		err    error
 	)
-	if ancestorDepthSet {
+	switch {
+	case ancestorDepthSet:
 		policy, err = request.NewSessionAncestorBinding(ancestorDepth)
-	} else {
+	case ancestorNameSet:
 		policy, err = request.NewSessionAncestorNameBinding(ancestorName)
+	default:
+		policy, err = request.NewSessionAncestorNamesBinding(ancestorNames)
 	}
 	if err != nil {
 		return err
@@ -549,6 +565,7 @@ func cloneSessionBindingPolicy(policy *request.SessionBindingPolicy) *request.Se
 		return nil
 	}
 	clone := *policy
+	clone.AncestorNames = slices.Clone(policy.AncestorNames)
 	return &clone
 }
 

--- a/internal/profileconfig/profileconfig_test.go
+++ b/internal/profileconfig/profileconfig_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"testing"
@@ -77,6 +78,15 @@ profiles:
         ancestor_name: Codex
     secrets:
       CODEX_TOKEN: op://Example/Codex/token
+  agents:
+    reason: Agent wrappers
+    session:
+      bind:
+        ancestor_names:
+          - Claude
+          - Codex
+    secrets:
+      AGENT_TOKEN: op://Example/Agent/token
 `)
 
 	base, err := Load(LoadOptions{Name: "base", StartDir: root})
@@ -108,6 +118,20 @@ profiles:
 		codex.SessionBinding.AncestorName != "Codex" {
 		t.Fatalf("codex session binding = %+v", codex.SessionBinding)
 	}
+	if !slices.Equal(codex.SessionBinding.AncestorNames, []string{"Codex"}) {
+		t.Fatalf("codex ancestor names = %v, want [Codex]", codex.SessionBinding.AncestorNames)
+	}
+
+	agents, err := Load(LoadOptions{Name: "agents", StartDir: root})
+	if err != nil {
+		t.Fatalf("Load agents returned error: %v", err)
+	}
+	if agents.SessionBinding == nil ||
+		agents.SessionBinding.Mode != request.SessionBindingModeAncestorName ||
+		agents.SessionBinding.AncestorName != "" ||
+		!slices.Equal(agents.SessionBinding.AncestorNames, []string{"Claude", "Codex"}) {
+		t.Fatalf("agents session binding = %+v", agents.SessionBinding)
+	}
 
 	info, err := Inspect(LoadOptions{StartDir: root})
 	if err != nil {
@@ -122,6 +146,12 @@ profiles:
 		codexInfo.Session.Bind == nil ||
 		codexInfo.Session.Bind.AncestorName != "Codex" {
 		t.Fatalf("inspect codex session binding = %+v", codexInfo.Session)
+	}
+	agentsInfo := findProfileInfo(t, info, "agents")
+	if agentsInfo.Session == nil ||
+		agentsInfo.Session.Bind == nil ||
+		!slices.Equal(agentsInfo.Session.Bind.AncestorNames, []string{"Claude", "Codex"}) {
+		t.Fatalf("inspect agents session binding = %+v", agentsInfo.Session)
 	}
 }
 
@@ -187,6 +217,21 @@ profiles:
 `,
 		},
 		{
+			name: "multiple ancestor name mapping keys",
+			config: `
+version: 1
+profiles:
+  deploy:
+    reason: Deploy
+    session:
+      bind:
+        ancestor_name: zsh
+        ancestor_names: [zsh, bash]
+    secrets:
+      TOKEN: op://Example/Item/token
+`,
+		},
+		{
 			name: "bad ancestor name",
 			config: `
 version: 1
@@ -196,6 +241,34 @@ profiles:
     session:
       bind:
         ancestor_name: /bin/zsh
+    secrets:
+      TOKEN: op://Example/Item/token
+`,
+		},
+		{
+			name: "bad ancestor names entry",
+			config: `
+version: 1
+profiles:
+  deploy:
+    reason: Deploy
+    session:
+      bind:
+        ancestor_names: [zsh, /bin/bash]
+    secrets:
+      TOKEN: op://Example/Item/token
+`,
+		},
+		{
+			name: "empty ancestor names",
+			config: `
+version: 1
+profiles:
+  deploy:
+    reason: Deploy
+    session:
+      bind:
+        ancestor_names: []
     secrets:
       TOKEN: op://Example/Item/token
 `,

--- a/internal/profileconfig/profileconfig_test.go
+++ b/internal/profileconfig/profileconfig_test.go
@@ -70,6 +70,13 @@ profiles:
         ancestor: 2
     secrets:
       DEPLOY_TOKEN: op://Example/Deploy/token
+  codex:
+    reason: Codex
+    session:
+      bind:
+        ancestor_name: Codex
+    secrets:
+      CODEX_TOKEN: op://Example/Codex/token
 `)
 
 	base, err := Load(LoadOptions{Name: "base", StartDir: root})
@@ -92,6 +99,16 @@ profiles:
 		t.Fatalf("deploy session binding = %+v", deploy.SessionBinding)
 	}
 
+	codex, err := Load(LoadOptions{Name: "codex", StartDir: root})
+	if err != nil {
+		t.Fatalf("Load codex returned error: %v", err)
+	}
+	if codex.SessionBinding == nil ||
+		codex.SessionBinding.Mode != request.SessionBindingModeAncestorName ||
+		codex.SessionBinding.AncestorName != "Codex" {
+		t.Fatalf("codex session binding = %+v", codex.SessionBinding)
+	}
+
 	info, err := Inspect(LoadOptions{StartDir: root})
 	if err != nil {
 		t.Fatalf("Inspect returned error: %v", err)
@@ -99,6 +116,12 @@ profiles:
 	deployInfo := findProfileInfo(t, info, "deploy")
 	if deployInfo.Session == nil || deployInfo.Session.Bind == nil || deployInfo.Session.Bind.AncestorDepth != 2 {
 		t.Fatalf("inspect deploy session binding = %+v", deployInfo.Session)
+	}
+	codexInfo := findProfileInfo(t, info, "codex")
+	if codexInfo.Session == nil ||
+		codexInfo.Session.Bind == nil ||
+		codexInfo.Session.Bind.AncestorName != "Codex" {
+		t.Fatalf("inspect codex session binding = %+v", codexInfo.Session)
 	}
 }
 
@@ -144,6 +167,35 @@ profiles:
     session:
       bind:
         pid: 123
+    secrets:
+      TOKEN: op://Example/Item/token
+`,
+		},
+		{
+			name: "multiple mapping keys",
+			config: `
+version: 1
+profiles:
+  deploy:
+    reason: Deploy
+    session:
+      bind:
+        ancestor: 1
+        ancestor_name: zsh
+    secrets:
+      TOKEN: op://Example/Item/token
+`,
+		},
+		{
+			name: "bad ancestor name",
+			config: `
+version: 1
+profiles:
+  deploy:
+    reason: Deploy
+    session:
+      bind:
+        ancestor_name: /bin/zsh
     secrets:
       TOKEN: op://Example/Item/token
 `,

--- a/internal/request/session.go
+++ b/internal/request/session.go
@@ -16,6 +16,7 @@ const (
 	DefaultSessionMaxReads = 1
 	MaxSessionReads        = 100
 	MaxSessionBindAncestor = 3
+	MaxSessionBindNameLen  = 128
 )
 
 var (
@@ -91,18 +92,21 @@ type SessionSummary struct {
 type SessionBindingMode string
 
 const (
-	SessionBindingModeAuto     SessionBindingMode = "auto"
-	SessionBindingModeAncestor SessionBindingMode = "ancestor"
+	SessionBindingModeAuto         SessionBindingMode = "auto"
+	SessionBindingModeAncestor     SessionBindingMode = "ancestor"
+	SessionBindingModeAncestorName SessionBindingMode = "ancestor_name"
 )
 
 type SessionBindingPolicy struct {
 	Mode          SessionBindingMode `json:"mode,omitempty"`
 	AncestorDepth int                `json:"ancestor_depth,omitempty"`
+	AncestorName  string             `json:"ancestor_name,omitempty"`
 }
 
 type SessionBindingInfo struct {
 	Mode           SessionBindingMode    `json:"mode"`
 	AncestorDepth  int                   `json:"ancestor_depth,omitempty"`
+	AncestorName   string                `json:"ancestor_name,omitempty"`
 	BoundProcess   SessionBindingProcess `json:"bound_process"`
 	CreatorProcess SessionBindingProcess `json:"creator_process"`
 }
@@ -123,6 +127,15 @@ func NewSessionAncestorBinding(depth int) (SessionBindingPolicy, error) {
 	return NormalizeSessionBindingPolicy(policy)
 }
 
+func NewSessionAncestorNameBinding(name string) (SessionBindingPolicy, error) {
+	name, err := validateSessionAncestorName(name)
+	if err != nil {
+		return SessionBindingPolicy{}, err
+	}
+	policy := SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: name}
+	return NormalizeSessionBindingPolicy(policy)
+}
+
 func NormalizeSessionBindingPolicy(policy SessionBindingPolicy) (SessionBindingPolicy, error) {
 	if policy.Mode == "" {
 		policy.Mode = SessionBindingModeAuto
@@ -131,6 +144,9 @@ func NormalizeSessionBindingPolicy(policy SessionBindingPolicy) (SessionBindingP
 	case SessionBindingModeAuto:
 		if policy.AncestorDepth != 0 {
 			return SessionBindingPolicy{}, fmt.Errorf("%w: auto binding does not accept ancestor depth", ErrInvalidSessionBind)
+		}
+		if policy.AncestorName != "" {
+			return SessionBindingPolicy{}, fmt.Errorf("%w: auto binding does not accept ancestor name", ErrInvalidSessionBind)
 		}
 		return policy, nil
 	case SessionBindingModeAncestor:
@@ -141,10 +157,37 @@ func NormalizeSessionBindingPolicy(policy SessionBindingPolicy) (SessionBindingP
 				MaxSessionBindAncestor,
 			)
 		}
+		if policy.AncestorName != "" {
+			return SessionBindingPolicy{}, fmt.Errorf("%w: ancestor depth binding does not accept ancestor name", ErrInvalidSessionBind)
+		}
+		return policy, nil
+	case SessionBindingModeAncestorName:
+		if policy.AncestorDepth != 0 {
+			return SessionBindingPolicy{}, fmt.Errorf("%w: ancestor name binding does not accept ancestor depth", ErrInvalidSessionBind)
+		}
+		name, err := validateSessionAncestorName(policy.AncestorName)
+		if err != nil {
+			return SessionBindingPolicy{}, err
+		}
+		policy.AncestorName = name
 		return policy, nil
 	default:
 		return SessionBindingPolicy{}, fmt.Errorf("%w: unknown binding mode %q", ErrInvalidSessionBind, policy.Mode)
 	}
+}
+
+func validateSessionAncestorName(raw string) (string, error) {
+	name := strings.TrimSpace(raw)
+	if name == "" {
+		return "", fmt.Errorf("%w: ancestor name is required", ErrInvalidSessionBind)
+	}
+	if len(name) > MaxSessionBindNameLen {
+		return "", fmt.Errorf("%w: ancestor name must be at most %d bytes", ErrInvalidSessionBind, MaxSessionBindNameLen)
+	}
+	if name == "." || name == ".." || strings.Contains(name, "/") || strings.ContainsRune(name, 0) {
+		return "", fmt.Errorf("%w: ancestor name must be an executable basename", ErrInvalidSessionBind)
+	}
+	return name, nil
 }
 
 func NewSessionCreate(opts SessionCreateOptions) (SessionCreateRequest, error) {

--- a/internal/request/session.go
+++ b/internal/request/session.go
@@ -16,6 +16,7 @@ const (
 	DefaultSessionMaxReads = 1
 	MaxSessionReads        = 100
 	MaxSessionBindAncestor = 3
+	MaxSessionBindNames    = 16
 	MaxSessionBindNameLen  = 128
 )
 
@@ -101,12 +102,14 @@ type SessionBindingPolicy struct {
 	Mode          SessionBindingMode `json:"mode,omitempty"`
 	AncestorDepth int                `json:"ancestor_depth,omitempty"`
 	AncestorName  string             `json:"ancestor_name,omitempty"`
+	AncestorNames []string           `json:"ancestor_names,omitempty"`
 }
 
 type SessionBindingInfo struct {
 	Mode           SessionBindingMode    `json:"mode"`
 	AncestorDepth  int                   `json:"ancestor_depth,omitempty"`
 	AncestorName   string                `json:"ancestor_name,omitempty"`
+	AncestorNames  []string              `json:"ancestor_names,omitempty"`
 	BoundProcess   SessionBindingProcess `json:"bound_process"`
 	CreatorProcess SessionBindingProcess `json:"creator_process"`
 }
@@ -128,11 +131,11 @@ func NewSessionAncestorBinding(depth int) (SessionBindingPolicy, error) {
 }
 
 func NewSessionAncestorNameBinding(name string) (SessionBindingPolicy, error) {
-	name, err := validateSessionAncestorName(name)
-	if err != nil {
-		return SessionBindingPolicy{}, err
-	}
-	policy := SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: name}
+	return NewSessionAncestorNamesBinding([]string{name})
+}
+
+func NewSessionAncestorNamesBinding(names []string) (SessionBindingPolicy, error) {
+	policy := SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorNames: names}
 	return NormalizeSessionBindingPolicy(policy)
 }
 
@@ -148,6 +151,9 @@ func NormalizeSessionBindingPolicy(policy SessionBindingPolicy) (SessionBindingP
 		if policy.AncestorName != "" {
 			return SessionBindingPolicy{}, fmt.Errorf("%w: auto binding does not accept ancestor name", ErrInvalidSessionBind)
 		}
+		if len(policy.AncestorNames) > 0 {
+			return SessionBindingPolicy{}, fmt.Errorf("%w: auto binding does not accept ancestor names", ErrInvalidSessionBind)
+		}
 		return policy, nil
 	case SessionBindingModeAncestor:
 		if policy.AncestorDepth < 1 || policy.AncestorDepth > MaxSessionBindAncestor {
@@ -160,20 +166,67 @@ func NormalizeSessionBindingPolicy(policy SessionBindingPolicy) (SessionBindingP
 		if policy.AncestorName != "" {
 			return SessionBindingPolicy{}, fmt.Errorf("%w: ancestor depth binding does not accept ancestor name", ErrInvalidSessionBind)
 		}
+		if len(policy.AncestorNames) > 0 {
+			return SessionBindingPolicy{}, fmt.Errorf("%w: ancestor depth binding does not accept ancestor names", ErrInvalidSessionBind)
+		}
 		return policy, nil
 	case SessionBindingModeAncestorName:
 		if policy.AncestorDepth != 0 {
 			return SessionBindingPolicy{}, fmt.Errorf("%w: ancestor name binding does not accept ancestor depth", ErrInvalidSessionBind)
 		}
-		name, err := validateSessionAncestorName(policy.AncestorName)
+		names, selectedName, err := normalizeSessionAncestorNames(policy.AncestorName, policy.AncestorNames)
 		if err != nil {
 			return SessionBindingPolicy{}, err
 		}
-		policy.AncestorName = name
+		policy.AncestorName = selectedName
+		policy.AncestorNames = names
 		return policy, nil
 	default:
 		return SessionBindingPolicy{}, fmt.Errorf("%w: unknown binding mode %q", ErrInvalidSessionBind, policy.Mode)
 	}
+}
+
+func normalizeSessionAncestorNames(singleName string, rawNames []string) ([]string, string, error) {
+	if singleName == "" && len(rawNames) == 0 {
+		return nil, "", fmt.Errorf("%w: ancestor name is required", ErrInvalidSessionBind)
+	}
+	if len(rawNames) > MaxSessionBindNames {
+		return nil, "", fmt.Errorf("%w: ancestor names must include at most %d entries", ErrInvalidSessionBind, MaxSessionBindNames)
+	}
+	names := make([]string, 0, max(1, len(rawNames)))
+	seen := make(map[string]struct{}, len(rawNames)+1)
+	for _, rawName := range rawNames {
+		name, err := validateSessionAncestorName(rawName)
+		if err != nil {
+			return nil, "", err
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	selectedName := ""
+	if singleName != "" {
+		name, err := validateSessionAncestorName(singleName)
+		if err != nil {
+			return nil, "", err
+		}
+		selectedName = name
+		if _, ok := seen[name]; !ok {
+			if len(rawNames) > 0 {
+				return nil, "", fmt.Errorf("%w: ancestor_name must be included in ancestor_names", ErrInvalidSessionBind)
+			}
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return nil, "", fmt.Errorf("%w: ancestor name is required", ErrInvalidSessionBind)
+	}
+	if len(names) == 1 && selectedName == "" {
+		selectedName = names[0]
+	}
+	return names, selectedName, nil
 }
 
 func validateSessionAncestorName(raw string) (string, error) {

--- a/internal/request/session_test.go
+++ b/internal/request/session_test.go
@@ -44,7 +44,7 @@ func TestNewSessionCreateDefaultsAndDaemonValidation(t *testing.T) {
 	if req.MaxReads != DefaultSessionMaxReads {
 		t.Fatalf("max reads = %d, want %d", req.MaxReads, DefaultSessionMaxReads)
 	}
-	if req.Binding.Mode != SessionBindingModeAuto || req.Binding.AncestorDepth != 0 {
+	if req.Binding.Mode != SessionBindingModeAuto || req.Binding.AncestorDepth != 0 || req.Binding.AncestorName != "" {
 		t.Fatalf("binding = %+v, want auto", req.Binding)
 	}
 	if !req.ExpiresAt.Equal(receivedAt.Add(DefaultSessionTTL)) {
@@ -126,6 +126,9 @@ func TestNewSessionCreateRejectsInvalidInputs(t *testing.T) {
 		{name: "bad bind depth", mutate: func(o *SessionCreateOptions) {
 			o.Binding = SessionBindingPolicy{Mode: SessionBindingModeAncestor, AncestorDepth: MaxSessionBindAncestor + 1}
 		}, want: ErrInvalidSessionBind},
+		{name: "bad bind name", mutate: func(o *SessionCreateOptions) {
+			o.Binding = SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: "/bin/zsh"}
+		}, want: ErrInvalidSessionBind},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -153,6 +156,13 @@ func TestSessionBindingPolicyValidation(t *testing.T) {
 	if parent.Mode != SessionBindingModeAncestor || parent.AncestorDepth != 1 {
 		t.Fatalf("parent binding = %+v", parent)
 	}
+	named, err := NewSessionAncestorNameBinding(" Codex ")
+	if err != nil {
+		t.Fatalf("NewSessionAncestorNameBinding returned error: %v", err)
+	}
+	if named.Mode != SessionBindingModeAncestorName || named.AncestorName != "Codex" || named.AncestorDepth != 0 {
+		t.Fatalf("named binding = %+v", named)
+	}
 
 	tests := []struct {
 		name   string
@@ -161,6 +171,13 @@ func TestSessionBindingPolicyValidation(t *testing.T) {
 		{name: "zero ancestor", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestor}},
 		{name: "too deep ancestor", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestor, AncestorDepth: MaxSessionBindAncestor + 1}},
 		{name: "auto with depth", policy: SessionBindingPolicy{Mode: SessionBindingModeAuto, AncestorDepth: 1}},
+		{name: "auto with name", policy: SessionBindingPolicy{Mode: SessionBindingModeAuto, AncestorName: "Codex"}},
+		{name: "ancestor with name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestor, AncestorDepth: 1, AncestorName: "Codex"}},
+		{name: "ancestor name with depth", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorDepth: 1, AncestorName: "Codex"}},
+		{name: "empty ancestor name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName}},
+		{name: "path ancestor name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: "/bin/zsh"}},
+		{name: "dot ancestor name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: "."}},
+		{name: "long ancestor name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: strings.Repeat("a", MaxSessionBindNameLen+1)}},
 		{name: "unknown mode", policy: SessionBindingPolicy{Mode: "pid", AncestorDepth: 1}},
 	}
 	for _, tt := range tests {

--- a/internal/request/session_test.go
+++ b/internal/request/session_test.go
@@ -44,7 +44,10 @@ func TestNewSessionCreateDefaultsAndDaemonValidation(t *testing.T) {
 	if req.MaxReads != DefaultSessionMaxReads {
 		t.Fatalf("max reads = %d, want %d", req.MaxReads, DefaultSessionMaxReads)
 	}
-	if req.Binding.Mode != SessionBindingModeAuto || req.Binding.AncestorDepth != 0 || req.Binding.AncestorName != "" {
+	if req.Binding.Mode != SessionBindingModeAuto ||
+		req.Binding.AncestorDepth != 0 ||
+		req.Binding.AncestorName != "" ||
+		len(req.Binding.AncestorNames) != 0 {
 		t.Fatalf("binding = %+v, want auto", req.Binding)
 	}
 	if !req.ExpiresAt.Equal(receivedAt.Add(DefaultSessionTTL)) {
@@ -163,6 +166,19 @@ func TestSessionBindingPolicyValidation(t *testing.T) {
 	if named.Mode != SessionBindingModeAncestorName || named.AncestorName != "Codex" || named.AncestorDepth != 0 {
 		t.Fatalf("named binding = %+v", named)
 	}
+	if !slices.Equal(named.AncestorNames, []string{"Codex"}) {
+		t.Fatalf("named ancestor names = %v, want [Codex]", named.AncestorNames)
+	}
+
+	names, err := NewSessionAncestorNamesBinding([]string{" claude ", "Codex", "claude"})
+	if err != nil {
+		t.Fatalf("NewSessionAncestorNamesBinding returned error: %v", err)
+	}
+	if names.Mode != SessionBindingModeAncestorName ||
+		names.AncestorName != "" ||
+		!slices.Equal(names.AncestorNames, []string{"claude", "Codex"}) {
+		t.Fatalf("names binding = %+v, want ordered deduplicated allowlist", names)
+	}
 
 	tests := []struct {
 		name   string
@@ -172,10 +188,15 @@ func TestSessionBindingPolicyValidation(t *testing.T) {
 		{name: "too deep ancestor", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestor, AncestorDepth: MaxSessionBindAncestor + 1}},
 		{name: "auto with depth", policy: SessionBindingPolicy{Mode: SessionBindingModeAuto, AncestorDepth: 1}},
 		{name: "auto with name", policy: SessionBindingPolicy{Mode: SessionBindingModeAuto, AncestorName: "Codex"}},
+		{name: "auto with names", policy: SessionBindingPolicy{Mode: SessionBindingModeAuto, AncestorNames: []string{"Codex"}}},
 		{name: "ancestor with name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestor, AncestorDepth: 1, AncestorName: "Codex"}},
+		{name: "ancestor with names", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestor, AncestorDepth: 1, AncestorNames: []string{"Codex"}}},
 		{name: "ancestor name with depth", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorDepth: 1, AncestorName: "Codex"}},
 		{name: "empty ancestor name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName}},
 		{name: "path ancestor name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: "/bin/zsh"}},
+		{name: "path ancestor names entry", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorNames: []string{"zsh", "/bin/bash"}}},
+		{name: "too many ancestor names", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorNames: repeatedStrings("zsh", MaxSessionBindNames+1)}},
+		{name: "single name not in names", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: "zsh", AncestorNames: []string{"bash"}}},
 		{name: "dot ancestor name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: "."}},
 		{name: "long ancestor name", policy: SessionBindingPolicy{Mode: SessionBindingModeAncestorName, AncestorName: strings.Repeat("a", MaxSessionBindNameLen+1)}},
 		{name: "unknown mode", policy: SessionBindingPolicy{Mode: "pid", AncestorDepth: 1}},
@@ -189,6 +210,14 @@ func TestSessionBindingPolicyValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func repeatedStrings(value string, count int) []string {
+	values := make([]string, count)
+	for i := range values {
+		values[i] = value
+	}
+	return values
 }
 
 func TestSessionResolveValidation(t *testing.T) {

--- a/site/docs.html
+++ b/site/docs.html
@@ -253,12 +253,16 @@ agent-secret session destroy asid_123</code></pre>
               <code>with-session</code> from the parent shell. Deeper wrappers
               can use <code>--bind-ancestor N</code> up to <code>3</code>;
               Agent Secret accepts only ancestors of the current
-              <code>agent-secret</code> process, not arbitrary PIDs. Profiles
-              can set <code>session.bind: parent</code>,
-              <code>session.bind: auto</code>, or
-              <code>session.bind: { ancestor: N }</code>. Session list JSON
-              includes non-secret binding metadata so process mismatch failures
-              are easier to debug.
+              <code>agent-secret</code> process, not arbitrary PIDs. When the
+              wrapper depth varies but the target process name is stable, use
+              <code>--bind-ancestor-name NAME</code>; it matches the nearest
+              eligible ancestor executable basename in the current ancestry.
+              Profiles can set <code>session.bind: parent</code>,
+              <code>session.bind: auto</code>,
+              <code>session.bind: { ancestor: N }</code>, or
+              <code>session.bind: { ancestor_name: NAME }</code>. Session list
+              JSON includes non-secret binding metadata so process mismatch
+              failures are easier to debug.
             </p>
             <p>
               Sessions end when TTL passes, the read count is exhausted,

--- a/site/docs.html
+++ b/site/docs.html
@@ -254,13 +254,15 @@ agent-secret session destroy asid_123</code></pre>
               can use <code>--bind-ancestor N</code> up to <code>3</code>;
               Agent Secret accepts only ancestors of the current
               <code>agent-secret</code> process, not arbitrary PIDs. When the
-              wrapper depth varies but the target process name is stable, use
+              wrapper depth varies across accepted agents, repeat
               <code>--bind-ancestor-name NAME</code>; it matches the nearest
-              eligible ancestor executable basename in the current ancestry.
+              eligible ancestor executable basename in the allowed set within
+              the current ancestry.
               Profiles can set <code>session.bind: parent</code>,
               <code>session.bind: auto</code>,
               <code>session.bind: { ancestor: N }</code>, or
-              <code>session.bind: { ancestor_name: NAME }</code>. Session list
+              <code>session.bind: { ancestor_name: NAME }</code> /
+              <code>session.bind: { ancestor_names: [NAME, ...] }</code>. Session list
               JSON includes non-secret binding metadata so process mismatch
               failures are easier to debug.
             </p>

--- a/site/index.html
+++ b/site/index.html
@@ -364,7 +364,7 @@ profiles:
               <li>The background helper fetches only the secrets you approved for the request.</li>
               <li>Audit logs record metadata, never raw secrets.</li>
               <li>Reusable approvals stay bounded by command, cwd, references, account, TTL, and use count.</li>
-              <li>Sessions stay bounded by requester process tree or an explicit ancestor binding, cwd, aliases, TTL, read count, secret tokens, and the <code>with-session</code> wrapper.</li>
+              <li>Sessions stay bounded by requester process tree or an explicit ancestor binding, including nearest matching ancestor names, plus cwd, aliases, TTL, read count, secret tokens, and the <code>with-session</code> wrapper.</li>
             </ul>
           </div>
           <div>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agent-secret.sh/</loc>
-    <lastmod>2026-06-16</lastmod>
+    <lastmod>2026-06-17</lastmod>
   </url>
   <url>
     <loc>https://agent-secret.sh/docs</loc>
-    <lastmod>2026-06-16</lastmod>
+    <lastmod>2026-06-17</lastmod>
   </url>
   <url>
     <loc>https://agent-secret.sh/privacy</loc>


### PR DESCRIPTION
## Summary

- add session create support for --bind-ancestor-name NAME and profile session.bind: { ancestor_name: NAME }
- bind by walking only the creator process ancestry and choosing the nearest eligible executable basename match
- expose ancestor name metadata in session JSON and approval inspection text
- update README, configuration docs, PRD, release notes, bundled skill, public site, and session E2E docs

## Validation

- mise run lint
- mise run test
- mise run build
- scripts/deploy-site.sh --check-only
- npx --yes markdownlint-cli README.md CHANGELOG.md SECURITY.md docs/configuration.md docs/prd.md docs/session-e2e-validation.md docs/threat-model.md .agents/skills/agent-secret/SKILL.md